### PR TITLE
[FEAT] 공통 기반 클래스 및 ENUM 구현 (#1)

### DIFF
--- a/src/main/java/org/example/shield/ShieldApplication.java
+++ b/src/main/java/org/example/shield/ShieldApplication.java
@@ -2,8 +2,10 @@ package org.example.shield;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ShieldApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/example/shield/common/domain/BaseEntity.java
+++ b/src/main/java/org/example/shield/common/domain/BaseEntity.java
@@ -1,12 +1,33 @@
 package org.example.shield.common.domain;
 
-/**
- * 공통 엔티티 - 모든 엔티티가 상속.
- *
- * TODO: @MappedSuperclass + @EntityListeners(AuditingEntityListener.class) 구현
- * - id: UUID (PK, @GeneratedValue(strategy = GenerationType.UUID))
- * - createdAt: LocalDateTime (@CreatedDate)
- * - updatedAt: LocalDateTime (@LastModifiedDate)
- */
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
 public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/example/shield/common/enums/BriefStatus.java
+++ b/src/main/java/org/example/shield/common/enums/BriefStatus.java
@@ -2,7 +2,15 @@ package org.example.shield.common.enums;
 
 /**
  * 의뢰서 상태 ENUM.
- * TODO: enum으로 변경. DRAFT, CONFIRMED, DELIVERED, DISCARDED
+ *
+ * DRAFT     - 초안 (AI 생성 직후)
+ * CONFIRMED - 사용자 확정
+ * DELIVERED - 변호사에게 전달
+ * REJECTED  - 거절
  */
-public class BriefStatus {
+public enum BriefStatus {
+    DRAFT,
+    CONFIRMED,
+    DELIVERED,
+    REJECTED
 }

--- a/src/main/java/org/example/shield/common/enums/DeliveryStatus.java
+++ b/src/main/java/org/example/shield/common/enums/DeliveryStatus.java
@@ -2,7 +2,13 @@ package org.example.shield.common.enums;
 
 /**
  * 전달 상태 ENUM.
- * TODO: enum으로 변경. SENT, VIEWED, ACCEPTED, REJECTED, NO_RESPONSE
+ *
+ * DELIVERED - 전달됨
+ * CONFIRMED - 변호사 수락
+ * REJECTED  - 변호사 거절
  */
-public class DeliveryStatus {
+public enum DeliveryStatus {
+    DELIVERED,
+    CONFIRMED,
+    REJECTED
 }

--- a/src/main/java/org/example/shield/common/enums/PrivacySetting.java
+++ b/src/main/java/org/example/shield/common/enums/PrivacySetting.java
@@ -1,8 +1,12 @@
 package org.example.shield.common.enums;
 
 /**
- * 의뢰서 공개 설정 Enum.
- * 값: PUBLIC, PARTIAL
+ * 의뢰서 공개 설정 ENUM.
+ *
+ * PUBLIC  - 전체 공개
+ * PARTIAL - 부분 공개 (이름 마스킹)
  */
 public enum PrivacySetting {
+    PUBLIC,
+    PARTIAL
 }

--- a/src/main/java/org/example/shield/common/enums/UserRole.java
+++ b/src/main/java/org/example/shield/common/enums/UserRole.java
@@ -2,7 +2,13 @@ package org.example.shield.common.enums;
 
 /**
  * 사용자 역할 ENUM.
- * TODO: enum으로 변경. CLIENT, LAWYER, ADMIN
+ *
+ * USER   - 일반 사용자 (의뢰인)
+ * LAWYER - 변호사
+ * ADMIN  - 관리자
  */
-public class UserRole {
+public enum UserRole {
+    USER,
+    LAWYER,
+    ADMIN
 }

--- a/src/main/java/org/example/shield/common/enums/VerificationStatus.java
+++ b/src/main/java/org/example/shield/common/enums/VerificationStatus.java
@@ -2,7 +2,13 @@ package org.example.shield.common.enums;
 
 /**
  * 변호사 검증 상태 ENUM.
- * TODO: enum으로 변경. PENDING, APPROVED, REJECTED
+ *
+ * PENDING  - 인증 대기
+ * VERIFIED - 인증 완료
+ * REJECTED - 인증 거절
  */
-public class VerificationStatus {
+public enum VerificationStatus {
+    PENDING,
+    VERIFIED,
+    REJECTED
 }

--- a/src/main/java/org/example/shield/common/exception/BusinessException.java
+++ b/src/main/java/org/example/shield/common/exception/BusinessException.java
@@ -1,11 +1,19 @@
 package org.example.shield.common.exception;
 
-/**
- * 비즈니스 예외 상위 클래스.
- *
- * TODO:
- * - ErrorCode 필드
- * - 생성자: BusinessException(ErrorCode errorCode)
- */
+import lombok.Getter;
+
+@Getter
 public abstract class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    protected BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    protected BusinessException(ErrorCode errorCode, String detailMessage) {
+        super(detailMessage);
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/org/example/shield/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/shield/common/exception/ErrorCode.java
@@ -1,22 +1,39 @@
 package org.example.shield.common.exception;
 
-/**
- * 에러 코드 Enum.
- *
- * TODO:
- * - httpStatus: HttpStatus
- * - message: String
- *
- * 값:
- * - INVALID_INPUT_VALUE(400, "잘못된 입력값입니다")
- * - UNAUTHORIZED(401, "인증이 필요합니다")
- * - ACCESS_DENIED(403, "접근 권한이 없습니다")
- * - USER_NOT_FOUND(404, "사용자를 찾을 수 없습니다")
- * - CONSULTATION_NOT_FOUND(404, "상담을 찾을 수 없습니다")
- * - CONSULTATION_NOT_CLASSIFIED(400, "분류를 먼저 진행해주세요")
- * - BRIEF_NOT_FOUND(404, "의뢰서를 찾을 수 없습니다")
- * - BRIEF_ALREADY_CONFIRMED(409, "이미 확정된 의뢰서입니다")
- * - LAWYER_NOT_FOUND(404, "변호사를 찾을 수 없습니다")
- */
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
 public enum ErrorCode {
+
+    // Common
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다"),
+
+    // User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
+
+    // Lawyer
+    LAWYER_NOT_FOUND(HttpStatus.NOT_FOUND, "변호사를 찾을 수 없습니다"),
+
+    // Consultation
+    CONSULTATION_NOT_FOUND(HttpStatus.NOT_FOUND, "상담을 찾을 수 없습니다"),
+    CONSULTATION_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "대화가 완료되지 않았습니다"),
+
+    // Brief
+    BRIEF_NOT_FOUND(HttpStatus.NOT_FOUND, "의뢰서를 찾을 수 없습니다"),
+    BRIEF_ALREADY_CONFIRMED(HttpStatus.CONFLICT, "이미 확정된 의뢰서입니다"),
+
+    // Delivery
+    DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 전달 건입니다"),
+
+    // Verification
+    VERIFICATION_ALREADY_SUBMITTED(HttpStatus.CONFLICT, "이미 검증 신청된 상태입니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
 }

--- a/src/main/java/org/example/shield/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/shield/common/exception/GlobalExceptionHandler.java
@@ -1,12 +1,40 @@
 package org.example.shield.common.exception;
 
-/**
- * 전역 예외 처리기 - 모든 예외를 ApiResponse.error()로 변환.
- *
- * TODO: @RestControllerAdvice
- * - BusinessException → 해당 ErrorCode의 HTTP 상태 + 메시지
- * - MethodArgumentNotValidException → 400 + 유효성 검사 실패 메시지
- * - Exception → 500 + "서버 내부 오류가 발생했습니다"
- */
+import lombok.extern.slf4j.Slf4j;
+import org.example.shield.common.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        log.warn("Business exception: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(ApiResponse.error(e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        log.warn("Validation failed: {}", message);
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.error(message));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unexpected error", e);
+        return ResponseEntity.internalServerError()
+                .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
+    }
 }

--- a/src/main/java/org/example/shield/common/response/ApiResponse.java
+++ b/src/main/java/org/example/shield/common/response/ApiResponse.java
@@ -1,16 +1,29 @@
 package org.example.shield.common.response;
 
-/**
- * 공통 API 응답 래퍼.
- * 모든 API가 { result: true/false, message: "...", data: {...} } 형식으로 응답.
- *
- * TODO:
- * - result: boolean
- * - message: String
- * - data: T (제네릭)
- * - static ok(data): 성공 응답
- * - static ok(data, message): 성공 응답 + 메시지
- * - static error(message): 에러 응답
- */
-public class ApiResponse {
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+    private final boolean result;
+    private final String message;
+    private final T data;
+
+    private ApiResponse(boolean result, String message, T data) {
+        this.result = result;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(true, message, data);
+    }
+
+    public static ApiResponse<Void> success(String message) {
+        return new ApiResponse<>(true, message, null);
+    }
+
+    public static ApiResponse<Void> error(String message) {
+        return new ApiResponse<>(false, message, null);
+    }
 }

--- a/src/main/java/org/example/shield/common/response/PageResponse.java
+++ b/src/main/java/org/example/shield/common/response/PageResponse.java
@@ -1,16 +1,25 @@
 package org.example.shield.common.response;
 
-/**
- * 공통 페이징 응답 DTO.
- *
- * TODO: record로 구현
- * - content: List<T>
- * - page: int
- * - size: int
- * - totalElements: long
- * - totalPages: int
- * - hasNext: boolean
- * - static from(Page<T>): PageResponse<T>
- */
-public class PageResponse {
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean hasNext
+) {
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.hasNext()
+        );
+    }
 }


### PR DESCRIPTION
## 요약

### 모든 도메인(사용자, 변호사, 상담, 의뢰서 등)에서 공통으로 사용하는 기반 클래스와 ENUM을 구현했습니다.



## 변경 사항

### 기반 클래스
- **BaseEntity**: 공통 필드(id, createdAt, updatedAt) + `@EnableJpaAuditing` 설정
  - 상속 대상: `lawyers`, `consultations`, `briefs`
  - 상속 안 함: `users`(timestamp 없음), `messages`(created_at만), `deliveries`(sent_at 사용), `forms`(created_at만)
- **ApiResponse**: 공통 API 응답 래퍼 (`success`, `error` static 메서드)
- **PageResponse**: 페이징 응답 DTO (`Page<T>` → `PageResponse<T>` 변환)

### 예외 처리
- **ErrorCode**: 도메인별 에러 코드 ENUM (HttpStatus + 메시지)
- **BusinessException**: 모든 비즈니스 예외의 추상 상위 클래스
- **GlobalExceptionHandler**: `@RestControllerAdvice`로 예외 일괄 처리
  - `BusinessException` → 해당 ErrorCode의 HTTP 상태 + 메시지
  - `MethodArgumentNotValidException` → 400 + 유효성 검사 실패 메시지
  - `Exception` → 500 + 서버 내부 오류

### ENUM (8개)
- **ConsultationStatus**: COLLECTING / ANALYZING / AWAITING_CONFIRM / CONFIRMED / REJECTED
- **DomainType**: DEPOSIT_FRAUD / LEASE_DISPUTE / PRESALE / PROPERTY_TRADE / OTHER
- **MessageRole**: USER / AI
- **BriefStatus**: DRAFT / CONFIRMED / DELIVERED / REJECTED
- **DeliveryStatus**: DELIVERED / CONFIRMED / REJECTED
- **PrivacySetting**: PUBLIC / PARTIAL
- **VerificationStatus**: PENDING / VERIFIED / REJECTED
- **UserRole**: USER / LAWYER / ADMIN

### 기타
- Supabase 무료 플랜 연결 수 제한 해결: Session mode(5432) → Transaction mode(6543) 변경

## 테스트
- [x] `gradlew compileJava` 빌드 성공
- [x] Swagger UI 접속 확인 (Supabase Transaction mode)
- [x] Swagger UI 접속 확인 (로컬 PostgreSQL)

## 관련 이슈
closes #1