### PR TITLE
[FEAT] 인증/Auth API 구현 (Issue #6)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/org/example/shield/auth/application/AuthService.java
+++ b/src/main/java/org/example/shield/auth/application/AuthService.java
@@ -34,9 +34,33 @@ public class AuthService {
                         User.builder()
                                 .email(userInfo.email())
                                 .name(userInfo.name())
-                                .role(UserRole.valueOf(role))
+                                .role(UserRole.valueOf(role.toUpperCase()))
                                 .provider("GOOGLE")
                                 .googleId(userInfo.googleId())
+                                .build()
+                ));
+
+        JwtToken tokenPair = jwtService.createTokenPair(user.getId(), user.getRole().name());
+        user.updateRefreshToken(tokenPair.refreshToken());
+
+        LoginResponse response = new LoginResponse(
+                tokenPair.accessToken(),
+                user.getId(),
+                user.getName(),
+                user.getRole().name()
+        );
+        return new LoginResult(response, tokenPair.refreshToken());
+    }
+
+    public LoginResult devLogin(String email, String name, String role) {
+        User user = userReader.findByEmail(email)
+                .orElseGet(() -> userWriter.save(
+                        User.builder()
+                                .email(email)
+                                .name(name)
+                                .role(UserRole.valueOf(role.toUpperCase()))
+                                .provider("DEV")
+                                .googleId("dev-" + UUID.randomUUID())
                                 .build()
                 ));
 

--- a/src/main/java/org/example/shield/auth/application/AuthService.java
+++ b/src/main/java/org/example/shield/auth/application/AuthService.java
@@ -4,8 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.example.shield.auth.controller.dto.LoginResponse;
 import org.example.shield.auth.domain.JwtToken;
 import org.example.shield.auth.domain.OAuthUserInfo;
+import org.example.shield.auth.exception.InvalidRoleException;
 import org.example.shield.auth.exception.InvalidTokenException;
 import org.example.shield.common.enums.UserRole;
+import org.example.shield.common.exception.ErrorCode;
 import org.example.shield.user.domain.User;
 import org.example.shield.user.domain.UserReader;
 import org.example.shield.user.domain.UserWriter;
@@ -34,7 +36,7 @@ public class AuthService {
                         User.builder()
                                 .email(userInfo.email())
                                 .name(userInfo.name())
-                                .role(UserRole.valueOf(role.toUpperCase()))
+                                .role(parseRole(role))
                                 .provider("GOOGLE")
                                 .googleId(userInfo.googleId())
                                 .build()
@@ -59,7 +61,7 @@ public class AuthService {
                         User.builder()
                                 .email(email)
                                 .name(name)
-                                .role(UserRole.valueOf(role.toUpperCase()))
+                                .role(parseRole(role))
                                 .provider("DEV")
                                 .googleId("dev-" + UUID.randomUUID())
                                 .build()
@@ -85,19 +87,27 @@ public class AuthService {
 
     public String refreshToken(String refreshToken) {
         if (!jwtService.validateToken(refreshToken)) {
-            throw new InvalidTokenException();
+            throw new InvalidTokenException(ErrorCode.TOKEN_EXPIRED);
         }
 
         UUID userId = jwtService.getUserIdFromToken(refreshToken);
         User user = userReader.findById(userId);
 
         if (user.getRefreshToken() == null || !user.getRefreshToken().equals(refreshToken)) {
-            throw new InvalidTokenException();
+            throw new InvalidTokenException(ErrorCode.REFRESH_TOKEN_MISMATCH);
         }
 
         JwtToken tokenPair = jwtService.createTokenPair(userId, user.getRole().name());
         user.updateRefreshToken(tokenPair.refreshToken());
 
         return tokenPair.accessToken();
+    }
+
+    private UserRole parseRole(String role) {
+        try {
+            return UserRole.valueOf(role.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidRoleException();
+        }
     }
 }

--- a/src/main/java/org/example/shield/auth/application/AuthService.java
+++ b/src/main/java/org/example/shield/auth/application/AuthService.java
@@ -85,7 +85,7 @@ public class AuthService {
         user.updateRefreshToken(null);
     }
 
-    public String refreshToken(String refreshToken) {
+    public JwtToken refreshToken(String refreshToken) {
         if (!jwtService.validateToken(refreshToken)) {
             throw new InvalidTokenException(ErrorCode.TOKEN_EXPIRED);
         }
@@ -100,7 +100,7 @@ public class AuthService {
         JwtToken tokenPair = jwtService.createTokenPair(userId, user.getRole().name());
         user.updateRefreshToken(tokenPair.refreshToken());
 
-        return tokenPair.accessToken();
+        return tokenPair;
     }
 
     private UserRole parseRole(String role) {

--- a/src/main/java/org/example/shield/auth/application/AuthService.java
+++ b/src/main/java/org/example/shield/auth/application/AuthService.java
@@ -1,27 +1,77 @@
 package org.example.shield.auth.application;
 
-/**
- * 인증 서비스 - Google OAuth 로그인/로그아웃/토큰 갱신 비즈니스 로직.
- *
- * Layer: application
- * Called by: AuthController
- * Calls: GoogleOAuthService, JwtService, UserReader, UserWriter
- *
- * TODO:
- * - googleLogin(authorizationCode, role):
- *   1. GoogleOAuthService로 인증코드 → 사용자 정보(email, name, googleId) 받기
- *   2. UserReader에서 email로 기존 회원 조회
- *   3. 없으면 새 User 생성 (role: USER/LAWYER/ADMIN)
- *   4. JwtService로 Access Token + Refresh Token 생성
- *   5. Refresh Token을 users.refresh_token에 저장
- *   6. LoginResponse 반환
- *
- * - logout(userId):
- *   1. users.refresh_token = null
- *
- * - refreshToken(refreshToken):
- *   1. Refresh Token 유효성 검증
- *   2. 새 Access Token 발급
- */
+import lombok.RequiredArgsConstructor;
+import org.example.shield.auth.controller.dto.LoginResponse;
+import org.example.shield.auth.domain.JwtToken;
+import org.example.shield.auth.domain.OAuthUserInfo;
+import org.example.shield.auth.exception.InvalidTokenException;
+import org.example.shield.common.enums.UserRole;
+import org.example.shield.user.domain.User;
+import org.example.shield.user.domain.UserReader;
+import org.example.shield.user.domain.UserWriter;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class AuthService {
+
+    private final GoogleOAuthService googleOAuthService;
+    private final JwtService jwtService;
+    private final UserReader userReader;
+    private final UserWriter userWriter;
+
+    public record LoginResult(LoginResponse response, String refreshToken) {}
+
+    public LoginResult googleLogin(String authorizationCode, String role) {
+        OAuthUserInfo userInfo = googleOAuthService.getUserInfo(authorizationCode);
+
+        User user = userReader.findByGoogleId(userInfo.googleId())
+                .orElseGet(() -> userWriter.save(
+                        User.builder()
+                                .email(userInfo.email())
+                                .name(userInfo.name())
+                                .role(UserRole.valueOf(role))
+                                .provider("GOOGLE")
+                                .googleId(userInfo.googleId())
+                                .build()
+                ));
+
+        JwtToken tokenPair = jwtService.createTokenPair(user.getId(), user.getRole().name());
+        user.updateRefreshToken(tokenPair.refreshToken());
+
+        LoginResponse response = new LoginResponse(
+                tokenPair.accessToken(),
+                user.getId(),
+                user.getName(),
+                user.getRole().name()
+        );
+        return new LoginResult(response, tokenPair.refreshToken());
+    }
+
+    public void logout(UUID userId) {
+        User user = userReader.findById(userId);
+        user.updateRefreshToken(null);
+    }
+
+    public String refreshToken(String refreshToken) {
+        if (!jwtService.validateToken(refreshToken)) {
+            throw new InvalidTokenException();
+        }
+
+        UUID userId = jwtService.getUserIdFromToken(refreshToken);
+        User user = userReader.findById(userId);
+
+        if (user.getRefreshToken() == null || !user.getRefreshToken().equals(refreshToken)) {
+            throw new InvalidTokenException();
+        }
+
+        JwtToken tokenPair = jwtService.createTokenPair(userId, user.getRole().name());
+        user.updateRefreshToken(tokenPair.refreshToken());
+
+        return tokenPair.accessToken();
+    }
 }

--- a/src/main/java/org/example/shield/auth/application/AuthService.java
+++ b/src/main/java/org/example/shield/auth/application/AuthService.java
@@ -45,6 +45,7 @@ public class AuthService {
 
         LoginResponse response = new LoginResponse(
                 tokenPair.accessToken(),
+                tokenPair.refreshToken(),
                 user.getId(),
                 user.getName(),
                 user.getRole().name()
@@ -69,6 +70,7 @@ public class AuthService {
 
         LoginResponse response = new LoginResponse(
                 tokenPair.accessToken(),
+                tokenPair.refreshToken(),
                 user.getId(),
                 user.getName(),
                 user.getRole().name()

--- a/src/main/java/org/example/shield/auth/application/GoogleOAuthService.java
+++ b/src/main/java/org/example/shield/auth/application/GoogleOAuthService.java
@@ -1,17 +1,17 @@
 package org.example.shield.auth.application;
 
-/**
- * Google OAuth 서비스 - Google API와 통신하여 사용자 정보를 받아온다.
- *
- * Layer: application
- * Called by: AuthService.googleLogin()
- * Calls: GoogleOAuthClient
- *
- * TODO:
- * - getUserInfo(authorizationCode):
- *   1. GoogleOAuthClient로 인증코드 → Access Token 교환
- *   2. Access Token으로 Google 사용자 정보 API 호출
- *   3. email, name 추출하여 반환
- */
+import lombok.RequiredArgsConstructor;
+import org.example.shield.auth.domain.OAuthClient;
+import org.example.shield.auth.domain.OAuthUserInfo;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class GoogleOAuthService {
+
+    private final OAuthClient oAuthClient;
+
+    public OAuthUserInfo getUserInfo(String authorizationCode) {
+        return oAuthClient.getUserInfo(authorizationCode);
+    }
 }

--- a/src/main/java/org/example/shield/auth/application/JwtService.java
+++ b/src/main/java/org/example/shield/auth/application/JwtService.java
@@ -1,17 +1,36 @@
 package org.example.shield.auth.application;
 
-/**
- * JWT 서비스 - JWT 토큰 생성/검증/파싱 로직.
- *
- * Layer: application
- * Called by: AuthService, JwtAuthFilter
- * Calls: JwtTokenProvider
- *
- * TODO:
- * - createTokenPair(userId, role): Access Token(30분) + Refresh Token(14일) 생성
- * - validateToken(token): 토큰 유효성 검증 (만료, 위조, 블랙리스트)
- * - getUserIdFromToken(token): 토큰에서 userId 추출
- * - getRoleFromToken(token): 토큰에서 role 추출
- */
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.example.shield.auth.domain.JwtToken;
+import org.example.shield.auth.infrastructure.JwtTokenProvider;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
 public class JwtService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtToken createTokenPair(UUID userId, String role) {
+        String accessToken = jwtTokenProvider.generateAccessToken(userId, role);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(userId, role);
+        return new JwtToken(accessToken, refreshToken);
+    }
+
+    public boolean validateToken(String token) {
+        return jwtTokenProvider.isValid(token);
+    }
+
+    public UUID getUserIdFromToken(String token) {
+        Claims claims = jwtTokenProvider.parseClaims(token);
+        return UUID.fromString(claims.getSubject());
+    }
+
+    public String getRoleFromToken(String token) {
+        Claims claims = jwtTokenProvider.parseClaims(token);
+        return claims.get("role", String.class);
+    }
 }

--- a/src/main/java/org/example/shield/auth/controller/AuthController.java
+++ b/src/main/java/org/example/shield/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.shield.auth.application.AuthService;
+import org.example.shield.auth.controller.dto.DevLoginRequest;
 import org.example.shield.auth.controller.dto.GoogleLoginRequest;
 import org.example.shield.auth.controller.dto.LoginResponse;
 import org.example.shield.auth.exception.InvalidTokenException;
@@ -35,6 +36,17 @@ public class AuthController {
 
         addRefreshTokenCookie(response, result.refreshToken());
         return ResponseEntity.ok(ApiResponse.success("로그인 성공", result.response()));
+    }
+
+    @PostMapping("/dev/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> devLogin(
+            @RequestBody DevLoginRequest request,
+            HttpServletResponse response) {
+        AuthService.LoginResult result = authService.devLogin(
+                request.email(), request.name(), request.role());
+
+        addRefreshTokenCookie(response, result.refreshToken());
+        return ResponseEntity.ok(ApiResponse.success("개발용 로그인 성공", result.response()));
     }
 
     @PostMapping("/logout")

--- a/src/main/java/org/example/shield/auth/controller/AuthController.java
+++ b/src/main/java/org/example/shield/auth/controller/AuthController.java
@@ -1,5 +1,7 @@
 package org.example.shield.auth.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
+@Tag(name = "Auth", description = "인증 API")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -27,6 +30,7 @@ public class AuthController {
 
     private final AuthService authService;
 
+    @Operation(summary = "Google 로그인", description = "Google OAuth 인증 코드로 로그인 및 JWT 발급")
     @PostMapping("/google")
     public ResponseEntity<ApiResponse<LoginResponse>> googleLogin(
             @Valid @RequestBody GoogleLoginRequest request,
@@ -38,6 +42,7 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success("로그인 성공", result.response()));
     }
 
+    @Operation(summary = "개발용 로그인", description = "Google OAuth 없이 테스트용 JWT 발급")
     @PostMapping("/dev/login")
     public ResponseEntity<ApiResponse<LoginResponse>> devLogin(
             @RequestBody DevLoginRequest request,
@@ -49,6 +54,7 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success("개발용 로그인 성공", result.response()));
     }
 
+    @Operation(summary = "로그아웃", description = "현재 세션 종료 및 Refresh Token 무효화")
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
             @AuthenticationPrincipal UUID userId,
@@ -58,6 +64,7 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success("로그아웃 성공"));
     }
 
+    @Operation(summary = "토큰 갱신", description = "Refresh Token으로 새 Access Token 발급")
     @PostMapping("/token/refresh")
     public ResponseEntity<ApiResponse<String>> refreshToken(
             @CookieValue(name = "refreshToken", required = false) String refreshToken) {

--- a/src/main/java/org/example/shield/auth/controller/AuthController.java
+++ b/src/main/java/org/example/shield/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.shield.auth.application.AuthService;
 import org.example.shield.auth.controller.dto.DevLoginRequest;
+import org.example.shield.auth.domain.JwtToken;
 import org.example.shield.auth.controller.dto.GoogleLoginRequest;
 import org.example.shield.auth.controller.dto.LoginResponse;
 import org.example.shield.auth.exception.InvalidTokenException;
@@ -64,15 +65,17 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success("로그아웃 성공"));
     }
 
-    @Operation(summary = "토큰 갱신", description = "Refresh Token으로 새 Access Token 발급")
+    @Operation(summary = "토큰 갱신", description = "Refresh Token으로 새 Access Token + Refresh Token 재발급")
     @PostMapping("/token/refresh")
     public ResponseEntity<ApiResponse<String>> refreshToken(
-            @CookieValue(name = "refreshToken", required = false) String refreshToken) {
+            @CookieValue(name = "refreshToken", required = false) String refreshToken,
+            HttpServletResponse response) {
         if (refreshToken == null) {
             throw new InvalidTokenException();
         }
-        String newAccessToken = authService.refreshToken(refreshToken);
-        return ResponseEntity.ok(ApiResponse.success("토큰 갱신 성공", newAccessToken));
+        JwtToken tokenPair = authService.refreshToken(refreshToken);
+        addRefreshTokenCookie(response, tokenPair.refreshToken());
+        return ResponseEntity.ok(ApiResponse.success("토큰 갱신 성공", tokenPair.accessToken()));
     }
 
     private void addRefreshTokenCookie(HttpServletResponse response, String token) {

--- a/src/main/java/org/example/shield/auth/controller/AuthController.java
+++ b/src/main/java/org/example/shield/auth/controller/AuthController.java
@@ -1,16 +1,76 @@
 package org.example.shield.auth.controller;
 
-/**
- * 인증 API 컨트롤러.
- *
- * Layer: controller
- * Called by: 프론트엔드
- * Calls: AuthService
- *
- * API 목록 (3개):
- * - POST /api/auth/google    구글 로그인 (body: authorizationCode, role)
- * - POST /api/auth/logout     로그아웃 (Header: Authorization Bearer)
- * - POST /api/auth/token/refresh  토큰 갱신 (Cookie: refreshToken)
- */
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.shield.auth.application.AuthService;
+import org.example.shield.auth.controller.dto.GoogleLoginRequest;
+import org.example.shield.auth.controller.dto.LoginResponse;
+import org.example.shield.auth.exception.InvalidTokenException;
+import org.example.shield.common.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/google")
+    public ResponseEntity<ApiResponse<LoginResponse>> googleLogin(
+            @Valid @RequestBody GoogleLoginRequest request,
+            HttpServletResponse response) {
+        AuthService.LoginResult result = authService.googleLogin(
+                request.authorizationCode(), request.role());
+
+        addRefreshTokenCookie(response, result.refreshToken());
+        return ResponseEntity.ok(ApiResponse.success("로그인 성공", result.response()));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @AuthenticationPrincipal UUID userId,
+            HttpServletResponse response) {
+        authService.logout(userId);
+        clearRefreshTokenCookie(response);
+        return ResponseEntity.ok(ApiResponse.success("로그아웃 성공"));
+    }
+
+    @PostMapping("/token/refresh")
+    public ResponseEntity<ApiResponse<String>> refreshToken(
+            @CookieValue(name = "refreshToken", required = false) String refreshToken) {
+        if (refreshToken == null) {
+            throw new InvalidTokenException();
+        }
+        String newAccessToken = authService.refreshToken(refreshToken);
+        return ResponseEntity.ok(ApiResponse.success("토큰 갱신 성공", newAccessToken));
+    }
+
+    private void addRefreshTokenCookie(HttpServletResponse response, String token) {
+        Cookie cookie = new Cookie("refreshToken", token);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(14 * 24 * 60 * 60);
+        response.addCookie(cookie);
+    }
+
+    private void clearRefreshTokenCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie("refreshToken", null);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
 }

--- a/src/main/java/org/example/shield/auth/controller/dto/DevLoginRequest.java
+++ b/src/main/java/org/example/shield/auth/controller/dto/DevLoginRequest.java
@@ -1,0 +1,7 @@
+package org.example.shield.auth.controller.dto;
+
+public record DevLoginRequest(
+        String email,
+        String name,
+        String role
+) {}

--- a/src/main/java/org/example/shield/auth/controller/dto/GoogleLoginRequest.java
+++ b/src/main/java/org/example/shield/auth/controller/dto/GoogleLoginRequest.java
@@ -1,11 +1,11 @@
 package org.example.shield.auth.controller.dto;
 
-/**
- * 구글 로그인 요청 DTO.
- *
- * TODO: record로 구현
- * - authorizationCode: String (Google OAuth 인증 코드)
- * - role: String (USER / LAWYER / ADMIN)
- */
-public class GoogleLoginRequest {
-}
+import jakarta.validation.constraints.NotBlank;
+
+public record GoogleLoginRequest(
+        @NotBlank(message = "인증 코드는 필수입니다")
+        String authorizationCode,
+
+        @NotBlank(message = "역할은 필수입니다")
+        String role
+) {}

--- a/src/main/java/org/example/shield/auth/controller/dto/LoginResponse.java
+++ b/src/main/java/org/example/shield/auth/controller/dto/LoginResponse.java
@@ -1,13 +1,10 @@
 package org.example.shield.auth.controller.dto;
 
-/**
- * 로그인 응답 DTO.
- *
- * TODO: record로 구현
- * - accessToken: String (JWT)
- * - userId: UUID
- * - name: String
- * - role: String (USER / LAWYER / ADMIN)
- */
-public class LoginResponse {
-}
+import java.util.UUID;
+
+public record LoginResponse(
+        String accessToken,
+        UUID userId,
+        String name,
+        String role
+) {}

--- a/src/main/java/org/example/shield/auth/controller/dto/LoginResponse.java
+++ b/src/main/java/org/example/shield/auth/controller/dto/LoginResponse.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 public record LoginResponse(
         String accessToken,
+        String refreshToken,
         UUID userId,
         String name,
         String role

--- a/src/main/java/org/example/shield/auth/domain/JwtToken.java
+++ b/src/main/java/org/example/shield/auth/domain/JwtToken.java
@@ -1,11 +1,6 @@
 package org.example.shield.auth.domain;
 
-/**
- * JWT 토큰 도메인 객체.
- *
- * TODO:
- * - accessToken: String
- * - refreshToken: String
- */
-public class JwtToken {
-}
+public record JwtToken(
+        String accessToken,
+        String refreshToken
+) {}

--- a/src/main/java/org/example/shield/auth/exception/InvalidRoleException.java
+++ b/src/main/java/org/example/shield/auth/exception/InvalidRoleException.java
@@ -3,9 +3,9 @@ package org.example.shield.auth.exception;
 import org.example.shield.common.exception.BusinessException;
 import org.example.shield.common.exception.ErrorCode;
 
-public class OAuthFailedException extends BusinessException {
+public class InvalidRoleException extends BusinessException {
 
-    public OAuthFailedException(ErrorCode errorCode) {
-        super(errorCode);
+    public InvalidRoleException() {
+        super(ErrorCode.INVALID_ROLE);
     }
 }

--- a/src/main/java/org/example/shield/auth/exception/InvalidTokenException.java
+++ b/src/main/java/org/example/shield/auth/exception/InvalidTokenException.java
@@ -6,6 +6,10 @@ import org.example.shield.common.exception.ErrorCode;
 public class InvalidTokenException extends BusinessException {
 
     public InvalidTokenException() {
-        super(ErrorCode.INVALID_TOKEN);
+        super(ErrorCode.TOKEN_INVALID);
+    }
+
+    public InvalidTokenException(ErrorCode errorCode) {
+        super(errorCode);
     }
 }

--- a/src/main/java/org/example/shield/auth/exception/InvalidTokenException.java
+++ b/src/main/java/org/example/shield/auth/exception/InvalidTokenException.java
@@ -1,8 +1,11 @@
 package org.example.shield.auth.exception;
 
-/**
- * 유효하지 않은 토큰 예외.
- * JWT 만료, 위조, 블랙리스트 토큰일 때 발생.
- */
-public class InvalidTokenException {
+import org.example.shield.common.exception.BusinessException;
+import org.example.shield.common.exception.ErrorCode;
+
+public class InvalidTokenException extends BusinessException {
+
+    public InvalidTokenException() {
+        super(ErrorCode.INVALID_TOKEN);
+    }
 }

--- a/src/main/java/org/example/shield/auth/exception/OAuthFailedException.java
+++ b/src/main/java/org/example/shield/auth/exception/OAuthFailedException.java
@@ -1,8 +1,11 @@
 package org.example.shield.auth.exception;
 
-/**
- * OAuth 인증 실패 예외.
- * Google OAuth 인증코드가 유효하지 않거나 Google API 장애 시 발생.
- */
-public class OAuthFailedException {
+import org.example.shield.common.exception.BusinessException;
+import org.example.shield.common.exception.ErrorCode;
+
+public class OAuthFailedException extends BusinessException {
+
+    public OAuthFailedException() {
+        super(ErrorCode.OAUTH_FAILED);
+    }
 }

--- a/src/main/java/org/example/shield/auth/infrastructure/GoogleOAuthClient.java
+++ b/src/main/java/org/example/shield/auth/infrastructure/GoogleOAuthClient.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.shield.auth.domain.OAuthClient;
 import org.example.shield.auth.domain.OAuthUserInfo;
 import org.example.shield.auth.exception.OAuthFailedException;
+import org.example.shield.common.exception.ErrorCode;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -50,14 +51,14 @@ public class GoogleOAuthClient implements OAuthClient {
                     .block();
 
             if (response == null || response.accessToken() == null) {
-                throw new OAuthFailedException();
+                throw new OAuthFailedException(ErrorCode.OAUTH_CODE_INVALID);
             }
             return response.accessToken();
         } catch (OAuthFailedException e) {
             throw e;
         } catch (Exception e) {
             log.error("Google OAuth token exchange failed", e);
-            throw new OAuthFailedException();
+            throw new OAuthFailedException(ErrorCode.OAUTH_CODE_INVALID);
         }
     }
 
@@ -71,14 +72,14 @@ public class GoogleOAuthClient implements OAuthClient {
                     .block();
 
             if (response == null || response.email() == null) {
-                throw new OAuthFailedException();
+                throw new OAuthFailedException(ErrorCode.OAUTH_USER_INFO_FAILED);
             }
             return new OAuthUserInfo(response.email(), response.name(), response.id());
         } catch (OAuthFailedException e) {
             throw e;
         } catch (Exception e) {
             log.error("Google OAuth user info fetch failed", e);
-            throw new OAuthFailedException();
+            throw new OAuthFailedException(ErrorCode.OAUTH_USER_INFO_FAILED);
         }
     }
 

--- a/src/main/java/org/example/shield/auth/infrastructure/GoogleOAuthClient.java
+++ b/src/main/java/org/example/shield/auth/infrastructure/GoogleOAuthClient.java
@@ -1,16 +1,96 @@
 package org.example.shield.auth.infrastructure;
 
-/**
- * Google OAuth HTTP 클라이언트.
- *
- * Layer: infrastructure
- * Called by: GoogleOAuthService
- * Calls: Google OAuth API (https://oauth2.googleapis.com/token, https://www.googleapis.com/oauth2/v2/userinfo)
- *
- * TODO:
- * - exchangeCodeForToken(authorizationCode): 인증코드 → Google Access Token 교환
- * - getUserInfo(googleAccessToken): Google Access Token → 사용자 정보(email, name) 조회
- * - application.yml의 google.client-id, client-secret 사용
- */
-public class GoogleOAuthClient {
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.extern.slf4j.Slf4j;
+import org.example.shield.auth.domain.OAuthClient;
+import org.example.shield.auth.domain.OAuthUserInfo;
+import org.example.shield.auth.exception.OAuthFailedException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+public class GoogleOAuthClient implements OAuthClient {
+
+    private final WebClient webClient;
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUri;
+
+    public GoogleOAuthClient(
+            @Value("${google.client-id}") String clientId,
+            @Value("${google.client-secret}") String clientSecret,
+            @Value("${google.redirect-uri}") String redirectUri) {
+        this.webClient = WebClient.create();
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUri = redirectUri;
+    }
+
+    @Override
+    public OAuthUserInfo getUserInfo(String authorizationCode) {
+        String accessToken = exchangeCodeForToken(authorizationCode);
+        return fetchUserInfo(accessToken);
+    }
+
+    private String exchangeCodeForToken(String authorizationCode) {
+        try {
+            GoogleTokenResponse response = webClient.post()
+                    .uri("https://oauth2.googleapis.com/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .bodyValue("code=" + authorizationCode
+                            + "&client_id=" + clientId
+                            + "&client_secret=" + clientSecret
+                            + "&redirect_uri=" + redirectUri
+                            + "&grant_type=authorization_code")
+                    .retrieve()
+                    .bodyToMono(GoogleTokenResponse.class)
+                    .block();
+
+            if (response == null || response.accessToken() == null) {
+                throw new OAuthFailedException();
+            }
+            return response.accessToken();
+        } catch (OAuthFailedException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Google OAuth token exchange failed", e);
+            throw new OAuthFailedException();
+        }
+    }
+
+    private OAuthUserInfo fetchUserInfo(String accessToken) {
+        try {
+            GoogleUserResponse response = webClient.get()
+                    .uri("https://www.googleapis.com/oauth2/v2/userinfo")
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .bodyToMono(GoogleUserResponse.class)
+                    .block();
+
+            if (response == null || response.email() == null) {
+                throw new OAuthFailedException();
+            }
+            return new OAuthUserInfo(response.email(), response.name(), response.id());
+        } catch (OAuthFailedException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Google OAuth user info fetch failed", e);
+            throw new OAuthFailedException();
+        }
+    }
+
+    private record GoogleTokenResponse(
+            @JsonProperty("access_token") String accessToken,
+            @JsonProperty("token_type") String tokenType
+    ) {}
+
+    private record GoogleUserResponse(
+            String id,
+            String email,
+            String name,
+            String picture
+    ) {}
 }

--- a/src/main/java/org/example/shield/auth/infrastructure/JwtAuthFilter.java
+++ b/src/main/java/org/example/shield/auth/infrastructure/JwtAuthFilter.java
@@ -56,6 +56,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
+        if (path.equals("/api/auth/logout")) {
+            return false;
+        }
         return path.startsWith("/api/auth/")
                 || path.startsWith("/swagger-ui/")
                 || path.startsWith("/api-docs")

--- a/src/main/java/org/example/shield/auth/infrastructure/JwtAuthFilter.java
+++ b/src/main/java/org/example/shield/auth/infrastructure/JwtAuthFilter.java
@@ -1,19 +1,64 @@
 package org.example.shield.auth.infrastructure;
 
-/**
- * JWT 인증 필터 - 모든 요청에서 JWT를 검증하는 Spring Security 필터.
- *
- * Layer: infrastructure
- * Called by: Spring Security 필터 체인 (SecurityConfig에서 등록)
- * Calls: JwtService
- *
- * TODO:
- * - doFilterInternal(request, response, filterChain):
- *   1. Authorization Header에서 "Bearer {token}" 추출
- *   2. JwtService.validateToken(token)으로 검증
- *   3. 유효하면 SecurityContext에 인증 정보 설정
- *   4. 유효하지 않으면 401 반환
- *   5. /api/auth/**, /swagger-ui/** 경로는 필터 건너뛰기
- */
-public class JwtAuthFilter {
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.example.shield.auth.application.JwtService;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = extractToken(request);
+
+        if (token != null && jwtService.validateToken(token)) {
+            UUID userId = jwtService.getUserIdFromToken(token);
+            String role = jwtService.getRoleFromToken(token);
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userId,
+                            null,
+                            List.of(new SimpleGrantedAuthority("ROLE_" + role))
+                    );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (StringUtils.hasText(header) && header.startsWith("Bearer ")) {
+            return header.substring(7);
+        }
+        return null;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path.startsWith("/api/auth/")
+                || path.startsWith("/swagger-ui/")
+                || path.startsWith("/api-docs")
+                || path.startsWith("/v3/api-docs");
+    }
 }

--- a/src/main/java/org/example/shield/auth/infrastructure/JwtTokenProvider.java
+++ b/src/main/java/org/example/shield/auth/infrastructure/JwtTokenProvider.java
@@ -1,16 +1,66 @@
 package org.example.shield.auth.infrastructure;
 
-/**
- * JWT 토큰 생성/파싱 유틸.
- *
- * Layer: infrastructure
- * Called by: JwtService
- *
- * TODO:
- * - generateToken(userId, role, expiry): JWT 문자열 생성
- * - parseClaims(token): JWT에서 Claims 추출
- * - isExpired(token): 만료 여부 확인
- * - application.yml의 jwt.secret, jwt.access-token-expiry 사용
- */
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
 public class JwtTokenProvider {
+
+    private final SecretKey secretKey;
+    private final long accessTokenExpiry;
+    private final long refreshTokenExpiry;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-expiry}") long accessTokenExpiry,
+            @Value("${jwt.refresh-token-expiry}") long refreshTokenExpiry) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpiry = accessTokenExpiry;
+        this.refreshTokenExpiry = refreshTokenExpiry;
+    }
+
+    public String generateAccessToken(UUID userId, String role) {
+        return generateToken(userId, role, accessTokenExpiry);
+    }
+
+    public String generateRefreshToken(UUID userId, String role) {
+        return generateToken(userId, role, refreshTokenExpiry);
+    }
+
+    private String generateToken(UUID userId, String role, long expiry) {
+        Date now = new Date();
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("role", role)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + expiry))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    public boolean isValid(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/org/example/shield/common/config/CorsConfig.java
+++ b/src/main/java/org/example/shield/common/config/CorsConfig.java
@@ -1,13 +1,26 @@
 package org.example.shield.common.config;
 
-/**
- * CORS 설정 - 프론트엔드(localhost:3000)에서의 요청 허용.
- *
- * TODO:
- * - allowedOrigins: http://localhost:3000
- * - allowedMethods: GET, POST, PATCH, DELETE
- * - allowedHeaders: *
- * - allowCredentials: true (쿠키 전송용)
- */
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
 public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:3000"));
+        config.setAllowedMethods(List.of("GET", "POST", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
 }

--- a/src/main/java/org/example/shield/common/config/SecurityConfig.java
+++ b/src/main/java/org/example/shield/common/config/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/logout").authenticated()
                         .requestMatchers(
                                 "/api/auth/**",
                                 "/swagger-ui/**",

--- a/src/main/java/org/example/shield/common/config/SecurityConfig.java
+++ b/src/main/java/org/example/shield/common/config/SecurityConfig.java
@@ -1,14 +1,43 @@
 package org.example.shield.common.config;
 
-/**
- * Spring Security 설정.
- *
- * TODO: @Configuration + @EnableWebSecurity + @EnableMethodSecurity
- * - CORS 설정 (localhost:3000 허용)
- * - CSRF 비활성화 (JWT 사용이므로)
- * - Stateless 세션
- * - 공개 경로: /api/auth/**, /swagger-ui/**, /api-docs/**, /v3/api-docs/**
- * - JwtAuthFilter를 UsernamePasswordAuthenticationFilter 전에 등록
- */
+import lombok.RequiredArgsConstructor;
+import org.example.shield.auth.infrastructure.JwtAuthFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
+    private final CorsConfig corsConfig;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(cors -> cors.configurationSource(corsConfig.corsConfigurationSource()))
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/auth/**",
+                                "/swagger-ui/**",
+                                "/api-docs/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
 }

--- a/src/main/java/org/example/shield/common/config/SwaggerConfig.java
+++ b/src/main/java/org/example/shield/common/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package org.example.shield.common.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,10 +13,20 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+        String securitySchemeName = "bearerAuth";
+
         return new OpenAPI()
                 .info(new Info()
                         .title("SHIELD API")
                         .version("1.0.0")
-                        .description("부동산 법률 상담 플랫폼 SHIELD API"));
+                        .description("AI 기반 법률 상담 + 변호사 매칭 플랫폼"))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName,
+                                new SecurityScheme()
+                                        .name(securitySchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
     }
 }

--- a/src/main/java/org/example/shield/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/shield/common/exception/ErrorCode.java
@@ -14,6 +14,10 @@ public enum ErrorCode {
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다"),
 
+    // Auth
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
+    OAUTH_FAILED(HttpStatus.UNAUTHORIZED, "OAuth 인증에 실패했습니다"),
+
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
 

--- a/src/main/java/org/example/shield/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/shield/common/exception/ErrorCode.java
@@ -14,9 +14,17 @@ public enum ErrorCode {
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다"),
 
-    // Auth
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
-    OAUTH_FAILED(HttpStatus.UNAUTHORIZED, "OAuth 인증에 실패했습니다"),
+    // Auth - Token
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다"),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 일치하지 않습니다"),
+
+    // Auth - OAuth
+    OAUTH_CODE_INVALID(HttpStatus.UNAUTHORIZED, "OAuth 인증 코드가 유효하지 않습니다"),
+    OAUTH_USER_INFO_FAILED(HttpStatus.UNAUTHORIZED, "OAuth 사용자 정보 조회에 실패했습니다"),
+
+    // Auth - Role
+    INVALID_ROLE(HttpStatus.BAD_REQUEST, "유효하지 않은 역할입니다 (USER, LAWYER, ADMIN)"),
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),

--- a/src/main/java/org/example/shield/user/application/UserService.java
+++ b/src/main/java/org/example/shield/user/application/UserService.java
@@ -2,7 +2,6 @@ package org.example.shield.user.application;
 
 import lombok.RequiredArgsConstructor;
 import org.example.shield.user.controller.dto.UserResponse;
-import org.example.shield.user.controller.dto.UserUpdateRequest;
 import org.example.shield.user.domain.User;
 import org.example.shield.user.domain.UserReader;
 import org.springframework.stereotype.Service;
@@ -19,13 +18,6 @@ public class UserService {
 
     public UserResponse getMyInfo(UUID userId) {
         User user = userReader.findById(userId);
-        return UserResponse.from(user);
-    }
-
-    @Transactional
-    public UserResponse updateMyInfo(UUID userId, UserUpdateRequest request) {
-        User user = userReader.findById(userId);
-        user.updateName(request.name());
         return UserResponse.from(user);
     }
 }

--- a/src/main/java/org/example/shield/user/application/UserService.java
+++ b/src/main/java/org/example/shield/user/application/UserService.java
@@ -1,15 +1,31 @@
 package org.example.shield.user.application;
 
-/**
- * 사용자 서비스 - 사용자 정보 조회/수정.
- *
- * Layer: application
- * Called by: UserController
- * Calls: UserRepository
- *
- * TODO:
- * - getMyInfo(userId): JWT에서 추출한 userId로 사용자 정보 조회 → UserResponse 반환
- * - updateMyInfo(userId, request): 이름 등 기본 정보 수정 (차후 구현)
- */
+import lombok.RequiredArgsConstructor;
+import org.example.shield.user.controller.dto.UserResponse;
+import org.example.shield.user.controller.dto.UserUpdateRequest;
+import org.example.shield.user.domain.User;
+import org.example.shield.user.domain.UserReader;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserService {
+
+    private final UserReader userReader;
+
+    public UserResponse getMyInfo(UUID userId) {
+        User user = userReader.findById(userId);
+        return UserResponse.from(user);
+    }
+
+    @Transactional
+    public UserResponse updateMyInfo(UUID userId, UserUpdateRequest request) {
+        User user = userReader.findById(userId);
+        user.updateName(request.name());
+        return UserResponse.from(user);
+    }
 }

--- a/src/main/java/org/example/shield/user/controller/UserController.java
+++ b/src/main/java/org/example/shield/user/controller/UserController.java
@@ -2,17 +2,13 @@ package org.example.shield.user.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.shield.common.response.ApiResponse;
 import org.example.shield.user.application.UserService;
 import org.example.shield.user.controller.dto.UserResponse;
-import org.example.shield.user.controller.dto.UserUpdateRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,14 +28,5 @@ public class UserController {
             @AuthenticationPrincipal UUID userId) {
         UserResponse response = userService.getMyInfo(userId);
         return ResponseEntity.ok(ApiResponse.success("사용자 정보 조회 성공", response));
-    }
-
-    @Operation(summary = "내 정보 수정", description = "현재 로그인한 사용자 이름 수정")
-    @PatchMapping("/me")
-    public ResponseEntity<ApiResponse<UserResponse>> updateMyInfo(
-            @AuthenticationPrincipal UUID userId,
-            @Valid @RequestBody UserUpdateRequest request) {
-        UserResponse response = userService.updateMyInfo(userId, request);
-        return ResponseEntity.ok(ApiResponse.success("사용자 정보 수정 성공", response));
     }
 }

--- a/src/main/java/org/example/shield/user/controller/UserController.java
+++ b/src/main/java/org/example/shield/user/controller/UserController.java
@@ -1,15 +1,40 @@
 package org.example.shield.user.controller;
 
-/**
- * 사용자 API 컨트롤러.
- *
- * Layer: controller
- * Called by: 프론트엔드
- * Calls: UserService
- *
- * API 목록:
- * - GET   /api/users/me    내 정보 조회
- * - PATCH /api/users/me    내 정보 수정
- */
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.shield.common.response.ApiResponse;
+import org.example.shield.user.application.UserService;
+import org.example.shield.user.controller.dto.UserResponse;
+import org.example.shield.user.controller.dto.UserUpdateRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
 public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserResponse>> getMyInfo(
+            @AuthenticationPrincipal UUID userId) {
+        UserResponse response = userService.getMyInfo(userId);
+        return ResponseEntity.ok(ApiResponse.success("사용자 정보 조회 성공", response));
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<UserResponse>> updateMyInfo(
+            @AuthenticationPrincipal UUID userId,
+            @Valid @RequestBody UserUpdateRequest request) {
+        UserResponse response = userService.updateMyInfo(userId, request);
+        return ResponseEntity.ok(ApiResponse.success("사용자 정보 수정 성공", response));
+    }
 }

--- a/src/main/java/org/example/shield/user/controller/UserController.java
+++ b/src/main/java/org/example/shield/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package org.example.shield.user.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.shield.common.response.ApiResponse;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
+@Tag(name = "User", description = "사용자 API")
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
@@ -23,6 +26,7 @@ public class UserController {
 
     private final UserService userService;
 
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자 정보 조회")
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<UserResponse>> getMyInfo(
             @AuthenticationPrincipal UUID userId) {
@@ -30,6 +34,7 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success("사용자 정보 조회 성공", response));
     }
 
+    @Operation(summary = "내 정보 수정", description = "현재 로그인한 사용자 이름 수정")
     @PatchMapping("/me")
     public ResponseEntity<ApiResponse<UserResponse>> updateMyInfo(
             @AuthenticationPrincipal UUID userId,

--- a/src/main/java/org/example/shield/user/controller/dto/UserResponse.java
+++ b/src/main/java/org/example/shield/user/controller/dto/UserResponse.java
@@ -1,15 +1,25 @@
 package org.example.shield.user.controller.dto;
 
-/**
- * 사용자 정보 응답 DTO.
- *
- * TODO: record로 구현
- * - userId: UUID
- * - email: String
- * - name: String
- * - role: String (USER / LAWYER / ADMIN)
- * - provider: String (GOOGLE)
- * - profileImageUrl: String (nullable)
- */
-public class UserResponse {
+import org.example.shield.user.domain.User;
+
+import java.util.UUID;
+
+public record UserResponse(
+        UUID userId,
+        String email,
+        String name,
+        String role,
+        String provider,
+        String profileImageUrl
+) {
+    public static UserResponse from(User user) {
+        return new UserResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getRole().name(),
+                user.getProvider(),
+                user.getProfileImageUrl()
+        );
+    }
 }

--- a/src/main/java/org/example/shield/user/controller/dto/UserUpdateRequest.java
+++ b/src/main/java/org/example/shield/user/controller/dto/UserUpdateRequest.java
@@ -1,8 +1,0 @@
-package org.example.shield.user.controller.dto;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record UserUpdateRequest(
-        @NotBlank(message = "이름은 필수입니다")
-        String name
-) {}

--- a/src/main/java/org/example/shield/user/controller/dto/UserUpdateRequest.java
+++ b/src/main/java/org/example/shield/user/controller/dto/UserUpdateRequest.java
@@ -1,10 +1,8 @@
 package org.example.shield.user.controller.dto;
 
-/**
- * 사용자 정보 수정 요청 DTO.
- *
- * TODO:
- * - name: String (변경할 이름)
- */
-public class UserUpdateRequest {
-}
+import jakarta.validation.constraints.NotBlank;
+
+public record UserUpdateRequest(
+        @NotBlank(message = "이름은 필수입니다")
+        String name
+) {}

--- a/src/main/java/org/example/shield/user/domain/User.java
+++ b/src/main/java/org/example/shield/user/domain/User.java
@@ -4,19 +4,27 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.example.shield.common.domain.BaseEntity;
 import org.example.shield.common.enums.UserRole;
+
+import java.util.UUID;
 
 @Entity
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User extends BaseEntity {
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
 
     @Column(nullable = false, unique = true)
     private String email;

--- a/src/main/java/org/example/shield/user/domain/User.java
+++ b/src/main/java/org/example/shield/user/domain/User.java
@@ -1,17 +1,59 @@
 package org.example.shield.user.domain;
 
-/**
- * 사용자 엔티티 - users 테이블 매핑.
- *
- * TODO: @Entity 구현 (BaseEntity 상속 안 함)
- * - id: UUID (PK)
- * - email: String (UNIQUE, NOT NULL)
- * - name: String (NOT NULL)
- * - role: UserRole (USER / LAWYER / ADMIN)
- * - provider: String (GOOGLE)
- * - googleId: String (NOT NULL)
- * - refreshToken: String (nullable)
- * - profileImageUrl: String (nullable)
- */
-public class User {
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.shield.common.domain.BaseEntity;
+import org.example.shield.common.enums.UserRole;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
+
+    @Column(nullable = false)
+    private String provider;
+
+    @Column(nullable = false, unique = true)
+    private String googleId;
+
+    private String refreshToken;
+
+    private String profileImageUrl;
+
+    @Builder
+    public User(String email, String name, UserRole role, String provider,
+                String googleId, String profileImageUrl) {
+        this.email = email;
+        this.name = name;
+        this.role = role;
+        this.provider = provider;
+        this.googleId = googleId;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/org/example/shield/user/domain/User.java
+++ b/src/main/java/org/example/shield/user/domain/User.java
@@ -61,7 +61,4 @@ public class User {
         this.refreshToken = refreshToken;
     }
 
-    public void updateName(String name) {
-        this.name = name;
-    }
 }

--- a/src/main/java/org/example/shield/user/domain/UserReader.java
+++ b/src/main/java/org/example/shield/user/domain/UserReader.java
@@ -1,12 +1,13 @@
 package org.example.shield.user.domain;
 
-/**
- * User 조회 인터페이스.
- *
- * TODO:
- * - findById(UUID id): User
- * - findOptionalByEmail(String email): Optional<User>
- * - existsByEmail(String email): boolean
- */
+import java.util.Optional;
+import java.util.UUID;
+
 public interface UserReader {
+
+    User findById(UUID id);
+
+    Optional<User> findByGoogleId(String googleId);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/org/example/shield/user/domain/UserWriter.java
+++ b/src/main/java/org/example/shield/user/domain/UserWriter.java
@@ -1,11 +1,6 @@
 package org.example.shield.user.domain;
 
-/**
- * User 저장/삭제 인터페이스.
- *
- * TODO:
- * - save(User user): User
- * - delete(User user): void
- */
 public interface UserWriter {
+
+    User save(User user);
 }

--- a/src/main/java/org/example/shield/user/exception/UserNotFoundException.java
+++ b/src/main/java/org/example/shield/user/exception/UserNotFoundException.java
@@ -1,8 +1,11 @@
 package org.example.shield.user.exception;
 
-/**
- * 사용자 없음 예외.
- * userId로 조회했는데 없을 때 발생.
- */
-public class UserNotFoundException {
+import org.example.shield.common.exception.BusinessException;
+import org.example.shield.common.exception.ErrorCode;
+
+public class UserNotFoundException extends BusinessException {
+
+    public UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND);
+    }
 }

--- a/src/main/java/org/example/shield/user/infrastructure/UserReaderImpl.java
+++ b/src/main/java/org/example/shield/user/infrastructure/UserReaderImpl.java
@@ -1,11 +1,33 @@
 package org.example.shield.user.infrastructure;
 
-/**
- * UserReader 구현체.
- *
- * TODO: @Repository + implements UserReader
- * - UserRepository 주입
- * - findById: 없으면 UserNotFoundException
- */
-public class UserReaderImpl {
+import lombok.RequiredArgsConstructor;
+import org.example.shield.user.domain.User;
+import org.example.shield.user.domain.UserReader;
+import org.example.shield.user.exception.UserNotFoundException;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class UserReaderImpl implements UserReader {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public User findById(UUID id) {
+        return userRepository.findById(id)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    @Override
+    public Optional<User> findByGoogleId(String googleId) {
+        return userRepository.findByGoogleId(googleId);
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return userRepository.findByEmail(email);
+    }
 }

--- a/src/main/java/org/example/shield/user/infrastructure/UserRepository.java
+++ b/src/main/java/org/example/shield/user/infrastructure/UserRepository.java
@@ -1,11 +1,14 @@
 package org.example.shield.user.infrastructure;
 
-/**
- * 사용자 JPA Repository.
- *
- * TODO: extends JpaRepository<User, UUID>
- * - findByEmail(String email): Optional<User>
- * - findByGoogleId(String googleId): Optional<User>
- */
-public interface UserRepository {
+import org.example.shield.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+
+    Optional<User> findByGoogleId(String googleId);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/org/example/shield/user/infrastructure/UserWriterImpl.java
+++ b/src/main/java/org/example/shield/user/infrastructure/UserWriterImpl.java
@@ -1,10 +1,18 @@
 package org.example.shield.user.infrastructure;
 
-/**
- * UserWriter 구현체.
- *
- * TODO: @Repository + implements UserWriter
- * - UserRepository 주입
- */
-public class UserWriterImpl {
+import lombok.RequiredArgsConstructor;
+import org.example.shield.user.domain.User;
+import org.example.shield.user.domain.UserWriter;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserWriterImpl implements UserWriter {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public User save(User user) {
+        return userRepository.save(user);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,18 @@ spring:
       hibernate:
         format_sql: true
 
+# JWT
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiry: 1800000
+  refresh-token-expiry: 1209600000
+
+# Google OAuth
+google:
+  client-id: ${GOOGLE_CLIENT_ID}
+  client-secret: ${GOOGLE_CLIENT_SECRET}
+  redirect-uri: ${GOOGLE_REDIRECT_URI}
+
 # Swagger
 springdoc:
   swagger-ui:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,12 @@ spring:
   application:
     name: shield
 
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+
   # PostgreSQL
   datasource:
     url: ${DB_URL}?prepareThreshold=0&stringtype=unspecified


### PR DESCRIPTION
## 개요
인증(Auth) 도메인 + 사용자(User) 도메인 API 구현 (Google OAuth + JWT)

## 변경 사항

### API
- `POST /api/auth/google` - Google OAuth 로그인 (인증 코드 → JWT 발급)
- `POST /api/auth/dev/login` - 개발용 로그인 (Google 키 없이 테스트용 JWT 발급)
- `POST /api/auth/logout` - 로그아웃 (Refresh Token 무효화)
- `POST /api/auth/token/refresh` - Refresh Token → 새 Access Token 발급
- `GET /api/users/me` - 현재 로그인 사용자 정보 조회

### 구조
- User Entity + UserRepository + Reader/Writer 패턴
- AuthService → GoogleOAuthService → GoogleOAuthClient (Google OAuth 흐름)
- JwtService → JwtTokenProvider (JWT 생성/검증)
- JwtAuthFilter (OncePerRequestFilter, Bearer 토큰 검증 → SecurityContext 설정)
- 모든 Request/Response를 전용 record DTO로 분리
- LoginResponse에 refreshToken 포함 (Swagger 테스트 편의용, HttpOnly 쿠키도 유지)

### Security / Config
- SecurityConfig: CSRF 비활성화, Stateless 세션, JWT 필터 등록
- CorsConfig: localhost:3000 허용
- SwaggerConfig: JWT Bearer 인증 스킴 추가
- `/api/auth/logout`은 인증 필요 경로로 분리 (JWT 필터 적용)

### 에러코드 세분화
- `TOKEN_EXPIRED` / `TOKEN_INVALID` / `REFRESH_TOKEN_MISMATCH`
- `OAUTH_CODE_INVALID` / `OAUTH_USER_INFO_FAILED`
- `INVALID_ROLE`

### DB / 설정
- User Entity는 BaseEntity 상속 제거 (DB에 created_at, updated_at 없음)
- application.yml에 JWT, Google OAuth 환경변수 설정 추가
- DB URL 파라미터 구분자 수정
- UTF-8 인코딩 강제 설정 추가
- `.vscode/launch.json`에서 `env` 파일 자동 로드

### 의존성 추가
- `spring-boot-starter-security`
- `jjwt-api` / `jjwt-impl` / `jjwt-jackson` (0.12.6)
- `spring-boot-starter-webflux` (Google API 호출용)

## 참고
- Google OAuth는 코드 구현 완료, 키 발급 후 실제 테스트 예정
- 개발용 로그인 API(`/api/auth/dev/login`)로 Swagger 테스트 가능
- role은 대소문자 무관하게 처리 (`user` → `USER`)
- 내 정보 수정 API (`PATCH /api/users/me`)는 불필요하여 제거

## 테스트
- ✅ Swagger UI 전체 API 동작 확인
- ✅ 개발용 로그인 → 토큰 발급 → 사용자 조회 흐름 검증
- ✅ 로그아웃 후 Refresh Token 무효화 검증
- ✅ 토큰 갱신 API 검증
- ✅ 잘못된 role / 토큰 없음 / 만료 토큰 등 에러 케이스 검증 (15개 테스트 통과)