### PR TITLE
[FEAT] 의뢰서 API + JWT 인증 연동 구현 (#10)

### DIFF
--- a/src/main/java/org/example/shield/brief/application/BriefService.java
+++ b/src/main/java/org/example/shield/brief/application/BriefService.java
@@ -10,6 +10,8 @@ import org.example.shield.brief.domain.BriefReader;
 import org.example.shield.brief.domain.BriefWriter;
 import org.example.shield.brief.exception.BriefAlreadyConfirmedException;
 import org.example.shield.common.enums.PrivacySetting;
+import org.example.shield.common.exception.BusinessException;
+import org.example.shield.common.exception.ErrorCode;
 import org.example.shield.common.response.PageResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -47,28 +49,31 @@ public class BriefService {
             throw new BriefAlreadyConfirmedException();
         }
 
+        // 내용 수정
+        brief.updateContent(
+                request.title() != null ? request.title() : brief.getTitle(),
+                request.content() != null ? request.content() : brief.getContent(),
+                request.keywords() != null ? request.keywords() : brief.getKeywords(),
+                request.keyIssues() != null ? request.keyIssues() : brief.getKeyIssues(),
+                brief.getStrategy()
+        );
+
+        // 개인정보 설정 변경
+        if (request.privacySetting() != null) {
+            try {
+                brief.updatePrivacySetting(PrivacySetting.valueOf(request.privacySetting()));
+            } catch (IllegalArgumentException e) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE) {};
+            }
+        }
+
         // 상태 변경
         if (request.status() != null) {
             switch (request.status()) {
                 case "CONFIRMED" -> brief.confirm();
                 case "DISCARDED" -> brief.discard();
+                default -> throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE) {};
             }
-        }
-
-        // 개인정보 설정 변경
-        if (request.privacySetting() != null) {
-            brief.updatePrivacySetting(PrivacySetting.valueOf(request.privacySetting()));
-        }
-
-        // 내용 수정 (상태 변경이 아닌 경우)
-        if (request.status() == null) {
-            brief.updateContent(
-                    request.title() != null ? request.title() : brief.getTitle(),
-                    request.content() != null ? request.content() : brief.getContent(),
-                    request.keywords() != null ? request.keywords() : brief.getKeywords(),
-                    request.keyIssues() != null ? request.keyIssues() : brief.getKeyIssues(),
-                    brief.getStrategy()
-            );
         }
 
         Brief saved = briefWriter.save(brief);

--- a/src/main/java/org/example/shield/brief/application/BriefService.java
+++ b/src/main/java/org/example/shield/brief/application/BriefService.java
@@ -1,21 +1,88 @@
 package org.example.shield.brief.application;
 
-/**
- * 의뢰서 서비스 - 의뢰서 CRUD + 상태 변경.
- *
- * Layer: application
- * Called by: BriefController
- * Calls: BriefRepository
- *
- * TODO:
- * - getMyBriefs(userId, pageable): 의뢰인의 의뢰서 목록
- * - getBrief(briefId): 의뢰서 상세 (content 줄글 + keywords + status)
- * - updateBrief(briefId, request):
- *   - status가 CONFIRMED이면 수정 차단 (BriefAlreadyConfirmedException)
- *   - body에 status: "CONFIRMED" → 필수항목 검증 후 확정
- *   - body에 status: "DISCARDED" → 폐기
- *   - body에 content → 줄글 수정
- *   - body에 privacySetting → 개인정보 설정 변경
- */
+import lombok.RequiredArgsConstructor;
+import org.example.shield.brief.controller.dto.BriefResponse;
+import org.example.shield.brief.controller.dto.BriefSummaryResponse;
+import org.example.shield.brief.controller.dto.BriefUpdateRequest;
+import org.example.shield.brief.controller.dto.BriefUpdateResponse;
+import org.example.shield.brief.domain.Brief;
+import org.example.shield.brief.domain.BriefReader;
+import org.example.shield.brief.domain.BriefWriter;
+import org.example.shield.brief.exception.BriefAlreadyConfirmedException;
+import org.example.shield.common.enums.PrivacySetting;
+import org.example.shield.common.response.PageResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class BriefService {
+
+    private final BriefReader briefReader;
+    private final BriefWriter briefWriter;
+
+    public PageResponse<BriefSummaryResponse> getMyBriefs(UUID userId, Pageable pageable) {
+        Page<Brief> briefs = briefReader.findAllByUserId(userId, pageable);
+        Page<BriefSummaryResponse> responsePage = briefs.map(BriefSummaryResponse::from);
+        return PageResponse.from(responsePage);
+    }
+
+    public BriefResponse getBrief(UUID briefId, UUID userId) {
+        Brief brief = briefReader.findById(briefId);
+        validateOwner(brief, userId);
+        return BriefResponse.from(brief);
+    }
+
+    @Transactional
+    public BriefUpdateResponse updateBrief(UUID briefId, UUID userId, BriefUpdateRequest request) {
+        Brief brief = briefReader.findById(briefId);
+        validateOwner(brief, userId);
+
+        if (!brief.isEditable()) {
+            throw new BriefAlreadyConfirmedException();
+        }
+
+        // 상태 변경
+        if (request.status() != null) {
+            switch (request.status()) {
+                case "CONFIRMED" -> brief.confirm();
+                case "DISCARDED" -> brief.discard();
+            }
+        }
+
+        // 개인정보 설정 변경
+        if (request.privacySetting() != null) {
+            brief.updatePrivacySetting(PrivacySetting.valueOf(request.privacySetting()));
+        }
+
+        // 내용 수정 (상태 변경이 아닌 경우)
+        if (request.status() == null) {
+            brief.updateContent(
+                    request.title() != null ? request.title() : brief.getTitle(),
+                    request.content() != null ? request.content() : brief.getContent(),
+                    request.keywords() != null ? request.keywords() : brief.getKeywords(),
+                    request.keyIssues() != null ? request.keyIssues() : brief.getKeyIssues(),
+                    brief.getStrategy()
+            );
+        }
+
+        Brief saved = briefWriter.save(brief);
+
+        return new BriefUpdateResponse(
+                saved.getId(),
+                saved.getStatus().name(),
+                saved.getUpdatedAt()
+        );
+    }
+
+    private void validateOwner(Brief brief, UUID userId) {
+        if (!brief.getUserId().equals(userId)) {
+            throw new org.example.shield.brief.exception.BriefNotFoundException(brief.getId());
+        }
+    }
 }

