### PR TITLE
[FEAT] 상담 API 구현 (#4)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/org/example/shield/common/domain/BaseEntity.java
+++ b/src/main/java/org/example/shield/common/domain/BaseEntity.java
@@ -30,4 +30,8 @@ public abstract class BaseEntity {
     @LastModifiedDate
     @Column(nullable = false)
     private LocalDateTime updatedAt;
+
+    public void touch() {
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/org/example/shield/common/enums/MessageRole.java
+++ b/src/main/java/org/example/shield/common/enums/MessageRole.java
@@ -3,10 +3,16 @@ package org.example.shield.common.enums;
 /**
  * 메시지 발신자 ENUM.
  *
- * USER - 사용자 메시지
- * AI   - AI 메시지
+ * USER           - 사용자 메시지
+ * CHATBOT        - 챗봇 메시지
+ * CHATBOT_TIP    - 챗봇 팁 메시지
+ * ROUTER_REQUEST - 라우터 요청
+ * SYSTEM         - 시스템 메시지
  */
 public enum MessageRole {
     USER,
-    AI
+    CHATBOT,
+    CHATBOT_TIP,
+    ROUTER_REQUEST,
+    SYSTEM
 }

--- a/src/main/java/org/example/shield/common/response/ApiResponse.java
+++ b/src/main/java/org/example/shield/common/response/ApiResponse.java
@@ -1,8 +1,10 @@
 package org.example.shield.common.response;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 
 @Getter
+@JsonPropertyOrder({"result", "message", "data"})
 public class ApiResponse<T> {
 
     private final boolean result;

--- a/src/main/java/org/example/shield/consultation/application/ConsultationService.java
+++ b/src/main/java/org/example/shield/consultation/application/ConsultationService.java
@@ -10,7 +10,6 @@ import org.example.shield.consultation.domain.Consultation;
 import org.example.shield.consultation.domain.ConsultationReader;
 import org.example.shield.consultation.domain.ConsultationWriter;
 import org.example.shield.consultation.domain.Message;
-import org.example.shield.consultation.domain.MessageReader;
 import org.example.shield.consultation.domain.MessageWriter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,7 +27,6 @@ public class ConsultationService {
     private final ConsultationReader consultationReader;
     private final ConsultationWriter consultationWriter;
     private final MessageWriter messageWriter;
-    private final MessageReader messageReader;
 
     private static final String WELCOME_MESSAGE =
             "반갑습니다. SHIELD 법률 AI입니다. 어떤 법률 문제로 어려움을 겪고 계신가요? 구체적인 상황을 말씀해 주시면 정보 정리를 도와드리겠습니다.";
@@ -40,7 +38,9 @@ public class ConsultationService {
 
         Message welcomeMsg = Message.createAiMessage(
                 saved.getId(), WELCOME_MESSAGE, null, null, null, null);
-        messageWriter.save(welcomeMsg);
+        Message savedMsg = messageWriter.save(welcomeMsg);
+
+        saved.updateLastMessage(savedMsg.getContent(), savedMsg.getCreatedAt());
 
         return new CreateConsultationResponse(
                 saved.getId(),
@@ -52,18 +52,7 @@ public class ConsultationService {
 
     public PageResponse<ConsultationResponse> getMyConsultations(UUID userId, Pageable pageable) {
         Page<Consultation> consultations = consultationReader.findAllByUserId(userId, pageable);
-
-        Page<ConsultationResponse> responsePage = consultations.map(c -> {
-            // 마지막 메시지 조회
-            var lastMessage = messageReader.findLastByConsultationId(c.getId());
-
-            return ConsultationResponse.of(
-                    c,
-                    lastMessage.map(Message::getContent).orElse(null),
-                    lastMessage.map(Message::getCreatedAt).orElse(null)
-            );
-        });
-
+        Page<ConsultationResponse> responsePage = consultations.map(ConsultationResponse::from);
         return PageResponse.from(responsePage);
     }
 

--- a/src/main/java/org/example/shield/consultation/application/ConsultationService.java
+++ b/src/main/java/org/example/shield/consultation/application/ConsultationService.java
@@ -2,7 +2,6 @@ package org.example.shield.consultation.application;
 
 import lombok.RequiredArgsConstructor;
 import org.example.shield.common.enums.DomainType;
-import org.example.shield.common.enums.MessageRole;
 import org.example.shield.common.response.PageResponse;
 import org.example.shield.consultation.controller.dto.ClassifyResponse;
 import org.example.shield.consultation.controller.dto.ConsultationResponse;
@@ -18,6 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -68,11 +68,11 @@ public class ConsultationService {
     }
 
     @Transactional
-    public ClassifyResponse updateClassification(UUID consultationId, DomainType primaryField) {
+    public ClassifyResponse updateClassification(UUID consultationId, List<String> primaryField) {
         Consultation consultation = consultationReader.findById(consultationId);
         consultation.updateClassification(primaryField);
         consultationWriter.save(consultation);
 
-        return new ClassifyResponse(primaryField.name());
+        return new ClassifyResponse(primaryField);
     }
 }

--- a/src/main/java/org/example/shield/consultation/application/ConsultationService.java
+++ b/src/main/java/org/example/shield/consultation/application/ConsultationService.java
@@ -1,21 +1,78 @@
 package org.example.shield.consultation.application;
 
-/**
- * 상담 서비스 - 상담 생성/조회/목록.
- *
- * Layer: application
- * Called by: ConsultationController
- * Calls: ConsultationReader, ConsultationWriter, MessageWriter
- *
- * TODO:
- * - createConsultation(userId, domain):
- *   1. consultations 테이블에 새 row 생성 (status: COLLECTING)
- *   2. selected_domain 저장 (nullable)
- *   3. 환영 메시지를 messages 테이블에 AI 메시지로 저장
- *   4. welcomeMessage 반환
- *
- * - getMyConsultations(userId, pageable): 내 상담 목록
- *   → brief, primaryField, tags, lastMessage 포함
- */
+import lombok.RequiredArgsConstructor;
+import org.example.shield.common.enums.DomainType;
+import org.example.shield.common.enums.MessageRole;
+import org.example.shield.common.response.PageResponse;
+import org.example.shield.consultation.controller.dto.ClassifyResponse;
+import org.example.shield.consultation.controller.dto.ConsultationResponse;
+import org.example.shield.consultation.controller.dto.CreateConsultationResponse;
+import org.example.shield.consultation.domain.Consultation;
+import org.example.shield.consultation.domain.ConsultationReader;
+import org.example.shield.consultation.domain.ConsultationWriter;
+import org.example.shield.consultation.domain.Message;
+import org.example.shield.consultation.domain.MessageReader;
+import org.example.shield.consultation.domain.MessageWriter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ConsultationService {
+
+    private final ConsultationReader consultationReader;
+    private final ConsultationWriter consultationWriter;
+    private final MessageWriter messageWriter;
+    private final MessageReader messageReader;
+
+    private static final String WELCOME_MESSAGE =
+            "반갑습니다. SHIELD 법률 AI입니다. 어떤 법률 문제로 어려움을 겪고 계신가요? 구체적인 상황을 말씀해 주시면 정보 정리를 도와드리겠습니다.";
+
+    @Transactional
+    public CreateConsultationResponse createConsultation(UUID userId, DomainType domain) {
+        Consultation consultation = Consultation.create(userId, domain);
+        Consultation saved = consultationWriter.save(consultation);
+
+        Message welcomeMsg = Message.createAiMessage(
+                saved.getId(), WELCOME_MESSAGE, null, null, null, null);
+        messageWriter.save(welcomeMsg);
+
+        return new CreateConsultationResponse(
+                saved.getId(),
+                saved.getStatus().name(),
+                WELCOME_MESSAGE,
+                saved.getCreatedAt()
+        );
+    }
+
+    public PageResponse<ConsultationResponse> getMyConsultations(UUID userId, Pageable pageable) {
+        Page<Consultation> consultations = consultationReader.findAllByUserId(userId, pageable);
+
+        Page<ConsultationResponse> responsePage = consultations.map(c -> {
+            // 마지막 메시지 조회
+            var lastMessage = messageReader.findLastByConsultationId(c.getId());
+
+            return ConsultationResponse.of(
+                    c,
+                    lastMessage.map(Message::getContent).orElse(null),
+                    lastMessage.map(Message::getCreatedAt).orElse(null)
+            );
+        });
+
+        return PageResponse.from(responsePage);
+    }
+
+    @Transactional
+    public ClassifyResponse updateClassification(UUID consultationId, DomainType primaryField) {
+        Consultation consultation = consultationReader.findById(consultationId);
+        consultation.updateClassification(primaryField);
+        consultationWriter.save(consultation);
+
+        return new ClassifyResponse(primaryField.name());
+    }
 }

--- a/src/main/java/org/example/shield/consultation/application/MessageService.java
+++ b/src/main/java/org/example/shield/consultation/application/MessageService.java
@@ -33,17 +33,18 @@ public class MessageService {
         Message userMessage = Message.createUserMessage(consultationId, content);
         Message saved = messageWriter.save(userMessage);
 
-        // 상담 updatedAt 갱신 (최신 대화순 정렬용)
-        consultation.touch();
-
         // TODO: AI 연동 시 여기서 AiClient 호출 → 아래 목 응답 제거
         Message aiMessage = Message.createAiMessage(
                 consultationId,
                 "해당 내용을 확인했습니다. 추가로 관련 서류나 계약서가 있으시면 알려주세요.",
                 "mock", null, null, null);
-        messageWriter.save(aiMessage);
+        Message savedAi = messageWriter.save(aiMessage);
 
-        return SendMessageResponse.from(aiMessage, false);
+        // 상담 마지막 메시지 + updatedAt 갱신
+        consultation.updateLastMessage(savedAi.getContent(), savedAi.getCreatedAt());
+        consultation.touch();
+
+        return SendMessageResponse.from(savedAi, false);
     }
 
     public PageResponse<MessageResponse> getMessages(UUID consultationId, Pageable pageable) {

--- a/src/main/java/org/example/shield/consultation/application/MessageService.java
+++ b/src/main/java/org/example/shield/consultation/application/MessageService.java
@@ -1,26 +1,58 @@
 package org.example.shield.consultation.application;
 
-/**
- * 메시지 서비스 - 챗봇 상담 메시지 전송/조회.
- *
- * Layer: application
- * Called by: ConsultationController.sendMessage(), getMessages()
- * Calls: MessageReader, MessageWriter, ConsultationReader, ConsultationWriter, AiClient
- *
- * TODO:
- * - sendMessage(consultationId, content):
- *   1. messages 테이블에 USER 메시지 INSERT
- *   2. messages 테이블에서 전체 chatHistory 조립
- *   3. AiClient에 { domain, chatHistory } 전송
- *   4. AI Response: { nextQuestion, primaryField, tags, allCompleted }
- *   5. primaryField != null → consultations.primary_field 덮어쓰기
- *   6. tags != null → consultations.tags 덮어쓰기
- *   7. messages 테이블에 AI 메시지 INSERT
- *   8. allCompleted = true → analyze 자동 시작
- *   9. Response: { content, timestamp, allCompleted, classification(완료 시만) }
- *
- * - getMessages(consultationId, pageable):
- *   → messages 테이블에서 sequence 순서로 조회
- */
+import lombok.RequiredArgsConstructor;
+import org.example.shield.common.response.PageResponse;
+import org.example.shield.consultation.controller.dto.MessageResponse;
+import org.example.shield.consultation.controller.dto.SendMessageResponse;
+import org.example.shield.consultation.domain.Consultation;
+import org.example.shield.consultation.domain.ConsultationReader;
+import org.example.shield.consultation.domain.Message;
+import org.example.shield.consultation.domain.MessageReader;
+import org.example.shield.consultation.domain.MessageWriter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MessageService {
+
+    private final MessageReader messageReader;
+    private final MessageWriter messageWriter;
+    private final ConsultationReader consultationReader;
+
+    @Transactional
+    public SendMessageResponse sendMessage(UUID consultationId, String content) {
+        Consultation consultation = consultationReader.findById(consultationId);
+
+        // USER 메시지 저장
+        Message userMessage = Message.createUserMessage(consultationId, content);
+        Message saved = messageWriter.save(userMessage);
+
+        // 상담 updatedAt 갱신 (최신 대화순 정렬용)
+        consultation.touch();
+
+        // TODO: AI 연동 시 여기서 AiClient 호출 → 아래 목 응답 제거
+        Message aiMessage = Message.createAiMessage(
+                consultationId,
+                "해당 내용을 확인했습니다. 추가로 관련 서류나 계약서가 있으시면 알려주세요.",
+                "mock", null, null, null);
+        messageWriter.save(aiMessage);
+
+        return SendMessageResponse.from(aiMessage, false);
+    }
+
+    public PageResponse<MessageResponse> getMessages(UUID consultationId, Pageable pageable) {
+        // 상담 존재 확인
+        consultationReader.findById(consultationId);
+
+        Page<Message> messages = messageReader.findAllByConsultationId(consultationId, pageable);
+        Page<MessageResponse> responsePage = messages.map(MessageResponse::from);
+
+        return PageResponse.from(responsePage);
+    }
 }

--- a/src/main/java/org/example/shield/consultation/controller/ConsultationController.java
+++ b/src/main/java/org/example/shield/consultation/controller/ConsultationController.java
@@ -1,20 +1,103 @@
 package org.example.shield.consultation.controller;
 
-/**
- * 상담 API 컨트롤러.
- *
- * Layer: controller
- * Called by: 프론트엔드
- * Calls: ConsultationService, MessageService, AnalysisService
- *
- * API 목록:
- * - POST  /api/consultations                                 상담 생성
- * - GET   /api/consultations                                 내 상담 목록
- * - POST  /api/consultations/{consultationId}/messages        메시지 전송
- * - GET   /api/consultations/{consultationId}/messages        메시지 목록 조회
- * - PATCH /api/consultations/{consultationId}/classify        분류 직접 수정
- * - POST  /api/consultations/{consultationId}/analyze         의뢰서 생성 (비동기)
- * - GET   /api/legal-fields                                  법률 분야 목록 조회
- */
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.shield.common.enums.DomainType;
+import org.example.shield.common.response.ApiResponse;
+import org.example.shield.common.response.PageResponse;
+import org.example.shield.consultation.application.ConsultationService;
+import org.example.shield.consultation.application.MessageService;
+import org.example.shield.consultation.controller.dto.ConsultationResponse;
+import org.example.shield.consultation.controller.dto.ClassifyRequest;
+import org.example.shield.consultation.controller.dto.ClassifyResponse;
+import org.example.shield.consultation.controller.dto.CreateConsultationRequest;
+import org.example.shield.consultation.controller.dto.CreateConsultationResponse;
+import org.example.shield.consultation.controller.dto.MessageRequest;
+import org.example.shield.consultation.controller.dto.MessageResponse;
+import org.example.shield.consultation.controller.dto.SendMessageResponse;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@Tag(name = "Consultation", description = "상담 API")
+@RestController
+@RequestMapping("/api/consultations")
+@RequiredArgsConstructor
 public class ConsultationController {
+
+    private final ConsultationService consultationService;
+    private final MessageService messageService;
+
+    @Operation(summary = "법률 분야 목록 조회", description = "분야 선택 UI에서 사용하는 법률 분야 목록")
+    @GetMapping("/legal-fields")
+    public ApiResponse<List<DomainType>> getLegalFields() {
+        return ApiResponse.success("조회 성공", List.of(DomainType.values()));
+    }
+
+    @Operation(summary = "상담 생성", description = "새로운 상담을 생성하고 환영 메시지를 반환합니다")
+    @PostMapping
+    public ApiResponse<CreateConsultationResponse> create(@RequestBody CreateConsultationRequest request) {
+        // TODO: Auth 연동 후 JWT에서 userId 추출
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+
+        CreateConsultationResponse result = consultationService.createConsultation(userId, request.domain());
+        return ApiResponse.success("상담이 생성되었습니다", result);
+    }
+
+    @Operation(summary = "내 상담 목록", description = "로그인한 사용자의 상담 목록을 조회합니다")
+    @GetMapping
+    public ApiResponse<PageResponse<ConsultationResponse>> getMyConsultations(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        // TODO: Auth 연동 후 JWT에서 userId 추출
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "updatedAt"));
+        PageResponse<ConsultationResponse> result = consultationService.getMyConsultations(userId, pageable);
+        return ApiResponse.success("조회 성공", result);
+    }
+
+    @Operation(summary = "메시지 전송", description = "상담에 메시지를 전송합니다")
+    @PostMapping("/{consultationId}/messages")
+    public ApiResponse<SendMessageResponse> sendMessage(
+            @PathVariable UUID consultationId,
+            @Valid @RequestBody MessageRequest request) {
+        SendMessageResponse result = messageService.sendMessage(consultationId, request.content());
+        return ApiResponse.success("전송 완료", result);
+    }
+
+    @Operation(summary = "메시지 목록 조회", description = "상담의 대화 내역을 조회합니다")
+    @GetMapping("/{consultationId}/messages")
+    public ApiResponse<PageResponse<MessageResponse>> getMessages(
+            @PathVariable UUID consultationId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "50") int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "sequence"));
+        PageResponse<MessageResponse> result = messageService.getMessages(consultationId, pageable);
+        return ApiResponse.success("조회 성공", result);
+    }
+
+    @Operation(summary = "분류 직접 수정", description = "AI 분류 결과를 사용자가 직접 수정합니다")
+    @PatchMapping("/{consultationId}/classify")
+    public ApiResponse<ClassifyResponse> updateClassification(
+            @PathVariable UUID consultationId,
+            @Valid @RequestBody ClassifyRequest request) {
+        ClassifyResponse result = consultationService.updateClassification(
+                consultationId, request.primaryField());
+        return ApiResponse.success("분류가 수정되었습니다", result);
+    }
 }

--- a/src/main/java/org/example/shield/consultation/controller/dto/ClassifyRequest.java
+++ b/src/main/java/org/example/shield/consultation/controller/dto/ClassifyRequest.java
@@ -1,0 +1,9 @@
+package org.example.shield.consultation.controller.dto;
+
+import jakarta.validation.constraints.NotNull;
+import org.example.shield.common.enums.DomainType;
+
+public record ClassifyRequest(
+        @NotNull(message = "분류 값은 필수입니다")
+        DomainType primaryField
+) {}

--- a/src/main/java/org/example/shield/consultation/controller/dto/ClassifyRequest.java
+++ b/src/main/java/org/example/shield/consultation/controller/dto/ClassifyRequest.java
@@ -1,9 +1,10 @@
 package org.example.shield.consultation.controller.dto;
 
-import jakarta.validation.constraints.NotNull;
-import org.example.shield.common.enums.DomainType;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
 
 public record ClassifyRequest(
-        @NotNull(message = "분류 값은 필수입니다")
-        DomainType primaryField
+        @NotEmpty(message = "분류 값은 필수입니다")
+        List<String> primaryField
 ) {}

--- a/src/main/java/org/example/shield/consultation/controller/dto/ClassifyResponse.java
+++ b/src/main/java/org/example/shield/consultation/controller/dto/ClassifyResponse.java
@@ -1,0 +1,5 @@
+package org.example.shield.consultation.controller.dto;
+
+public record ClassifyResponse(
+        String primaryField
+) {}

--- a/src/main/java/org/example/shield/consultation/controller/dto/ClassifyResponse.java
+++ b/src/main/java/org/example/shield/consultation/controller/dto/ClassifyResponse.java
@@ -1,5 +1,7 @@
 package org.example.shield.consultation.controller.dto;
 
+import java.util.List;
+
 public record ClassifyResponse(
-        String primaryField
+        List<String> primaryField
 ) {}

--- a/src/main/java/org/example/shield/consultation/controller/dto/ConsultationResponse.java
+++ b/src/main/java/org/example/shield/consultation/controller/dto/ConsultationResponse.java
@@ -1,20 +1,31 @@
 package org.example.shield.consultation.controller.dto;
 
-/**
- * 내 상담 목록 응답 DTO.
- *
- * TODO: record로 구현
- * - consultationId: UUID
- * - status: String (COLLECTING / ANALYZING / AWAITING_CONFIRM / CONFIRMED / REJECTED)
- * - primaryField: List<String> (nullable, 분류 전 null)
- * - tags: List<String> (nullable)
- * - lastMessage: String (nullable)
- * - lastMessageAt: LocalDateTime (nullable)
- * - createdAt: LocalDateTime
- * - brief: BriefSummary (nullable, 의뢰서 생성 전 null)
- *   - briefId: UUID
- *   - title: String
- *   - status: String
- */
-public class ConsultationResponse {
+import org.example.shield.consultation.domain.Consultation;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record ConsultationResponse(
+        UUID consultationId,
+        String status,
+        List<String> primaryField,
+        List<String> tags,
+        String lastMessage,
+        LocalDateTime lastMessageAt,
+        LocalDateTime createdAt
+) {
+    public static ConsultationResponse of(Consultation consultation,
+                                          String lastMessage,
+                                          LocalDateTime lastMessageAt) {
+        return new ConsultationResponse(
+                consultation.getId(),
+                consultation.getStatus().name(),
+                consultation.getPrimaryField(),
+                consultation.getTags(),
+                lastMessage,
+                lastMessageAt,
+                consultation.getCreatedAt()
+        );
+    }
 }

--- a/src/main/java/org/example/shield/consultation/controller/dto/ConsultationResponse.java
+++ b/src/main/java/org/example/shield/consultation/controller/dto/ConsultationResponse.java
@@ -15,16 +15,14 @@ public record ConsultationResponse(
         LocalDateTime lastMessageAt,
         LocalDateTime createdAt
 ) {
-    public static ConsultationResponse of(Consultation consultation,
-                                          String lastMessage,
-                                          LocalDateTime lastMessageAt) {
+    public static ConsultationResponse from(Consultation consultation) {
         return new ConsultationResponse(
                 consultation.getId(),
                 consultation.getStatus().name(),
                 consultation.getPrimaryField(),
                 consultation.getTags(),
-                lastMessage,
-                lastMessageAt,
+                consultation.getLastMessage(),
+                consultation.getLastMessageAt(),
                 consultation.getCreatedAt()
         );
     }

--- a/src/main/java/org/example/shield/consultation/controller/dto/CreateConsultationRequest.java
+++ b/src/main/java/org/example/shield/consultation/controller/dto/CreateConsultationRequest.java
@@ -1,0 +1,7 @@
+package org.example.shield.consultation.controller.dto;
+
+import org.example.shield.common.enums.DomainType;
+
+public record CreateConsultationRequest(
+        DomainType domain
+) {}

--- a/src/main/java/org/example/shield/consultation/controller/dto/CreateConsultationResponse.java
+++ b/src/main/java/org/example/shield/consultation/controller/dto/CreateConsultationResponse.java
@@ -1,0 +1,11 @@
+package org.example.shield.consultation.controller.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CreateConsultationResponse(
+        UUID consultationId,
+        String status,
+        String welcomeMessage,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/org/example/shield/consultation/controller/dto/MessageRequest.java
+++ b/src/main/java/org/example/shield/consultation/controller/dto/MessageRequest.java
@@ -1,10 +1,8 @@
 package org.example.shield.consultation.controller.dto;
 
-/**
- * 메시지 전송 요청 DTO.
- *
- * TODO:
- * - content: String (상담 메시지 내용)
- */
-public class MessageRequest {
-}
+import jakarta.validation.constraints.NotBlank;
+
+public record MessageRequest(
+        @NotBlank(message = "내용은 필수입니다")
+        String content
+) {}

--- a/src/main/java/org/example/shield/consultation/controller/dto/MessageResponse.java
+++ b/src/main/java/org/example/shield/consultation/controller/dto/MessageResponse.java
@@ -1,15 +1,19 @@
 package org.example.shield.consultation.controller.dto;
 
-/**
- * 메시지 전송 응답 DTO.
- *
- * TODO: record로 구현
- * - content: String (AI 답변)
- * - timestamp: LocalDateTime
- * - allCompleted: boolean (전체 대화 완료 여부)
- * - classification: ClassificationDto (allCompleted일 때만, 아니면 null)
- *   - primaryField: List<String> (AI 분류 결과)
- *   - tags: List<String> (AI 분류 태그)
- */
-public class MessageResponse {
+import org.example.shield.consultation.domain.Message;
+
+import java.time.LocalDateTime;
+
+public record MessageResponse(
+        String sender,
+        String content,
+        LocalDateTime timestamp
+) {
+    public static MessageResponse from(Message message) {
+        return new MessageResponse(
+                message.getRole().name(),
+                message.getContent(),
+                message.getCreatedAt()
+        );
+    }
 }

--- a/src/main/java/org/example/shield/consultation/controller/dto/SendMessageResponse.java
+++ b/src/main/java/org/example/shield/consultation/controller/dto/SendMessageResponse.java
@@ -1,0 +1,19 @@
+package org.example.shield.consultation.controller.dto;
+
+import org.example.shield.consultation.domain.Message;
+
+import java.time.LocalDateTime;
+
+public record SendMessageResponse(
+        String content,
+        LocalDateTime timestamp,
+        boolean allCompleted
+) {
+    public static SendMessageResponse from(Message message, boolean allCompleted) {
+        return new SendMessageResponse(
+                message.getContent(),
+                message.getCreatedAt(),
+                allCompleted
+        );
+    }
+}

--- a/src/main/java/org/example/shield/consultation/domain/Consultation.java
+++ b/src/main/java/org/example/shield/consultation/domain/Consultation.java
@@ -57,8 +57,8 @@ public class Consultation extends BaseEntity {
                 .build();
     }
 
-    public void updateClassification(DomainType primaryField) {
-        this.selectedDomain = primaryField;
+    public void updateClassification(List<String> primaryField) {
+        this.primaryField = primaryField;
     }
 
     public void updateStatus(ConsultationStatus status) {

--- a/src/main/java/org/example/shield/consultation/domain/Consultation.java
+++ b/src/main/java/org/example/shield/consultation/domain/Consultation.java
@@ -1,18 +1,67 @@
 package org.example.shield.consultation.domain;
 
-/**
- * 상담 엔티티 - consultations 테이블 매핑.
- *
- * TODO: @Entity 구현
- * - id: UUID (PK)
- * - userId: UUID (FK -> users.id)
- * - status: ConsultationStatus (COLLECTING / ANALYZING / AWAITING_CONFIRM / CONFIRMED / REJECTED)
- * - selectedDomain: DomainType (nullable, "잘 모르겠어요" = null)
- * - primaryField: JSONB (nullable, AI 분류 결과, 복수 가능)
- * - tags: JSONB (nullable, AI 분류 태그)
- * - createdAt, updatedAt: LocalDateTime
- *
- * 대화 내역은 messages 테이블에 별도 저장 (1:N 관계)
- */
-public class Consultation {
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.shield.common.domain.BaseEntity;
+import org.example.shield.common.enums.ConsultationStatus;
+import org.example.shield.common.enums.DomainType;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "consultations")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Consultation extends BaseEntity {
+
+    @Column(nullable = false)
+    private UUID userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "consultation_status")
+    private ConsultationStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "domain_type")
+    private DomainType selectedDomain;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private List<String> primaryField;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private List<String> tags;
+
+    @Builder
+    private Consultation(UUID userId, DomainType selectedDomain) {
+        this.userId = userId;
+        this.selectedDomain = selectedDomain;
+        this.status = ConsultationStatus.COLLECTING;
+    }
+
+    public static Consultation create(UUID userId, DomainType selectedDomain) {
+        return Consultation.builder()
+                .userId(userId)
+                .selectedDomain(selectedDomain)
+                .build();
+    }
+
+    public void updateClassification(DomainType primaryField) {
+        this.selectedDomain = primaryField;
+    }
+
+    public void updateStatus(ConsultationStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/org/example/shield/consultation/domain/Consultation.java
+++ b/src/main/java/org/example/shield/consultation/domain/Consultation.java
@@ -15,6 +15,7 @@ import org.example.shield.common.enums.DomainType;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -43,6 +44,11 @@ public class Consultation extends BaseEntity {
     @Column(columnDefinition = "jsonb")
     private List<String> tags;
 
+    @Column(columnDefinition = "text")
+    private String lastMessage;
+
+    private LocalDateTime lastMessageAt;
+
     @Builder
     private Consultation(UUID userId, DomainType selectedDomain) {
         this.userId = userId;
@@ -63,5 +69,10 @@ public class Consultation extends BaseEntity {
 
     public void updateStatus(ConsultationStatus status) {
         this.status = status;
+    }
+
+    public void updateLastMessage(String content, LocalDateTime timestamp) {
+        this.lastMessage = content;
+        this.lastMessageAt = timestamp;
     }
 }

--- a/src/main/java/org/example/shield/consultation/domain/ConsultationReader.java
+++ b/src/main/java/org/example/shield/consultation/domain/ConsultationReader.java
@@ -1,11 +1,13 @@
 package org.example.shield.consultation.domain;
 
-/**
- * Consultation 조회 인터페이스.
- *
- * TODO:
- * - findById(UUID id): Consultation
- * - findAllByUserId(UUID userId, Pageable pageable): Page<Consultation>
- */
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
 public interface ConsultationReader {
+
+    Consultation findById(UUID id);
+
+    Page<Consultation> findAllByUserId(UUID userId, Pageable pageable);
 }

--- a/src/main/java/org/example/shield/consultation/domain/ConsultationWriter.java
+++ b/src/main/java/org/example/shield/consultation/domain/ConsultationWriter.java
@@ -1,10 +1,6 @@
 package org.example.shield.consultation.domain;
 
-/**
- * Consultation 저장 인터페이스.
- *
- * TODO:
- * - save(Consultation consultation): Consultation
- */
 public interface ConsultationWriter {
+
+    Consultation save(Consultation consultation);
 }

--- a/src/main/java/org/example/shield/consultation/domain/Message.java
+++ b/src/main/java/org/example/shield/consultation/domain/Message.java
@@ -53,8 +53,6 @@ public class Message {
 
     private Integer latencyMs;
 
-    private UUID parentMessageId;
-
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -62,7 +60,7 @@ public class Message {
     @Builder
     private Message(UUID consultationId, MessageRole role, String content,
                     String model, Integer tokensInput, Integer tokensOutput,
-                    Integer latencyMs, UUID parentMessageId) {
+                    Integer latencyMs) {
         this.consultationId = consultationId;
         this.role = role;
         this.content = content;
@@ -70,7 +68,6 @@ public class Message {
         this.tokensInput = tokensInput;
         this.tokensOutput = tokensOutput;
         this.latencyMs = latencyMs;
-        this.parentMessageId = parentMessageId;
     }
 
     public static Message createUserMessage(UUID consultationId, String content) {

--- a/src/main/java/org/example/shield/consultation/domain/Message.java
+++ b/src/main/java/org/example/shield/consultation/domain/Message.java
@@ -1,20 +1,97 @@
 package org.example.shield.consultation.domain;
 
-/**
- * 메시지 엔티티 - messages 테이블 매핑.
- *
- * TODO: @Entity 구현
- * - id: UUID (PK)
- * - consultationId: UUID (FK -> consultations.id)
- * - sequence: Integer (AUTO INCREMENT, 메시지 순서)
- * - role: MessageRole ENUM (USER / AI)
- * - content: String (메시지 내용)
- * - model: String (nullable, AI 모델명: grok-3 등)
- * - tokensInput: Integer (nullable, 입력 토큰 수)
- * - tokensOutput: Integer (nullable, 출력 토큰 수)
- * - latencyMs: Integer (nullable, AI 응답 시간 ms)
- * - parentMessageId: UUID (nullable, 이전 메시지 참조)
- * - createdAt: LocalDateTime
- */
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.shield.common.enums.MessageRole;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "messages")
+@EntityListeners(org.springframework.data.jpa.domain.support.AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Message {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID consultationId;
+
+    @Column(nullable = false, insertable = false, updatable = false)
+    private Integer sequence;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "message_role")
+    private MessageRole role;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String content;
+
+    private String model;
+
+    private Integer tokensInput;
+
+    private Integer tokensOutput;
+
+    private Integer latencyMs;
+
+    private UUID parentMessageId;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    private Message(UUID consultationId, MessageRole role, String content,
+                    String model, Integer tokensInput, Integer tokensOutput,
+                    Integer latencyMs, UUID parentMessageId) {
+        this.consultationId = consultationId;
+        this.role = role;
+        this.content = content;
+        this.model = model;
+        this.tokensInput = tokensInput;
+        this.tokensOutput = tokensOutput;
+        this.latencyMs = latencyMs;
+        this.parentMessageId = parentMessageId;
+    }
+
+    public static Message createUserMessage(UUID consultationId, String content) {
+        return Message.builder()
+                .consultationId(consultationId)
+                .role(MessageRole.USER)
+                .content(content)
+                .build();
+    }
+
+    public static Message createAiMessage(UUID consultationId, String content,
+                                          String model, Integer tokensInput,
+                                          Integer tokensOutput, Integer latencyMs) {
+        return Message.builder()
+                .consultationId(consultationId)
+                .role(MessageRole.CHATBOT)
+                .content(content)
+                .model(model)
+                .tokensInput(tokensInput)
+                .tokensOutput(tokensOutput)
+                .latencyMs(latencyMs)
+                .build();
+    }
 }

--- a/src/main/java/org/example/shield/consultation/domain/MessageReader.java
+++ b/src/main/java/org/example/shield/consultation/domain/MessageReader.java
@@ -1,12 +1,17 @@
 package org.example.shield.consultation.domain;
 
-/**
- * Message 조회 인터페이스.
- *
- * TODO:
- * - findAllByConsultationId(UUID consultationId): List<Message> (sequence 순)
- * - findLastByConsultationId(UUID consultationId): Optional<Message>
- * - getMaxSequence(UUID consultationId): int
- */
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 public interface MessageReader {
+
+    List<Message> findAllByConsultationId(UUID consultationId);
+
+    Page<Message> findAllByConsultationId(UUID consultationId, Pageable pageable);
+
+    Optional<Message> findLastByConsultationId(UUID consultationId);
 }

--- a/src/main/java/org/example/shield/consultation/domain/MessageWriter.java
+++ b/src/main/java/org/example/shield/consultation/domain/MessageWriter.java
@@ -1,10 +1,6 @@
 package org.example.shield.consultation.domain;
 
-/**
- * Message 저장 인터페이스.
- *
- * TODO:
- * - save(Message message): Message
- */
 public interface MessageWriter {
+
+    Message save(Message message);
 }

--- a/src/main/java/org/example/shield/consultation/exception/ConsultationNotFoundException.java
+++ b/src/main/java/org/example/shield/consultation/exception/ConsultationNotFoundException.java
@@ -1,8 +1,14 @@
 package org.example.shield.consultation.exception;
 
-/**
- * 상담 없음 예외.
- * consultationId로 조회했는데 없을 때 발생.
- */
-public class ConsultationNotFoundException {
+import org.example.shield.common.exception.BusinessException;
+import org.example.shield.common.exception.ErrorCode;
+
+import java.util.UUID;
+
+public class ConsultationNotFoundException extends BusinessException {
+
+    public ConsultationNotFoundException(UUID consultationId) {
+        super(ErrorCode.CONSULTATION_NOT_FOUND,
+                "상담을 찾을 수 없습니다. ID: " + consultationId);
+    }
 }

--- a/src/main/java/org/example/shield/consultation/infrastructure/ConsultationReaderImpl.java
+++ b/src/main/java/org/example/shield/consultation/infrastructure/ConsultationReaderImpl.java
@@ -1,11 +1,29 @@
 package org.example.shield.consultation.infrastructure;
 
-/**
- * ConsultationReader 구현체.
- *
- * TODO: @Repository + implements ConsultationReader
- * - ConsultationRepository 주입
- * - findById: 없으면 ConsultationNotFoundException
- */
-public class ConsultationReaderImpl {
+import lombok.RequiredArgsConstructor;
+import org.example.shield.consultation.domain.Consultation;
+import org.example.shield.consultation.domain.ConsultationReader;
+import org.example.shield.consultation.exception.ConsultationNotFoundException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class ConsultationReaderImpl implements ConsultationReader {
+
+    private final ConsultationRepository consultationRepository;
+
+    @Override
+    public Consultation findById(UUID id) {
+        return consultationRepository.findById(id)
+                .orElseThrow(() -> new ConsultationNotFoundException(id));
+    }
+
+    @Override
+    public Page<Consultation> findAllByUserId(UUID userId, Pageable pageable) {
+        return consultationRepository.findAllByUserId(userId, pageable);
+    }
 }

--- a/src/main/java/org/example/shield/consultation/infrastructure/ConsultationRepository.java
+++ b/src/main/java/org/example/shield/consultation/infrastructure/ConsultationRepository.java
@@ -1,10 +1,13 @@
 package org.example.shield.consultation.infrastructure;
 
-/**
- * 상담 JPA Repository.
- *
- * TODO: extends JpaRepository<Consultation, UUID>
- * - findByUserId(UUID userId): List<Consultation>
- */
-public interface ConsultationRepository {
+import org.example.shield.consultation.domain.Consultation;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ConsultationRepository extends JpaRepository<Consultation, UUID> {
+
+    Page<Consultation> findAllByUserId(UUID userId, Pageable pageable);
 }

--- a/src/main/java/org/example/shield/consultation/infrastructure/ConsultationWriterImpl.java
+++ b/src/main/java/org/example/shield/consultation/infrastructure/ConsultationWriterImpl.java
@@ -1,10 +1,18 @@
 package org.example.shield.consultation.infrastructure;
 
-/**
- * ConsultationWriter 구현체.
- *
- * TODO: @Repository + implements ConsultationWriter
- * - ConsultationRepository 주입
- */
-public class ConsultationWriterImpl {
+import lombok.RequiredArgsConstructor;
+import org.example.shield.consultation.domain.Consultation;
+import org.example.shield.consultation.domain.ConsultationWriter;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ConsultationWriterImpl implements ConsultationWriter {
+
+    private final ConsultationRepository consultationRepository;
+
+    @Override
+    public Consultation save(Consultation consultation) {
+        return consultationRepository.save(consultation);
+    }
 }

--- a/src/main/java/org/example/shield/consultation/infrastructure/MessageReaderImpl.java
+++ b/src/main/java/org/example/shield/consultation/infrastructure/MessageReaderImpl.java
@@ -1,10 +1,34 @@
 package org.example.shield.consultation.infrastructure;
 
-/**
- * MessageReader 구현체.
- *
- * TODO: @Repository + implements MessageReader
- * - MessageRepository 주입
- */
-public class MessageReaderImpl {
+import lombok.RequiredArgsConstructor;
+import org.example.shield.consultation.domain.Message;
+import org.example.shield.consultation.domain.MessageReader;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class MessageReaderImpl implements MessageReader {
+
+    private final MessageRepository messageRepository;
+
+    @Override
+    public List<Message> findAllByConsultationId(UUID consultationId) {
+        return messageRepository.findAllByConsultationIdOrderBySequence(consultationId);
+    }
+
+    @Override
+    public Page<Message> findAllByConsultationId(UUID consultationId, Pageable pageable) {
+        return messageRepository.findAllByConsultationIdOrderBySequence(consultationId, pageable);
+    }
+
+    @Override
+    public Optional<Message> findLastByConsultationId(UUID consultationId) {
+        return messageRepository.findTopByConsultationIdOrderBySequenceDesc(consultationId);
+    }
 }

--- a/src/main/java/org/example/shield/consultation/infrastructure/MessageRepository.java
+++ b/src/main/java/org/example/shield/consultation/infrastructure/MessageRepository.java
@@ -1,11 +1,19 @@
 package org.example.shield.consultation.infrastructure;
 
-/**
- * Message JPA Repository.
- *
- * TODO: extends JpaRepository<Message, UUID>
- * - findAllByConsultationIdOrderBySequence(UUID consultationId): List<Message>
- * - findTopByConsultationIdOrderBySequenceDesc(UUID consultationId): Optional<Message>
- */
-public interface MessageRepository {
+import org.example.shield.consultation.domain.Message;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MessageRepository extends JpaRepository<Message, UUID> {
+
+    List<Message> findAllByConsultationIdOrderBySequence(UUID consultationId);
+
+    Page<Message> findAllByConsultationIdOrderBySequence(UUID consultationId, Pageable pageable);
+
+    Optional<Message> findTopByConsultationIdOrderBySequenceDesc(UUID consultationId);
 }

--- a/src/main/java/org/example/shield/consultation/infrastructure/MessageWriterImpl.java
+++ b/src/main/java/org/example/shield/consultation/infrastructure/MessageWriterImpl.java
@@ -1,10 +1,18 @@
 package org.example.shield.consultation.infrastructure;
 
-/**
- * MessageWriter 구현체.
- *
- * TODO: @Repository + implements MessageWriter
- * - MessageRepository 주입
- */
-public class MessageWriterImpl {
+import lombok.RequiredArgsConstructor;
+import org.example.shield.consultation.domain.Message;
+import org.example.shield.consultation.domain.MessageWriter;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MessageWriterImpl implements MessageWriter {
+
+    private final MessageRepository messageRepository;
+
+    @Override
+    public Message save(Message message) {
+        return messageRepository.save(message);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,13 +4,13 @@ spring:
 
   # PostgreSQL
   datasource:
-    url: ${DB_URL}
+    url: ${DB_URL}&prepareThreshold=0
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
       naming:
         physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
     show-sql: true


### PR DESCRIPTION
## 개요
상담 도메인 API 6개 구현 (AI 독립 기능)

## 변경 사항
### API
- `GET /api/consultations/legal-fields` - 법률 분야 목록 조회
- `POST /api/consultations` - 상담 생성 (환영 메시지 자동 생성)
- `GET /api/consultations` - 내 상담 목록 (최신 대화순 정렬)
- `POST /api/consultations/{id}/messages` - 메시지 전송 (목 AI 응답 포함)
- `GET /api/consultations/{id}/messages` - 메시지 목록 조회
- `PATCH /api/consultations/{id}/classify` - 분류 직접 수정

### 구조
- Consultation, Message Entity + Reader/Writer 패턴
- 모든 Request/Response를 전용 record DTO로 분리
- 메시지 전송 시 `consultation.touch()`로 updatedAt 갱신 → 최신 대화순 정렬

### DB / 설정
- PostgreSQL ENUM 타입 호환을 위해 `.env`에 `stringtype=unspecified` 추가 필수
- `application.yml`은 `${DB_URL}&prepareThreshold=0`으로 연결
- Java Enum ↔ DB Enum 동기화 (`MessageRole.AI` → `CHATBOT` 등)
- Entity ENUM 필드에 `columnDefinition` 지정
- `springdoc-openapi` 2.3.0 → 2.8.6 (Spring Boot 4.x 호환)

## 참고
- 메시지 전송 API는 목 AI 응답 상태 (AI 연동 시 교체 예정)
- `.env`에 `stringtype=unspecified` 없으면 `invalid input value for enum` 에러 발생
- `ApiResponse` JSON 필드 순서 `result → message → data`로 고정

## 테스트
- [x] Swagger UI 전체 API 동작 확인
- [x] 상담 생성 → 메시지 전송 → 목록 조회 흐름 검증
- [x] 분류 수정 API 검증
- [x] 최신 대화순 정렬 검증