--- a/src/main/java/org/example/shield/brief/application/DeliveryService.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryService.java
@@ -114,8 +114,10 @@ public class DeliveryService {
         Brief brief = briefReader.findById(delivery.getBriefId());
         User client = userReader.findById(brief.getUserId());
 
-        // privacySetting에 따라 의뢰인 정보 마스킹
-        String clientName = maskName(client.getName());
+        // TODO: 전체공개/부분공개 설정에 따른 마스킹 정책 세분화 (API 명세 확정 후 구현)
+        // 현재: PUBLIC = 이름+이메일 노출, PARTIAL = 이름 마스킹 + 이메일 미노출
+        String clientName = brief.getPrivacySetting() == PrivacySetting.PUBLIC
+                ? client.getName() : maskName(client.getName());
         String clientEmail = brief.getPrivacySetting() == PrivacySetting.PUBLIC
                 ? client.getEmail() : null;
 

--- a/src/main/java/org/example/shield/brief/application/DeliveryService.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryService.java
@@ -3,21 +3,30 @@ package org.example.shield.brief.application;
 import lombok.RequiredArgsConstructor;
 import org.example.shield.brief.controller.dto.DeliveryListResponse;
 import org.example.shield.brief.controller.dto.DeliveryResponse;
+import org.example.shield.brief.controller.dto.InboxDetailResponse;
+import org.example.shield.brief.controller.dto.InboxResponse;
 import org.example.shield.brief.domain.Brief;
 import org.example.shield.brief.domain.BriefDelivery;
 import org.example.shield.brief.domain.BriefReader;
 import org.example.shield.brief.exception.BriefNotFoundException;
 import org.example.shield.brief.infrastructure.BriefDeliveryRepository;
 import org.example.shield.common.enums.BriefStatus;
+import org.example.shield.common.enums.PrivacySetting;
 import org.example.shield.common.exception.BusinessException;
 import org.example.shield.common.exception.ErrorCode;
+import org.example.shield.common.response.PageResponse;
 import org.example.shield.user.domain.User;
 import org.example.shield.user.domain.UserReader;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -37,7 +46,6 @@ public class DeliveryService {
             throw new BusinessException(ErrorCode.BRIEF_NOT_CONFIRMED) {};
         }
 
-        // 중복 전달 방지
         boolean alreadySent = deliveryRepository.findAllByBriefId(briefId).stream()
                 .anyMatch(d -> d.getLawyerId().equals(lawyerId));
         if (alreadySent) {
@@ -47,7 +55,6 @@ public class DeliveryService {
         BriefDelivery delivery = BriefDelivery.create(briefId, lawyerId);
         BriefDelivery saved = deliveryRepository.save(delivery);
 
-        // 의뢰서 상태를 DELIVERED로 변경
         brief.markDelivered();
 
         User lawyer = userReader.findById(lawyerId);
@@ -60,14 +67,64 @@ public class DeliveryService {
 
         List<BriefDelivery> deliveries = deliveryRepository.findAllByBriefId(briefId);
 
+        // N+1 방지: 변호사 ID를 모아서 한 번에 조회
+        List<UUID> lawyerIds = deliveries.stream().map(BriefDelivery::getLawyerId).toList();
+        Map<UUID, User> lawyerMap = userReader.findAllByIds(lawyerIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
         List<DeliveryResponse> responses = deliveries.stream()
                 .map(d -> {
-                    User lawyer = userReader.findById(d.getLawyerId());
-                    return DeliveryResponse.of(d, lawyer.getName());
+                    User lawyer = lawyerMap.get(d.getLawyerId());
+                    return DeliveryResponse.of(d, lawyer != null ? lawyer.getName() : "알 수 없음");
                 })
                 .toList();
 
         return new DeliveryListResponse(responses);
+    }
+
+    public PageResponse<InboxResponse> getInbox(UUID lawyerId, Pageable pageable) {
+        Page<BriefDelivery> deliveries = deliveryRepository.findAllByLawyerId(lawyerId, pageable);
+
+        // N+1 방지: Brief ID를 모아서 한 번에 조회
+        List<UUID> briefIds = deliveries.getContent().stream()
+                .map(BriefDelivery::getBriefId).toList();
+        Map<UUID, Brief> briefMap = briefIds.stream()
+                .collect(Collectors.toMap(id -> id, briefReader::findById));
+
+        Page<InboxResponse> responsePage = deliveries.map(d -> {
+            Brief brief = briefMap.get(d.getBriefId());
+            return InboxResponse.of(d, brief);
+        });
+
+        return PageResponse.from(responsePage);
+    }
+
+    @Transactional
+    public InboxDetailResponse getInboxDetail(UUID deliveryId, UUID lawyerId) {
+        BriefDelivery delivery = deliveryRepository.findById(deliveryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DELIVERY_NOT_FOUND) {});
+
+        if (!delivery.getLawyerId().equals(lawyerId)) {
+            throw new BusinessException(ErrorCode.DELIVERY_NOT_FOUND) {};
+        }
+
+        // 열람 시 viewedAt 기록
+        delivery.markViewed();
+
+        Brief brief = briefReader.findById(delivery.getBriefId());
+        User client = userReader.findById(brief.getUserId());
+
+        // privacySetting에 따라 의뢰인 정보 마스킹
+        String clientName = maskName(client.getName());
+        String clientEmail = brief.getPrivacySetting() == PrivacySetting.PUBLIC
+                ? client.getEmail() : null;
+
+        return InboxDetailResponse.of(delivery, brief, clientName, clientEmail);
+    }
+
+    private String maskName(String name) {
+        if (name == null || name.length() <= 1) return name;
+        return name.charAt(0) + "*".repeat(name.length() - 1);
     }
 
     private void validateOwner(Brief brief, UUID userId) {

--- a/src/main/java/org/example/shield/brief/application/DeliveryService.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryService.java
@@ -11,6 +11,7 @@ import org.example.shield.brief.domain.BriefReader;
 import org.example.shield.brief.exception.BriefNotFoundException;
 import org.example.shield.brief.infrastructure.BriefDeliveryRepository;
 import org.example.shield.common.enums.BriefStatus;
+import org.example.shield.common.enums.UserRole;
 import org.example.shield.common.enums.PrivacySetting;
 import org.example.shield.common.exception.BusinessException;
 import org.example.shield.common.exception.ErrorCode;
@@ -46,6 +47,11 @@ public class DeliveryService {
             throw new BusinessException(ErrorCode.BRIEF_NOT_CONFIRMED) {};
         }
 
+        User lawyer = userReader.findById(lawyerId);
+        if (lawyer.getRole() != UserRole.LAWYER) {
+            throw new BusinessException(ErrorCode.INVALID_ROLE) {};
+        }
+
         if (deliveryRepository.existsByBriefIdAndLawyerId(briefId, lawyerId)) {
             throw new BusinessException(ErrorCode.DELIVERY_ALREADY_EXISTS) {};
         }
@@ -55,7 +61,6 @@ public class DeliveryService {
 
         brief.markDelivered();
 
-        User lawyer = userReader.findById(lawyerId);
         return DeliveryResponse.of(saved, lawyer.getName());
     }
 

--- a/src/main/java/org/example/shield/brief/application/DeliveryService.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryService.java
@@ -1,24 +1,78 @@
 package org.example.shield.brief.application;
 
-/**
- * 의뢰서 전달 서비스 - 전달/현황조회/접수/거절.
- *
- * Layer: application
- * Called by: BriefController, LawyerInboxController
- * Calls: DeliveryReader, DeliveryWriter, BriefReader, NotificationSender
- *
- * TODO:
- * - createDelivery(briefId, lawyerId):
- *   1. brief가 CONFIRMED 상태인지 확인
- *   2. deliveries에 새 row (status: DELIVERED, sentAt: now())
- *   3. NotificationSender로 변호사에게 이메일 알림
- *
- * - getDeliveries(briefId): 전달 현황 (sentAt, viewedAt, respondedAt 포함)
- * - getInbox(lawyerId, pageable): 수신 의뢰서 목록 (변호사용)
- * - getInboxDetail(deliveryId): 수신 의뢰서 상세 (privacySetting 적용)
- * - updateDeliveryStatus(deliveryId, status, rejectionReason):
- *   - CONFIRMED: 수락 → respondedAt 기록 + 의뢰인에게 알림
- *   - REJECTED: 거절 → rejectionReason 저장 + respondedAt 기록 + 의뢰인에게 알림
- */
+import lombok.RequiredArgsConstructor;
+import org.example.shield.brief.controller.dto.DeliveryListResponse;
+import org.example.shield.brief.controller.dto.DeliveryResponse;
+import org.example.shield.brief.domain.Brief;
+import org.example.shield.brief.domain.BriefDelivery;
+import org.example.shield.brief.domain.BriefReader;
+import org.example.shield.brief.exception.BriefNotFoundException;
+import org.example.shield.brief.infrastructure.BriefDeliveryRepository;
+import org.example.shield.common.enums.BriefStatus;
+import org.example.shield.common.exception.BusinessException;
+import org.example.shield.common.exception.ErrorCode;
+import org.example.shield.user.domain.User;
+import org.example.shield.user.domain.UserReader;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class DeliveryService {
+
+    private final BriefReader briefReader;
+    private final BriefDeliveryRepository deliveryRepository;
+    private final UserReader userReader;
+
+    @Transactional
+    public DeliveryResponse createDelivery(UUID briefId, UUID lawyerId, UUID userId) {
+        Brief brief = briefReader.findById(briefId);
+        validateOwner(brief, userId);
+
+        if (brief.getStatus() != BriefStatus.CONFIRMED) {
+            throw new BusinessException(ErrorCode.BRIEF_NOT_CONFIRMED) {};
+        }
+
+        // 중복 전달 방지
+        boolean alreadySent = deliveryRepository.findAllByBriefId(briefId).stream()
+                .anyMatch(d -> d.getLawyerId().equals(lawyerId));
+        if (alreadySent) {
+            throw new BusinessException(ErrorCode.DELIVERY_ALREADY_EXISTS) {};
+        }
+
+        BriefDelivery delivery = BriefDelivery.create(briefId, lawyerId);
+        BriefDelivery saved = deliveryRepository.save(delivery);
+
+        // 의뢰서 상태를 DELIVERED로 변경
+        brief.markDelivered();
+
+        User lawyer = userReader.findById(lawyerId);
+        return DeliveryResponse.of(saved, lawyer.getName());
+    }
+
+    public DeliveryListResponse getDeliveries(UUID briefId, UUID userId) {
+        Brief brief = briefReader.findById(briefId);
+        validateOwner(brief, userId);
+
+        List<BriefDelivery> deliveries = deliveryRepository.findAllByBriefId(briefId);
+
+        List<DeliveryResponse> responses = deliveries.stream()
+                .map(d -> {
+                    User lawyer = userReader.findById(d.getLawyerId());
+                    return DeliveryResponse.of(d, lawyer.getName());
+                })
+                .toList();
+
+        return new DeliveryListResponse(responses);
+    }
+
+    private void validateOwner(Brief brief, UUID userId) {
+        if (!brief.getUserId().equals(userId)) {
+            throw new BriefNotFoundException(brief.getId());
+        }
+    }
 }

--- a/src/main/java/org/example/shield/brief/application/DeliveryService.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryService.java
@@ -46,9 +46,7 @@ public class DeliveryService {
             throw new BusinessException(ErrorCode.BRIEF_NOT_CONFIRMED) {};
         }
 
-        boolean alreadySent = deliveryRepository.findAllByBriefId(briefId).stream()
-                .anyMatch(d -> d.getLawyerId().equals(lawyerId));
-        if (alreadySent) {
+        if (deliveryRepository.existsByBriefIdAndLawyerId(briefId, lawyerId)) {
             throw new BusinessException(ErrorCode.DELIVERY_ALREADY_EXISTS) {};
         }
 
@@ -85,11 +83,10 @@ public class DeliveryService {
     public PageResponse<InboxResponse> getInbox(UUID lawyerId, Pageable pageable) {
         Page<BriefDelivery> deliveries = deliveryRepository.findAllByLawyerId(lawyerId, pageable);
 
-        // N+1 방지: Brief ID를 모아서 한 번에 조회
         List<UUID> briefIds = deliveries.getContent().stream()
                 .map(BriefDelivery::getBriefId).toList();
-        Map<UUID, Brief> briefMap = briefIds.stream()
-                .collect(Collectors.toMap(id -> id, briefReader::findById));
+        Map<UUID, Brief> briefMap = briefReader.findAllByIds(briefIds).stream()
+                .collect(Collectors.toMap(Brief::getId, Function.identity()));
 
         Page<InboxResponse> responsePage = deliveries.map(d -> {
             Brief brief = briefMap.get(d.getBriefId());

--- a/src/main/java/org/example/shield/brief/application/LawyerMatchingService.java
+++ b/src/main/java/org/example/shield/brief/application/LawyerMatchingService.java
@@ -1,19 +1,79 @@
 package org.example.shield.brief.application;
 
-/**
- * 변호사 매칭 서비스 - 의뢰서 기반 변호사 매칭 (여러 명).
- *
- * Layer: application
- * Called by: BriefController.getLawyerRecommendations()
- * Calls: BriefReader, LawyerReader
- *
- * TODO:
- * - findMatching(briefId, pageable):
- *   1. brief에서 keywords, legalField 조회
- *   2. lawyers에서 verificationStatus = VERIFIED인 변호사 필터
- *   3. keywords와 lawyers.tags 비교 → matchedKeywords 추출
- *   4. 기본 정렬: 경력순 (experience)
- *   5. PageResponse로 반환
- */
+import lombok.RequiredArgsConstructor;
+import org.example.shield.brief.controller.dto.MatchingResponse;
+import org.example.shield.brief.domain.Brief;
+import org.example.shield.brief.domain.BriefReader;
+import org.example.shield.brief.exception.BriefNotFoundException;
+import org.example.shield.common.enums.VerificationStatus;
+import org.example.shield.common.response.PageResponse;
+import org.example.shield.lawyer.domain.LawyerProfile;
+import org.example.shield.lawyer.domain.LawyerReader;
+import org.example.shield.user.domain.User;
+import org.example.shield.user.domain.UserReader;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class LawyerMatchingService {
+
+    private final BriefReader briefReader;
+    private final LawyerReader lawyerReader;
+    private final UserReader userReader;
+
+    // TODO: AI 서버 연동 시 벡터DB 유사도 검색으로 교체
+    // 현재는 VERIFIED 변호사를 경력순으로 반환하는 목 매칭
+    public PageResponse<MatchingResponse> findMatching(UUID briefId, UUID userId, Pageable pageable) {
+        Brief brief = briefReader.findById(briefId);
+        if (!brief.getUserId().equals(userId)) {
+            throw new BriefNotFoundException(briefId);
+        }
+
+        List<String> briefKeywords = brief.getKeywords() != null ? brief.getKeywords() : Collections.emptyList();
+
+        Page<LawyerProfile> lawyers = lawyerReader.findAllByVerificationStatus(
+                VerificationStatus.VERIFIED, pageable);
+
+        // 변호사 userId 일괄 조회 (이름 가져오기용)
+        List<UUID> userIds = lawyers.getContent().stream()
+                .map(LawyerProfile::getUserId).toList();
+        Map<UUID, User> userMap = userReader.findAllByIds(userIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        Page<MatchingResponse> responsePage = lawyers.map(lawyer -> {
+            User user = userMap.get(lawyer.getUserId());
+            List<String> matched = findMatchedKeywords(briefKeywords, lawyer.getTags());
+
+            return new MatchingResponse(
+                    lawyer.getUserId(),
+                    user != null ? user.getName() : "알 수 없음",
+                    user != null ? user.getProfileImageUrl() : null,
+                    lawyer.getSpecializations(),
+                    lawyer.getExperienceYears(),
+                    lawyer.getTags(),
+                    matched
+            );
+        });
+
+        return PageResponse.from(responsePage);
+    }
+
+    private List<String> findMatchedKeywords(List<String> briefKeywords, List<String> lawyerTags) {
+        if (briefKeywords == null || lawyerTags == null) return Collections.emptyList();
+        List<String> matched = new ArrayList<>(briefKeywords);
+        matched.retainAll(lawyerTags);
+        return matched;
+    }
 }

--- a/src/main/java/org/example/shield/brief/controller/BriefController.java
+++ b/src/main/java/org/example/shield/brief/controller/BriefController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import jakarta.validation.Valid;
 import org.example.shield.brief.application.BriefService;
 import org.example.shield.brief.application.DeliveryService;
+import org.example.shield.brief.application.LawyerMatchingService;
 import org.example.shield.brief.controller.dto.BriefResponse;
 import org.example.shield.brief.controller.dto.BriefSummaryResponse;
 import org.example.shield.brief.controller.dto.BriefUpdateRequest;
@@ -13,6 +14,7 @@ import org.example.shield.brief.controller.dto.BriefUpdateResponse;
 import org.example.shield.brief.controller.dto.DeliveryListResponse;
 import org.example.shield.brief.controller.dto.DeliveryRequest;
 import org.example.shield.brief.controller.dto.DeliveryResponse;
+import org.example.shield.brief.controller.dto.MatchingResponse;
 import org.example.shield.common.response.ApiResponse;
 import org.example.shield.common.response.PageResponse;
 import org.springframework.data.domain.PageRequest;
@@ -38,6 +40,7 @@ public class BriefController {
 
     private final BriefService briefService;
     private final DeliveryService deliveryService;
+    private final LawyerMatchingService lawyerMatchingService;
 
     @Operation(summary = "내 의뢰서 목록", description = "로그인한 사용자의 의뢰서 목록을 조회합니다")
     @GetMapping
@@ -86,5 +89,17 @@ public class BriefController {
             @AuthenticationPrincipal UUID userId) {
         DeliveryListResponse result = deliveryService.getDeliveries(briefId, userId);
         return ApiResponse.success("조회 성공", result);
+    }
+
+    @Operation(summary = "변호사 매칭 조회", description = "의뢰서 키워드 기반으로 매칭된 변호사 목록을 조회합니다")
+    @GetMapping("/{briefId}/lawyer-recommendations")
+    public ApiResponse<PageResponse<MatchingResponse>> getLawyerRecommendations(
+            @PathVariable UUID briefId,
+            @AuthenticationPrincipal UUID userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "experienceYears"));
+        PageResponse<MatchingResponse> result = lawyerMatchingService.findMatching(briefId, userId, pageable);
+        return ApiResponse.success("매칭 완료", result);
     }
 }

--- a/src/main/java/org/example/shield/brief/controller/BriefController.java
+++ b/src/main/java/org/example/shield/brief/controller/BriefController.java
@@ -1,19 +1,64 @@
 package org.example.shield.brief.controller;
 
-/**
- * 의뢰서 API 컨트롤러.
- *
- * Layer: controller
- * Called by: 프론트엔드
- * Calls: BriefService, DeliveryService, LawyerMatchingService
- *
- * API 목록:
- * - GET   /api/briefs                                    내 의뢰서 목록
- * - GET   /api/briefs/{briefId}                          의뢰서 조회
- * - PATCH /api/briefs/{briefId}                          의뢰서 수정 (내용+상태+개인정보)
- * - GET   /api/briefs/{briefId}/lawyer-recommendations   변호사 매칭 조회 (여러 명, 페이징)
- * - POST  /api/briefs/{briefId}/deliveries               의뢰서 전달
- * - GET   /api/briefs/{briefId}/deliveries               전달 현황 조회
- */
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.example.shield.brief.application.BriefService;
+import org.example.shield.brief.controller.dto.BriefResponse;
+import org.example.shield.brief.controller.dto.BriefSummaryResponse;
+import org.example.shield.brief.controller.dto.BriefUpdateRequest;
+import org.example.shield.brief.controller.dto.BriefUpdateResponse;
+import org.example.shield.common.response.ApiResponse;
+import org.example.shield.common.response.PageResponse;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@Tag(name = "Brief", description = "의뢰서 API")
+@RestController
+@RequestMapping("/api/briefs")
+@RequiredArgsConstructor
 public class BriefController {
+
+    private final BriefService briefService;
+
+    @Operation(summary = "내 의뢰서 목록", description = "로그인한 사용자의 의뢰서 목록을 조회합니다")
+    @GetMapping
+    public ApiResponse<PageResponse<BriefSummaryResponse>> getMyBriefs(
+            @AuthenticationPrincipal UUID userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        PageResponse<BriefSummaryResponse> result = briefService.getMyBriefs(userId, pageable);
+        return ApiResponse.success("조회 성공", result);
+    }
+
+    @Operation(summary = "의뢰서 상세 조회", description = "의뢰서의 상세 내용을 조회합니다")
+    @GetMapping("/{briefId}")
+    public ApiResponse<BriefResponse> getBrief(
+            @PathVariable UUID briefId,
+            @AuthenticationPrincipal UUID userId) {
+        BriefResponse result = briefService.getBrief(briefId, userId);
+        return ApiResponse.success("조회 성공", result);
+    }
+
+    @Operation(summary = "의뢰서 수정", description = "의뢰서를 수정합니다 (내용, 상태, 개인정보 설정)")
+    @PatchMapping("/{briefId}")
+    public ApiResponse<BriefUpdateResponse> updateBrief(
+            @PathVariable UUID briefId,
+            @AuthenticationPrincipal UUID userId,
+            @RequestBody BriefUpdateRequest request) {
+        BriefUpdateResponse result = briefService.updateBrief(briefId, userId, request);
+        return ApiResponse.success("의뢰서가 수정되었습니다", result);
+    }
 }

--- a/src/main/java/org/example/shield/brief/controller/BriefController.java
+++ b/src/main/java/org/example/shield/brief/controller/BriefController.java
@@ -3,11 +3,16 @@ package org.example.shield.brief.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import jakarta.validation.Valid;
 import org.example.shield.brief.application.BriefService;
+import org.example.shield.brief.application.DeliveryService;
 import org.example.shield.brief.controller.dto.BriefResponse;
 import org.example.shield.brief.controller.dto.BriefSummaryResponse;
 import org.example.shield.brief.controller.dto.BriefUpdateRequest;
 import org.example.shield.brief.controller.dto.BriefUpdateResponse;
+import org.example.shield.brief.controller.dto.DeliveryListResponse;
+import org.example.shield.brief.controller.dto.DeliveryRequest;
+import org.example.shield.brief.controller.dto.DeliveryResponse;
 import org.example.shield.common.response.ApiResponse;
 import org.example.shield.common.response.PageResponse;
 import org.springframework.data.domain.PageRequest;
@@ -17,6 +22,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,6 +37,7 @@ import java.util.UUID;
 public class BriefController {
 
     private final BriefService briefService;
+    private final DeliveryService deliveryService;
 
     @Operation(summary = "내 의뢰서 목록", description = "로그인한 사용자의 의뢰서 목록을 조회합니다")
     @GetMapping
@@ -60,5 +67,24 @@ public class BriefController {
             @RequestBody BriefUpdateRequest request) {
         BriefUpdateResponse result = briefService.updateBrief(briefId, userId, request);
         return ApiResponse.success("의뢰서가 수정되었습니다", result);
+    }
+
+    @Operation(summary = "의뢰서 전달", description = "확정된 의뢰서를 변호사에게 전달합니다")
+    @PostMapping("/{briefId}/deliveries")
+    public ApiResponse<DeliveryResponse> createDelivery(
+            @PathVariable UUID briefId,
+            @AuthenticationPrincipal UUID userId,
+            @Valid @RequestBody DeliveryRequest request) {
+        DeliveryResponse result = deliveryService.createDelivery(briefId, request.lawyerId(), userId);
+        return ApiResponse.success("의뢰서가 전달되었습니다", result);
+    }
+
+    @Operation(summary = "전달 현황 조회", description = "의뢰서의 전달 현황을 조회합니다")
+    @GetMapping("/{briefId}/deliveries")
+    public ApiResponse<DeliveryListResponse> getDeliveries(
+            @PathVariable UUID briefId,
+            @AuthenticationPrincipal UUID userId) {
+        DeliveryListResponse result = deliveryService.getDeliveries(briefId, userId);
+        return ApiResponse.success("조회 성공", result);
     }
 }

--- a/src/main/java/org/example/shield/brief/controller/LawyerInboxController.java
+++ b/src/main/java/org/example/shield/brief/controller/LawyerInboxController.java
@@ -1,16 +1,50 @@
 package org.example.shield.brief.controller;
 
-/**
- * 변호사 수신함 API 컨트롤러.
- *
- * Layer: controller
- * Called by: 프론트엔드 (변호사 화면)
- * Calls: DeliveryService
- *
- * API 목록:
- * - GET   /api/lawyer/inbox                              수신 의뢰서 목록
- * - GET   /api/lawyer/inbox/{deliveryId}                 수신 의뢰서 상세
- * - PATCH /api/lawyer/inbox/{deliveryId}/status           접수/거절 (body: status, rejectionReason)
- */
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.example.shield.brief.application.DeliveryService;
+import org.example.shield.brief.controller.dto.InboxDetailResponse;
+import org.example.shield.brief.controller.dto.InboxResponse;
+import org.example.shield.common.response.ApiResponse;
+import org.example.shield.common.response.PageResponse;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@Tag(name = "Lawyer Inbox", description = "변호사 수신함 API")
+@RestController
+@RequestMapping("/api/lawyer/inbox")
+@RequiredArgsConstructor
 public class LawyerInboxController {
+
+    private final DeliveryService deliveryService;
+
+    @Operation(summary = "수신 의뢰서 목록", description = "변호사에게 전달된 의뢰서 목록을 조회합니다")
+    @GetMapping
+    public ApiResponse<PageResponse<InboxResponse>> getInbox(
+            @AuthenticationPrincipal UUID lawyerId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "sentAt"));
+        PageResponse<InboxResponse> result = deliveryService.getInbox(lawyerId, pageable);
+        return ApiResponse.success("조회 성공", result);
+    }
+
+    @Operation(summary = "수신 의뢰서 상세", description = "전달받은 의뢰서의 상세 내용을 조회합니다")
+    @GetMapping("/{deliveryId}")
+    public ApiResponse<InboxDetailResponse> getInboxDetail(
+            @PathVariable UUID deliveryId,
+            @AuthenticationPrincipal UUID lawyerId) {
+        InboxDetailResponse result = deliveryService.getInboxDetail(deliveryId, lawyerId);
+        return ApiResponse.success("조회 성공", result);
+    }
 }

--- a/src/main/java/org/example/shield/brief/controller/dto/BriefResponse.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/BriefResponse.java
@@ -1,17 +1,35 @@
 package org.example.shield.brief.controller.dto;
 
-/**
- * 의뢰서 조회 응답 DTO.
- *
- * TODO:
- * - briefId: String (UUID)
- * - title: String ("[노동] 부당해고 관련 의뢰서")
- * - legalField: String
- * - content: String (줄글 의뢰서 전체 내용)
- * - keywords: List<String> (매칭용 키워드)
- * - privacySetting: String (FULL / PARTIAL / PRIVATE)
- * - status: String (DRAFT / CONFIRMED / DELIVERED / DISCARDED)
- * - createdAt: LocalDateTime
- */
-public class BriefResponse {
+import org.example.shield.brief.domain.Brief;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record BriefResponse(
+        UUID briefId,
+        String title,
+        String legalField,
+        String content,
+        List<String> keyIssues,
+        List<String> keywords,
+        String strategy,
+        String privacySetting,
+        String status,
+        LocalDateTime createdAt
+) {
+    public static BriefResponse from(Brief brief) {
+        return new BriefResponse(
+                brief.getId(),
+                brief.getTitle(),
+                brief.getLegalField(),
+                brief.getContent(),
+                brief.getKeyIssues(),
+                brief.getKeywords(),
+                brief.getStrategy(),
+                brief.getPrivacySetting().name(),
+                brief.getStatus().name(),
+                brief.getCreatedAt()
+        );
+    }
 }

--- a/src/main/java/org/example/shield/brief/controller/dto/BriefSummaryResponse.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/BriefSummaryResponse.java
@@ -1,0 +1,22 @@
+package org.example.shield.brief.controller.dto;
+
+import org.example.shield.brief.domain.Brief;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record BriefSummaryResponse(
+        UUID briefId,
+        String title,
+        String status,
+        LocalDateTime createdAt
+) {
+    public static BriefSummaryResponse from(Brief brief) {
+        return new BriefSummaryResponse(
+                brief.getId(),
+                brief.getTitle(),
+                brief.getStatus().name(),
+                brief.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/org/example/shield/brief/controller/dto/BriefUpdateRequest.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/BriefUpdateRequest.java
@@ -1,14 +1,12 @@
 package org.example.shield.brief.controller.dto;
 
-/**
- * 의뢰서 수정 요청 DTO (수정할 필드만 전송).
- *
- * TODO:
- * - title: String (선택)
- * - content: String (줄글 수정, 선택)
- * - keywords: List<String> (선택)
- * - privacySetting: String (FULL/PARTIAL/PRIVATE, 선택)
- * - status: String (CONFIRMED/DISCARDED, 선택)
- */
-public class BriefUpdateRequest {
-}
+import java.util.List;
+
+public record BriefUpdateRequest(
+        String title,
+        String content,
+        List<String> keyIssues,
+        List<String> keywords,
+        String privacySetting,
+        String status
+) {}

--- a/src/main/java/org/example/shield/brief/controller/dto/BriefUpdateResponse.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/BriefUpdateResponse.java
@@ -1,0 +1,10 @@
+package org.example.shield.brief.controller.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record BriefUpdateResponse(
+        UUID briefId,
+        String status,
+        LocalDateTime updatedAt
+) {}

--- a/src/main/java/org/example/shield/brief/controller/dto/DeliveryListResponse.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/DeliveryListResponse.java
@@ -1,0 +1,7 @@
+package org.example.shield.brief.controller.dto;
+
+import java.util.List;
+
+public record DeliveryListResponse(
+        List<DeliveryResponse> deliveries
+) {}

--- a/src/main/java/org/example/shield/brief/controller/dto/DeliveryRequest.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/DeliveryRequest.java
@@ -1,10 +1,10 @@
 package org.example.shield.brief.controller.dto;
 
-/**
- * 의뢰서 전달 요청 DTO.
- *
- * TODO: record로 구현
- * - lawyerId: UUID (매칭 목록에서 선택한 변호사)
- */
-public class DeliveryRequest {
-}
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record DeliveryRequest(
+        @NotNull(message = "변호사 ID는 필수입니다")
+        UUID lawyerId
+) {}

--- a/src/main/java/org/example/shield/brief/controller/dto/DeliveryResponse.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/DeliveryResponse.java
@@ -1,15 +1,28 @@
 package org.example.shield.brief.controller.dto;
 
-/**
- * 의뢰서 전달 응답 DTO.
- *
- * TODO: record로 구현
- * - deliveryId: UUID
- * - lawyerName: String
- * - status: String (DELIVERED / CONFIRMED / REJECTED)
- * - sentAt: LocalDateTime
- * - viewedAt: LocalDateTime (nullable)
- * - respondedAt: LocalDateTime (nullable)
- */
-public class DeliveryResponse {
+import org.example.shield.brief.domain.BriefDelivery;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record DeliveryResponse(
+        UUID deliveryId,
+        UUID lawyerId,
+        String lawyerName,
+        String status,
+        LocalDateTime sentAt,
+        LocalDateTime viewedAt,
+        LocalDateTime respondedAt
+) {
+    public static DeliveryResponse of(BriefDelivery delivery, String lawyerName) {
+        return new DeliveryResponse(
+                delivery.getId(),
+                delivery.getLawyerId(),
+                lawyerName,
+                delivery.getStatus().name(),
+                delivery.getSentAt(),
+                delivery.getViewedAt(),
+                delivery.getRespondedAt()
+        );
+    }
 }

--- a/src/main/java/org/example/shield/brief/controller/dto/InboxDetailResponse.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/InboxDetailResponse.java
@@ -1,0 +1,37 @@
+package org.example.shield.brief.controller.dto;
+
+import org.example.shield.brief.domain.Brief;
+import org.example.shield.brief.domain.BriefDelivery;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record InboxDetailResponse(
+        UUID deliveryId,
+        UUID briefId,
+        String title,
+        String legalField,
+        String content,
+        List<String> keywords,
+        String status,
+        String clientName,
+        String clientEmail,
+        LocalDateTime sentAt
+) {
+    public static InboxDetailResponse of(BriefDelivery delivery, Brief brief,
+                                          String clientName, String clientEmail) {
+        return new InboxDetailResponse(
+                delivery.getId(),
+                brief.getId(),
+                brief.getTitle(),
+                brief.getLegalField(),
+                brief.getContent(),
+                brief.getKeywords(),
+                delivery.getStatus().name(),
+                clientName,
+                clientEmail,
+                delivery.getSentAt()
+        );
+    }
+}

--- a/src/main/java/org/example/shield/brief/controller/dto/InboxResponse.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/InboxResponse.java
@@ -1,14 +1,25 @@
 package org.example.shield.brief.controller.dto;
 
-/**
- * 변호사 수신함 응답 DTO.
- *
- * TODO:
- * - deliveryId: String (UUID)
- * - briefTitle: String
- * - legalField: String
- * - status: String
- * - sentAt: LocalDateTime
- */
-public class InboxResponse {
+import org.example.shield.brief.domain.Brief;
+import org.example.shield.brief.domain.BriefDelivery;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record InboxResponse(
+        UUID deliveryId,
+        String briefTitle,
+        String legalField,
+        String status,
+        LocalDateTime sentAt
+) {
+    public static InboxResponse of(BriefDelivery delivery, Brief brief) {
+        return new InboxResponse(
+                delivery.getId(),
+                brief.getTitle(),
+                brief.getLegalField(),
+                delivery.getStatus().name(),
+                delivery.getSentAt()
+        );
+    }
 }

--- a/src/main/java/org/example/shield/brief/controller/dto/MatchingResponse.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/MatchingResponse.java
@@ -1,16 +1,14 @@
 package org.example.shield.brief.controller.dto;
 
-/**
- * 변호사 매칭 응답 DTO.
- *
- * TODO: record로 구현
- * - lawyerId: UUID
- * - name: String
- * - profileImageUrl: String (nullable)
- * - specializations: String
- * - experienceYears: int
- * - tags: List<String> (세부 전문 키워드)
- * - matchedKeywords: List<String> (의뢰서와 매칭된 키워드)
- */
-public class MatchingResponse {
-}
+import java.util.List;
+import java.util.UUID;
+
+public record MatchingResponse(
+        UUID lawyerId,
+        String name,
+        String profileImageUrl,
+        String specializations,
+        Integer experienceYears,
+        List<String> tags,
+        List<String> matchedKeywords
+) {}

--- a/src/main/java/org/example/shield/brief/domain/Brief.java
+++ b/src/main/java/org/example/shield/brief/domain/Brief.java
@@ -1,20 +1,122 @@
 package org.example.shield.brief.domain;
 
-/**
- * 의뢰서 엔티티 - briefs 테이블 매핑.
- *
- * TODO: @Entity 구현
- * - id: UUID (PK)
- * - consultationId: UUID (FK → consultations.id)
- * - userId: UUID (FK → users.id)
- * - title: String (자동 생성, "[노동] 부당해고 관련 의뢰서")
- * - legalField: String
- * - content: String (TEXT, Grok Expert가 생성한 줄글 의뢰서)
- * - keywords: List<String> (JSONB, 변호사 매칭용)
- * - privacySetting: String (FULL/PARTIAL/PRIVATE, 기본 PARTIAL)
- * - status: String (DRAFT/CONFIRMED/DELIVERED/DISCARDED)
- * - confirmedAt: LocalDateTime
- * - createdAt, updatedAt: LocalDateTime
- */
-public class Brief {
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.shield.common.domain.BaseEntity;
+import org.example.shield.common.enums.BriefStatus;
+import org.example.shield.common.enums.PrivacySetting;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "briefs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Brief extends BaseEntity {
+
+    @Column(nullable = false)
+    private UUID consultationId;
+
+    @Column(nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String legalField;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "privacy_setting")
+    private PrivacySetting privacySetting;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "brief_status")
+    private BriefStatus status;
+
+    private LocalDateTime confirmedAt;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private List<String> keywords;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private List<String> keyIssues;
+
+    @Column(columnDefinition = "text")
+    private String strategy;
+
+    @Builder
+    private Brief(UUID consultationId, UUID userId, String title, String legalField,
+                  String content, List<String> keywords, List<String> keyIssues, String strategy) {
+        this.consultationId = consultationId;
+        this.userId = userId;
+        this.title = title;
+        this.legalField = legalField;
+        this.content = content;
+        this.keywords = keywords;
+        this.keyIssues = keyIssues;
+        this.strategy = strategy;
+        this.privacySetting = PrivacySetting.PARTIAL;
+        this.status = BriefStatus.DRAFT;
+    }
+
+    public static Brief create(UUID consultationId, UUID userId, String title, String legalField,
+                               String content, List<String> keywords, List<String> keyIssues, String strategy) {
+        return Brief.builder()
+                .consultationId(consultationId)
+                .userId(userId)
+                .title(title)
+                .legalField(legalField)
+                .content(content)
+                .keywords(keywords)
+                .keyIssues(keyIssues)
+                .strategy(strategy)
+                .build();
+    }
+
+    public void updateContent(String title, String content, List<String> keywords,
+                              List<String> keyIssues, String strategy) {
+        this.title = title;
+        this.content = content;
+        this.keywords = keywords;
+        this.keyIssues = keyIssues;
+        this.strategy = strategy;
+    }
+
+    public void updatePrivacySetting(PrivacySetting privacySetting) {
+        this.privacySetting = privacySetting;
+    }
+
+    public void confirm() {
+        this.status = BriefStatus.CONFIRMED;
+        this.confirmedAt = LocalDateTime.now();
+    }
+
+    public void markDelivered() {
+        this.status = BriefStatus.DELIVERED;
+    }
+
+    public void discard() {
+        this.status = BriefStatus.DISCARDED;
+    }
+
+    public boolean isEditable() {
+        return this.status == BriefStatus.DRAFT;
+    }
 }

--- a/src/main/java/org/example/shield/brief/domain/BriefDelivery.java
+++ b/src/main/java/org/example/shield/brief/domain/BriefDelivery.java
@@ -1,17 +1,81 @@
 package org.example.shield.brief.domain;
 
-/**
- * 의뢰서 전달 엔티티 - deliveries 테이블 매핑.
- *
- * TODO: @Entity 구현 (BaseEntity 상속 안 함)
- * - id: UUID (PK)
- * - briefId: UUID (FK -> briefs.id)
- * - lawyerId: UUID (FK -> users.id)
- * - status: DeliveryStatus (DELIVERED / CONFIRMED / REJECTED)
- * - rejectionReason: String (nullable)
- * - sentAt: LocalDateTime (DEFAULT now())
- * - viewedAt: LocalDateTime (nullable)
- * - respondedAt: LocalDateTime (nullable)
- */
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.shield.common.enums.DeliveryStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "deliveries")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BriefDelivery {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID briefId;
+
+    @Column(nullable = false)
+    private UUID lawyerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "delivery_status")
+    private DeliveryStatus status;
+
+    @Column(columnDefinition = "text")
+    private String rejectionReason;
+
+    @Column(nullable = false)
+    private LocalDateTime sentAt;
+
+    private LocalDateTime viewedAt;
+
+    private LocalDateTime respondedAt;
+
+    @Builder
+    private BriefDelivery(UUID briefId, UUID lawyerId) {
+        this.briefId = briefId;
+        this.lawyerId = lawyerId;
+        this.status = DeliveryStatus.DELIVERED;
+        this.sentAt = LocalDateTime.now();
+    }
+
+    public static BriefDelivery create(UUID briefId, UUID lawyerId) {
+        return BriefDelivery.builder()
+                .briefId(briefId)
+                .lawyerId(lawyerId)
+                .build();
+    }
+
+    public void markViewed() {
+        if (this.viewedAt == null) {
+            this.viewedAt = LocalDateTime.now();
+        }
+    }
+
+    public void accept() {
+        this.status = DeliveryStatus.CONFIRMED;
+        this.respondedAt = LocalDateTime.now();
+    }
+
+    public void reject(String reason) {
+        this.status = DeliveryStatus.REJECTED;
+        this.rejectionReason = reason;
+        this.respondedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/org/example/shield/brief/domain/BriefReader.java
+++ b/src/main/java/org/example/shield/brief/domain/BriefReader.java
@@ -3,11 +3,13 @@ package org.example.shield.brief.domain;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface BriefReader {
     Brief findById(UUID id);
+    List<Brief> findAllByIds(List<UUID> ids);
     Page<Brief> findAllByUserId(UUID userId, Pageable pageable);
     Optional<Brief> findOptionalByConsultationId(UUID consultationId);
 }

--- a/src/main/java/org/example/shield/brief/domain/BriefReader.java
+++ b/src/main/java/org/example/shield/brief/domain/BriefReader.java
@@ -1,12 +1,13 @@
 package org.example.shield.brief.domain;
 
-/**
- * Brief 조회 인터페이스.
- *
- * TODO:
- * - findById(UUID id): Brief
- * - findAllByUserId(UUID userId, Pageable pageable): Page<Brief>
- * - findByConsultationId(UUID consultationId): Optional<Brief>
- */
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+import java.util.UUID;
+
 public interface BriefReader {
+    Brief findById(UUID id);
+    Page<Brief> findAllByUserId(UUID userId, Pageable pageable);
+    Optional<Brief> findOptionalByConsultationId(UUID consultationId);
 }

--- a/src/main/java/org/example/shield/brief/domain/BriefWriter.java
+++ b/src/main/java/org/example/shield/brief/domain/BriefWriter.java
@@ -1,10 +1,7 @@
 package org.example.shield.brief.domain;
 
-/**
- * Brief 저장 인터페이스.
- *
- * TODO:
- * - save(Brief brief): Brief
- */
+import java.util.UUID;
+
 public interface BriefWriter {
+    Brief save(Brief brief);
 }

--- a/src/main/java/org/example/shield/brief/exception/BriefAlreadyConfirmedException.java
+++ b/src/main/java/org/example/shield/brief/exception/BriefAlreadyConfirmedException.java
@@ -1,8 +1,10 @@
 package org.example.shield.brief.exception;
 
-/**
- * 의뢰서 이미 확정됨 예외.
- * CONFIRMED 상태의 의뢰서를 수정하려 할 때 발생.
- */
-public class BriefAlreadyConfirmedException {
+import org.example.shield.common.exception.BusinessException;
+import org.example.shield.common.exception.ErrorCode;
+
+public class BriefAlreadyConfirmedException extends BusinessException {
+    public BriefAlreadyConfirmedException() {
+        super(ErrorCode.BRIEF_ALREADY_CONFIRMED);
+    }
 }

--- a/src/main/java/org/example/shield/brief/exception/BriefNotFoundException.java
+++ b/src/main/java/org/example/shield/brief/exception/BriefNotFoundException.java
@@ -1,8 +1,12 @@
 package org.example.shield.brief.exception;
 
-/**
- * 의뢰서 없음 예외.
- * briefId로 조회했는데 없을 때 발생.
- */
-public class BriefNotFoundException {
+import org.example.shield.common.exception.BusinessException;
+import org.example.shield.common.exception.ErrorCode;
+
+import java.util.UUID;
+
+public class BriefNotFoundException extends BusinessException {
+    public BriefNotFoundException(UUID briefId) {
+        super(ErrorCode.BRIEF_NOT_FOUND);
+    }
 }

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryRepository.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryRepository.java
@@ -11,4 +11,5 @@ import java.util.UUID;
 public interface BriefDeliveryRepository extends JpaRepository<BriefDelivery, UUID> {
     List<BriefDelivery> findAllByBriefId(UUID briefId);
     Page<BriefDelivery> findAllByLawyerId(UUID lawyerId, Pageable pageable);
+    boolean existsByBriefIdAndLawyerId(UUID briefId, UUID lawyerId);
 }

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryRepository.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryRepository.java
@@ -1,11 +1,14 @@
 package org.example.shield.brief.infrastructure;
 
-/**
- * 의뢰서 전달 JPA Repository.
- *
- * TODO: extends JpaRepository<BriefDelivery, UUID>
- * - findByBriefId(UUID briefId): List<BriefDelivery>
- * - findByLawyerId(UUID lawyerId): List<BriefDelivery>
- */
-public interface BriefDeliveryRepository {
+import org.example.shield.brief.domain.BriefDelivery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface BriefDeliveryRepository extends JpaRepository<BriefDelivery, UUID> {
+    List<BriefDelivery> findAllByBriefId(UUID briefId);
+    Page<BriefDelivery> findAllByLawyerId(UUID lawyerId, Pageable pageable);
 }

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefReaderImpl.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefReaderImpl.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -21,6 +22,11 @@ public class BriefReaderImpl implements BriefReader {
     public Brief findById(UUID id) {
         return briefRepository.findById(id)
                 .orElseThrow(() -> new BriefNotFoundException(id));
+    }
+
+    @Override
+    public List<Brief> findAllByIds(List<UUID> ids) {
+        return briefRepository.findAllById(ids);
     }
 
     @Override

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefReaderImpl.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefReaderImpl.java
@@ -1,11 +1,35 @@
 package org.example.shield.brief.infrastructure;
 
-/**
- * BriefReader 구현체.
- *
- * TODO: @Repository + implements BriefReader
- * - BriefRepository 주입
- * - findById: 없으면 BriefNotFoundException
- */
-public class BriefReaderImpl {
+import lombok.RequiredArgsConstructor;
+import org.example.shield.brief.domain.Brief;
+import org.example.shield.brief.domain.BriefReader;
+import org.example.shield.brief.exception.BriefNotFoundException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class BriefReaderImpl implements BriefReader {
+
+    private final BriefRepository briefRepository;
+
+    @Override
+    public Brief findById(UUID id) {
+        return briefRepository.findById(id)
+                .orElseThrow(() -> new BriefNotFoundException(id));
+    }
+
+    @Override
+    public Page<Brief> findAllByUserId(UUID userId, Pageable pageable) {
+        return briefRepository.findAllByUserId(userId, pageable);
+    }
+
+    @Override
+    public Optional<Brief> findOptionalByConsultationId(UUID consultationId) {
+        return briefRepository.findByConsultationId(consultationId);
+    }
 }

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefRepository.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefRepository.java
@@ -1,11 +1,14 @@
 package org.example.shield.brief.infrastructure;
 
-/**
- * 의뢰서 JPA Repository.
- *
- * TODO: extends JpaRepository<Brief, UUID>
- * - findByUserId(UUID userId): List<Brief>
- * - findByConsultationId(UUID consultationId): Optional<Brief>
- */
-public interface BriefRepository {
+import org.example.shield.brief.domain.Brief;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface BriefRepository extends JpaRepository<Brief, UUID> {
+    Page<Brief> findAllByUserId(UUID userId, Pageable pageable);
+    Optional<Brief> findByConsultationId(UUID consultationId);
 }

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefWriterImpl.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefWriterImpl.java
@@ -1,10 +1,18 @@
 package org.example.shield.brief.infrastructure;
 
-/**
- * BriefWriter 구현체.
- *
- * TODO: @Repository + implements BriefWriter
- * - BriefRepository 주입
- */
-public class BriefWriterImpl {
+import lombok.RequiredArgsConstructor;
+import org.example.shield.brief.domain.Brief;
+import org.example.shield.brief.domain.BriefWriter;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BriefWriterImpl implements BriefWriter {
+
+    private final BriefRepository briefRepository;
+
+    @Override
+    public Brief save(Brief brief) {
+        return briefRepository.save(brief);
+    }
 }

--- a/src/main/java/org/example/shield/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/shield/common/exception/ErrorCode.java
@@ -42,6 +42,10 @@ public enum ErrorCode {
 
     // Delivery
     DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 전달 건입니다"),
+    DELIVERY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 전달된 변호사입니다"),
+
+    // Brief - Delivery
+    BRIEF_NOT_CONFIRMED(HttpStatus.BAD_REQUEST, "의뢰서를 먼저 확정해 주세요"),
 
     // Verification
     VERIFICATION_ALREADY_SUBMITTED(HttpStatus.CONFLICT, "이미 검증 신청된 상태입니다");

--- a/src/main/java/org/example/shield/consultation/controller/ConsultationController.java
+++ b/src/main/java/org/example/shield/consultation/controller/ConsultationController.java
@@ -20,7 +20,7 @@ import org.example.shield.consultation.controller.dto.SendMessageResponse;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -50,10 +50,9 @@ public class ConsultationController {
 
     @Operation(summary = "상담 생성", description = "새로운 상담을 생성하고 환영 메시지를 반환합니다")
     @PostMapping
-    public ApiResponse<CreateConsultationResponse> create(@RequestBody CreateConsultationRequest request) {
-        // TODO: Auth 연동 후 JWT에서 userId 추출
-        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
-
+    public ApiResponse<CreateConsultationResponse> create(
+            @RequestBody CreateConsultationRequest request,
+            @AuthenticationPrincipal UUID userId) {
         CreateConsultationResponse result = consultationService.createConsultation(userId, request.domain());
         return ApiResponse.success("상담이 생성되었습니다", result);
     }
@@ -61,11 +60,9 @@ public class ConsultationController {
     @Operation(summary = "내 상담 목록", description = "로그인한 사용자의 상담 목록을 조회합니다")
     @GetMapping
     public ApiResponse<PageResponse<ConsultationResponse>> getMyConsultations(
+            @AuthenticationPrincipal UUID userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
-        // TODO: Auth 연동 후 JWT에서 userId 추출
-        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
-
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "updatedAt"));
         PageResponse<ConsultationResponse> result = consultationService.getMyConsultations(userId, pageable);
         return ApiResponse.success("조회 성공", result);

--- a/src/main/java/org/example/shield/lawyer/domain/LawyerProfile.java
+++ b/src/main/java/org/example/shield/lawyer/domain/LawyerProfile.java
@@ -1,19 +1,54 @@
 package org.example.shield.lawyer.domain;
 
-/**
- * 변호사 프로필 엔티티 - lawyers 테이블 매핑 (BaseEntity 상속).
- *
- * TODO: @Entity 구현
- * - userId: UUID (FK -> users.id, UNIQUE)
- * - specializations: String (전문 분야)
- * - experienceYears: Integer (nullable)
- * - barAssociationNumber: String (NOT NULL)
- * - verificationStatus: VerificationStatus (PENDING / VERIFIED / REJECTED)
- * - verifiedAt: LocalDateTime (nullable)
- * - tags: JSONB (세부 전문 키워드)
- * - bio: String (nullable, 소개글)
- * - certifications: JSONB (자격증 목록)
- * - caseCount: Integer (수행 사례 수, DEFAULT 0)
- */
-public class LawyerProfile {
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.shield.common.domain.BaseEntity;
+import org.example.shield.common.enums.VerificationStatus;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "lawyers")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LawyerProfile extends BaseEntity {
+
+    @Column(nullable = false, unique = true)
+    private UUID userId;
+
+    private String specializations;
+
+    private Integer experienceYears;
+
+    @Column(nullable = false)
+    private String barAssociationNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "verification_status")
+    private VerificationStatus verificationStatus;
+
+    private LocalDateTime verifiedAt;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private List<String> tags;
+
+    @Column(columnDefinition = "text")
+    private String bio;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private List<String> certifications;
+
+    private Integer caseCount;
 }

--- a/src/main/java/org/example/shield/lawyer/domain/LawyerReader.java
+++ b/src/main/java/org/example/shield/lawyer/domain/LawyerReader.java
@@ -1,13 +1,13 @@
 package org.example.shield.lawyer.domain;
 
-/**
- * Lawyer 조회 인터페이스.
- *
- * TODO:
- * - findById(UUID id): LawyerProfile
- * - findByUserId(UUID userId): LawyerProfile
- * - findAll(Pageable pageable): Page<LawyerProfile>
- * - findAllByVerificationStatus(VerificationStatus status, Pageable pageable): Page<LawyerProfile>
- */
+import org.example.shield.common.enums.VerificationStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
 public interface LawyerReader {
+    LawyerProfile findById(UUID id);
+    LawyerProfile findByUserId(UUID userId);
+    Page<LawyerProfile> findAllByVerificationStatus(VerificationStatus status, Pageable pageable);
 }

--- a/src/main/java/org/example/shield/lawyer/infrastructure/LawyerProfileRepository.java
+++ b/src/main/java/org/example/shield/lawyer/infrastructure/LawyerProfileRepository.java
@@ -1,12 +1,15 @@
 package org.example.shield.lawyer.infrastructure;
 
-/**
- * 변호사 프로필 JPA Repository.
- *
- * TODO: extends JpaRepository<LawyerProfile, UUID>
- * - findByUserId(UUID userId): Optional<LawyerProfile>
- * - findByVerificationStatus(String status): List<LawyerProfile>
- * - findBySpecializationsContaining(String field): 전문분야로 검색 (매칭용)
- */
-public interface LawyerProfileRepository {
+import org.example.shield.common.enums.VerificationStatus;
+import org.example.shield.lawyer.domain.LawyerProfile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface LawyerProfileRepository extends JpaRepository<LawyerProfile, UUID> {
+    Optional<LawyerProfile> findByUserId(UUID userId);
+    Page<LawyerProfile> findAllByVerificationStatus(VerificationStatus status, Pageable pageable);
 }

--- a/src/main/java/org/example/shield/lawyer/infrastructure/LawyerReaderImpl.java
+++ b/src/main/java/org/example/shield/lawyer/infrastructure/LawyerReaderImpl.java
@@ -1,11 +1,37 @@
 package org.example.shield.lawyer.infrastructure;
 
-/**
- * LawyerReader 구현체.
- *
- * TODO: @Repository + implements LawyerReader
- * - LawyerProfileRepository 주입
- * - findById: 없으면 LawyerNotFoundException
- */
-public class LawyerReaderImpl {
+import lombok.RequiredArgsConstructor;
+import org.example.shield.common.enums.VerificationStatus;
+import org.example.shield.common.exception.BusinessException;
+import org.example.shield.common.exception.ErrorCode;
+import org.example.shield.lawyer.domain.LawyerProfile;
+import org.example.shield.lawyer.domain.LawyerReader;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class LawyerReaderImpl implements LawyerReader {
+
+    private final LawyerProfileRepository lawyerProfileRepository;
+
+    @Override
+    public LawyerProfile findById(UUID id) {
+        return lawyerProfileRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.LAWYER_NOT_FOUND) {});
+    }
+
+    @Override
+    public LawyerProfile findByUserId(UUID userId) {
+        return lawyerProfileRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.LAWYER_NOT_FOUND) {});
+    }
+
+    @Override
+    public Page<LawyerProfile> findAllByVerificationStatus(VerificationStatus status, Pageable pageable) {
+        return lawyerProfileRepository.findAllByVerificationStatus(status, pageable);
+    }
 }

--- a/src/main/java/org/example/shield/user/domain/UserReader.java
+++ b/src/main/java/org/example/shield/user/domain/UserReader.java
@@ -1,11 +1,14 @@
 package org.example.shield.user.domain;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface UserReader {
 
     User findById(UUID id);
+
+    List<User> findAllByIds(List<UUID> ids);
 
     Optional<User> findByGoogleId(String googleId);
 

--- a/src/main/java/org/example/shield/user/infrastructure/UserReaderImpl.java
+++ b/src/main/java/org/example/shield/user/infrastructure/UserReaderImpl.java
@@ -6,6 +6,7 @@ import org.example.shield.user.domain.UserReader;
 import org.example.shield.user.exception.UserNotFoundException;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -19,6 +20,11 @@ public class UserReaderImpl implements UserReader {
     public User findById(UUID id) {
         return userRepository.findById(id)
                 .orElseThrow(UserNotFoundException::new);
+    }
+
+    @Override
+    public List<User> findAllByIds(List<UUID> ids) {
+        return userRepository.findAllById(ids);
     }
 
     @Override


### PR DESCRIPTION
## 📌 개요

Issue #10 — 의뢰서(Brief) 도메인 전체 API 구현 + 기존 상담 API의 JWT 인증 연동

---

## 🔄 변경 사항

### 인증
| 항목 | 내용 |
|------|------|
| JWT 연동 | ConsultationController 하드코딩 userId 제거 → `@AuthenticationPrincipal UUID userId` |

### 의뢰서 (Brief)
| Method | Endpoint | 기능 | 상태 |
|--------|----------|------|------|
| GET | `/api/briefs` | 내 의뢰서 목록 | ✅ |
| GET | `/api/briefs/{briefId}` | 의뢰서 상세 조회 | ✅ |
| PATCH | `/api/briefs/{briefId}` | 의뢰서 수정 (내용/상태/개인정보) | ✅ |
| POST | `/api/briefs/{briefId}/deliveries` | 의뢰서 전달 | ✅ |
| GET | `/api/briefs/{briefId}/deliveries` | 전달 현황 조회 | ✅ |
| GET | `/api/briefs/{briefId}/lawyer-recommendations` | 변호사 매칭 조회 | ✅ |

### 변호사 수신함 (Lawyer Inbox)
| Method | Endpoint | 기능 | 상태 |
|--------|----------|------|------|
| GET | `/api/lawyer/inbox` | 수신 의뢰서 목록 | ✅ |
| GET | `/api/lawyer/inbox/{deliveryId}` | 수신 의뢰서 상세 | ✅ |

### 신규 Entity / Infrastructure
| 파일 | 설명 |
|------|------|
| `Brief` | BaseEntity 상속, ENUM(`brief_status`, `privacy_setting`) columnDefinition 적용 |
| `BriefDelivery` | 독립 엔티티, `create()` / `accept()` / `reject()` / `markViewed()` |
| `LawyerProfile` | BaseEntity 상속, ENUM(`verification_status`) columnDefinition 적용 |
| `BriefReader/Writer` | Clean Architecture Reader/Writer 패턴 |
| `LawyerReader` | VERIFIED 변호사 페이징 조회 지원 |

---

## 🛡️ 검증 로직

| 검증 | 설명 |
|------|------|
| 소유자 검증 | 본인 의뢰서만 조회/수정/전달 가능 |
| 상태 검증 | DRAFT 상태에서만 수정 가능 (`BriefAlreadyConfirmedException`) |
| 전달 검증 | CONFIRMED 상태에서만 전달 가능 (`BRIEF_NOT_CONFIRMED`) |
| 중복 방지 | 같은 변호사에게 중복 전달 차단 (`DELIVERY_ALREADY_EXISTS`) |
| 개인정보 | PUBLIC: 이름+이메일 노출 / PARTIAL: 이름 마스킹(`홍**`) + 이메일 미노출 |
| 열람 기록 | 변호사 상세 조회 시 `viewedAt` 자동 갱신 |

---

## ⚠️ Breaking Changes / Migration

- **`.env` 필수 항목 추가**: `JWT_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`
- **Supabase**: `briefs`, `deliveries`, `lawyers` 테이블 이미 존재. 추가 마이그레이션 없음
- **상담 API 인증 변경**: 기존 하드코딩 userId → JWT 필수. Swagger 테스트 시 `Authorize` 버튼으로 토큰 입력 필요
- **테스트용 로그인**: `POST /api/auth/dev/login` → `{"email":"test@test.com","name":"tester","role":"USER"}`

---

## ✅ 테스트 결과

| # | API | 결과 |
|---|-----|------|
| 1 | `POST /api/auth/dev/login` (USER) | ✅ |
| 2 | `POST /api/auth/dev/login` (LAWYER) | ✅ |
| 3 | `GET /api/consultations/legal-fields` | ✅ |
| 4 | `POST /api/consultations` (JWT 인증) | ✅ |
| 5 | `POST /api/consultations/{id}/messages` | ✅ |
| 6 | `GET /api/consultations/{id}/messages` | ✅ |
| 7 | `GET /api/briefs` | ✅ |
| 8 | `GET /api/briefs/{briefId}` | ✅ |
| 9 | `POST /api/briefs/{briefId}/deliveries` | ✅ |
| 10 | `GET /api/briefs/{briefId}/deliveries` | ✅ |
| 11 | `GET /api/lawyer/inbox` | ✅ |
| 12 | `GET /api/lawyer/inbox/{deliveryId}` (마스킹 확인) | ✅ |
| 13 | `GET /api/briefs/{briefId}/lawyer-recommendations` | ✅ |
| 14 | 중복 전달 차단 | ✅ |
| 15 | DELIVERED 상태 수정 차단 | ✅ |

---

## 📝 TODO (추후 구현)
- 변호사 매칭: AI 서버 벡터DB 유사도 검색으로 교체
- 개인정보 마스킹: 전체공개/부분공개 정책 세분화 (API 명세 확정 후)
- 메시지 전송: 목 AI 응답 → 실제 AI 연동