### PR TITLE
[FEAT] 관리자(Admin) API + DB 확장 구현 (#12)

### DIFF
--- a/src/main/java/org/example/shield/admin/application/AdminService.java
+++ b/src/main/java/org/example/shield/admin/application/AdminService.java
@@ -1,16 +1,20 @@
 package org.example.shield.admin.application;
 
 /**
- * 관리자 서비스 - 변호사 검증 + 상담 모니터링.
+ * 관리자 서비스 — 대시보드, 변호사 심사, 처리 이력.
  *
  * Layer: application
  * Called by: AdminController
- * Calls: LawyerProfileRepository, ConsultationRepository, VerificationService
+ * Calls: LawyerReader, LawyerWriter, UserReader, VerificationCheckReader,
+ *        VerificationLogWriter, LawyerDocumentReader
  *
- * TODO:
- * - getPendingLawyers(pageable): verificationStatus = PENDING인 변호사 목록
- * - processVerification(lawyerId, action, reason): VerificationService 위임
- * - getConsultations(pageable, status): 전체 상담 현황 (차후 구현)
+ * TODO: getDashboardStats()                          — 상태별 카운트 조회
+ * TODO: getDashboardAlerts()                         — 긴급 알림 (24시간 미처리, 서류 누락, 중복 의심)
+ * TODO: getPendingLawyers(keyword, status, page, size) — 심사 목록 (검색 + 필터 + 페이징)
+ * TODO: processVerification(lawyerId, adminId, status, reason) — 승인/보완요청/거절 + 로그 자동 생성
+ * TODO: getVerificationChecks(lawyerId)              — 자동 검증 결과 조회
+ * TODO: getVerificationLogs(period, status, page, size) — 처리 이력 조회
+ * TODO: getLawyerDocuments(lawyerId)                  — 변호사 서류 목록 조회
  */
 public class AdminService {
 }

--- a/src/main/java/org/example/shield/admin/application/AdminService.java
+++ b/src/main/java/org/example/shield/admin/application/AdminService.java
@@ -7,9 +7,11 @@ import org.example.shield.admin.controller.dto.DashboardStatsResponse;
 import org.example.shield.admin.controller.dto.LawyerDetailResponse;
 import org.example.shield.admin.controller.dto.PendingLawyerResponse;
 import org.example.shield.admin.controller.dto.VerificationChecksResponse;
+import org.example.shield.admin.controller.dto.VerificationLogResponse;
 import org.example.shield.admin.controller.dto.VerificationResponse;
 import org.example.shield.admin.domain.VerificationCheckReader;
 import org.example.shield.admin.domain.VerificationLog;
+import org.example.shield.admin.domain.VerificationLogReader;
 import org.example.shield.admin.domain.VerificationLogWriter;
 import org.example.shield.admin.infrastructure.VerificationLogRepository;
 import org.example.shield.common.enums.VerificationStatus;
@@ -47,6 +49,7 @@ public class AdminService {
     private final LawyerDocumentRepository lawyerDocumentRepository;
     private final LawyerProfileRepository lawyerProfileRepository;
     private final VerificationLogWriter verificationLogWriter;
+    private final VerificationLogReader verificationLogReader;
     private final VerificationLogRepository verificationLogRepository;
     private final VerificationCheckReader verificationCheckReader;
 
@@ -74,6 +77,67 @@ public class AdminService {
         long duplicateSuspectCount = lawyerProfileRepository.countDuplicateBarNumbers();
 
         return new DashboardAlertsResponse(overdueCount, missingDocumentCount, duplicateSuspectCount);
+    }
+
+    public PageResponse<VerificationLogResponse> getVerificationLogs(String period, String status,
+                                                                      Pageable pageable) {
+        log.info("처리 이력 조회. period={}, status={}", period, status);
+
+        LocalDateTime after = resolvePeriod(period);
+        Page<VerificationLog> logPage;
+
+        if (status != null && after != null) {
+            logPage = verificationLogReader.findAllByToStatusAndCreatedAtAfter(status, after, pageable);
+        } else if (status != null) {
+            logPage = verificationLogReader.findAllByToStatus(status, pageable);
+        } else if (after != null) {
+            logPage = verificationLogReader.findAllByCreatedAtAfter(after, pageable);
+        } else {
+            logPage = verificationLogReader.findAll(pageable);
+        }
+
+        List<VerificationLog> logs = logPage.getContent();
+        if (logs.isEmpty()) {
+            return PageResponse.from(logPage.map(l -> null));
+        }
+
+        List<UUID> lawyerIds = logs.stream().map(VerificationLog::getLawyerId).distinct().toList();
+        Map<UUID, LawyerProfile> lawyerMap = lawyerIds.stream()
+                .collect(Collectors.toMap(id -> id, lawyerReader::findById));
+
+        List<UUID> allUserIds = new java.util.ArrayList<>();
+        lawyerMap.values().forEach(lp -> allUserIds.add(lp.getUserId()));
+        logs.forEach(l -> allUserIds.add(l.getAdminId()));
+
+        Map<UUID, User> userMap = userReader.findAllByIds(allUserIds.stream().distinct().toList()).stream()
+                .collect(Collectors.toMap(User::getId, u -> u));
+
+        Page<VerificationLogResponse> responsePage = logPage.map(vlog -> {
+            LawyerProfile lawyer = lawyerMap.get(vlog.getLawyerId());
+            User lawyerUser = userMap.get(lawyer.getUserId());
+            User admin = userMap.get(vlog.getAdminId());
+            return new VerificationLogResponse(
+                    vlog.getId(),
+                    lawyerUser != null ? lawyerUser.getName() : null,
+                    vlog.getFromStatus(),
+                    vlog.getToStatus(),
+                    lawyer.getSpecializations(),
+                    admin != null ? admin.getName() : null,
+                    vlog.getReason(),
+                    vlog.getCreatedAt()
+            );
+        });
+
+        return PageResponse.from(responsePage);
+    }
+
+    private LocalDateTime resolvePeriod(String period) {
+        if (period == null) return null;
+        return switch (period.toLowerCase()) {
+            case "today" -> LocalDate.now().atStartOfDay();
+            case "week" -> LocalDate.now().minusDays(7).atStartOfDay();
+            default -> null;
+        };
     }
 
     public PageResponse<PendingLawyerResponse> getPendingLawyers(String keyword, String status,

--- a/src/main/java/org/example/shield/admin/application/AdminService.java
+++ b/src/main/java/org/example/shield/admin/application/AdminService.java
@@ -2,6 +2,7 @@ package org.example.shield.admin.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.shield.admin.controller.dto.DashboardAlertsResponse;
 import org.example.shield.admin.controller.dto.DashboardStatsResponse;
 import org.example.shield.admin.controller.dto.LawyerDetailResponse;
 import org.example.shield.admin.controller.dto.PendingLawyerResponse;
@@ -19,6 +20,7 @@ import org.example.shield.lawyer.domain.LawyerProfile;
 import org.example.shield.lawyer.domain.LawyerReader;
 import org.example.shield.lawyer.domain.LawyerWriter;
 import org.example.shield.lawyer.infrastructure.LawyerDocumentRepository;
+import org.example.shield.lawyer.infrastructure.LawyerProfileRepository;
 import org.example.shield.user.domain.User;
 import org.example.shield.user.domain.UserReader;
 import org.springframework.data.domain.Page;
@@ -43,6 +45,7 @@ public class AdminService {
     private final LawyerWriter lawyerWriter;
     private final UserReader userReader;
     private final LawyerDocumentRepository lawyerDocumentRepository;
+    private final LawyerProfileRepository lawyerProfileRepository;
     private final VerificationLogWriter verificationLogWriter;
     private final VerificationLogRepository verificationLogRepository;
     private final VerificationCheckReader verificationCheckReader;
@@ -59,6 +62,18 @@ public class AdminService {
                 todayStart, List.of("VERIFIED", "REJECTED"));
 
         return new DashboardStatsResponse(pendingCount, reviewingCount, supplementRequestedCount, todayProcessedCount);
+    }
+
+    public DashboardAlertsResponse getDashboardAlerts() {
+        log.info("대시보드 긴급 알림 조회");
+
+        LocalDateTime twentyFourHoursAgo = LocalDateTime.now().minusHours(24);
+        long overdueCount = lawyerProfileRepository.countByVerificationStatusAndCreatedAtBefore(
+                VerificationStatus.PENDING, twentyFourHoursAgo);
+        long missingDocumentCount = lawyerProfileRepository.countMissingDocuments();
+        long duplicateSuspectCount = lawyerProfileRepository.countDuplicateBarNumbers();
+
+        return new DashboardAlertsResponse(overdueCount, missingDocumentCount, duplicateSuspectCount);
     }
 
     public PageResponse<PendingLawyerResponse> getPendingLawyers(String keyword, String status,

--- a/src/main/java/org/example/shield/admin/application/AdminService.java
+++ b/src/main/java/org/example/shield/admin/application/AdminService.java
@@ -2,6 +2,7 @@ package org.example.shield.admin.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.shield.admin.controller.dto.LawyerDetailResponse;
 import org.example.shield.admin.controller.dto.PendingLawyerResponse;
 import org.example.shield.common.response.PageResponse;
 import org.example.shield.lawyer.domain.LawyerProfile;
@@ -41,14 +42,12 @@ public class AdminService {
             return PageResponse.from(lawyerPage.map(lp -> null));
         }
 
-        // N+1 방지: batch fetch users
         List<UUID> userIds = lawyers.stream()
                 .map(LawyerProfile::getUserId)
                 .toList();
         Map<UUID, User> userMap = userReader.findAllByIds(userIds).stream()
                 .collect(Collectors.toMap(User::getId, u -> u));
 
-        // N+1 방지: batch fetch document counts
         List<UUID> lawyerIds = lawyers.stream()
                 .map(LawyerProfile::getId)
                 .toList();
@@ -67,4 +66,10 @@ public class AdminService {
         return PageResponse.from(responsePage);
     }
 
+    public LawyerDetailResponse getLawyerDetail(UUID lawyerId) {
+        log.info("변호사 상세 조회. lawyerId={}", lawyerId);
+        LawyerProfile lawyer = lawyerReader.findById(lawyerId);
+        User user = userReader.findById(lawyer.getUserId());
+        return LawyerDetailResponse.from(lawyer, user);
+    }
 }

--- a/src/main/java/org/example/shield/admin/application/AdminService.java
+++ b/src/main/java/org/example/shield/admin/application/AdminService.java
@@ -2,6 +2,7 @@ package org.example.shield.admin.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.shield.admin.controller.dto.DashboardStatsResponse;
 import org.example.shield.admin.controller.dto.LawyerDetailResponse;
 import org.example.shield.admin.controller.dto.PendingLawyerResponse;
 import org.example.shield.admin.controller.dto.VerificationChecksResponse;
@@ -9,6 +10,7 @@ import org.example.shield.admin.controller.dto.VerificationResponse;
 import org.example.shield.admin.domain.VerificationCheckReader;
 import org.example.shield.admin.domain.VerificationLog;
 import org.example.shield.admin.domain.VerificationLogWriter;
+import org.example.shield.admin.infrastructure.VerificationLogRepository;
 import org.example.shield.common.enums.VerificationStatus;
 import org.example.shield.common.exception.BusinessException;
 import org.example.shield.common.exception.ErrorCode;
@@ -24,6 +26,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -40,7 +44,22 @@ public class AdminService {
     private final UserReader userReader;
     private final LawyerDocumentRepository lawyerDocumentRepository;
     private final VerificationLogWriter verificationLogWriter;
+    private final VerificationLogRepository verificationLogRepository;
     private final VerificationCheckReader verificationCheckReader;
+
+    public DashboardStatsResponse getDashboardStats() {
+        log.info("대시보드 통계 조회");
+
+        long pendingCount = lawyerReader.countByVerificationStatus(VerificationStatus.PENDING);
+        long reviewingCount = lawyerReader.countByVerificationStatus(VerificationStatus.REVIEWING);
+        long supplementRequestedCount = lawyerReader.countByVerificationStatus(VerificationStatus.SUPPLEMENT_REQUESTED);
+
+        LocalDateTime todayStart = LocalDate.now().atStartOfDay();
+        long todayProcessedCount = verificationLogRepository.countByCreatedAtAfterAndToStatusIn(
+                todayStart, List.of("VERIFIED", "REJECTED"));
+
+        return new DashboardStatsResponse(pendingCount, reviewingCount, supplementRequestedCount, todayProcessedCount);
+    }
 
     public PageResponse<PendingLawyerResponse> getPendingLawyers(String keyword, String status,
                                                                   Pageable pageable) {

--- a/src/main/java/org/example/shield/admin/application/AdminService.java
+++ b/src/main/java/org/example/shield/admin/application/AdminService.java
@@ -4,9 +4,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.shield.admin.controller.dto.LawyerDetailResponse;
 import org.example.shield.admin.controller.dto.PendingLawyerResponse;
+import org.example.shield.admin.controller.dto.VerificationResponse;
+import org.example.shield.admin.domain.VerificationLog;
+import org.example.shield.admin.domain.VerificationLogWriter;
+import org.example.shield.common.enums.VerificationStatus;
+import org.example.shield.common.exception.BusinessException;
+import org.example.shield.common.exception.ErrorCode;
 import org.example.shield.common.response.PageResponse;
 import org.example.shield.lawyer.domain.LawyerProfile;
 import org.example.shield.lawyer.domain.LawyerReader;
+import org.example.shield.lawyer.domain.LawyerWriter;
 import org.example.shield.lawyer.infrastructure.LawyerDocumentRepository;
 import org.example.shield.user.domain.User;
 import org.example.shield.user.domain.UserReader;
@@ -27,8 +34,10 @@ import java.util.stream.Collectors;
 public class AdminService {
 
     private final LawyerReader lawyerReader;
+    private final LawyerWriter lawyerWriter;
     private final UserReader userReader;
     private final LawyerDocumentRepository lawyerDocumentRepository;
+    private final VerificationLogWriter verificationLogWriter;
 
     public PageResponse<PendingLawyerResponse> getPendingLawyers(String keyword, String status,
                                                                   Pageable pageable) {
@@ -71,5 +80,46 @@ public class AdminService {
         LawyerProfile lawyer = lawyerReader.findById(lawyerId);
         User user = userReader.findById(lawyer.getUserId());
         return LawyerDetailResponse.from(lawyer, user);
+    }
+
+    @Transactional
+    public VerificationResponse processVerification(UUID lawyerId, UUID adminId,
+                                                     String statusStr, String reason) {
+        log.info("변호사 인증 처리. lawyerId={}, adminId={}, status={}", lawyerId, adminId, statusStr);
+
+        LawyerProfile lawyer = lawyerReader.findById(lawyerId);
+        String previousStatus = lawyer.getVerificationStatus().name();
+
+        VerificationStatus newStatus = parseVerificationStatus(statusStr);
+        validateReasonRequired(newStatus, reason);
+
+        lawyer.updateVerificationStatus(newStatus);
+        lawyerWriter.save(lawyer);
+
+        VerificationLog log = VerificationLog.create(lawyerId, adminId, previousStatus, newStatus.name(), reason);
+        verificationLogWriter.save(log);
+
+        return new VerificationResponse(
+                lawyerId,
+                previousStatus,
+                newStatus.name(),
+                reason,
+                log.getCreatedAt()
+        );
+    }
+
+    private VerificationStatus parseVerificationStatus(String status) {
+        try {
+            return VerificationStatus.valueOf(status.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE) {};
+        }
+    }
+
+    private void validateReasonRequired(VerificationStatus status, String reason) {
+        if ((status == VerificationStatus.REJECTED || status == VerificationStatus.SUPPLEMENT_REQUESTED)
+                && (reason == null || reason.isBlank())) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE) {};
+        }
     }
 }

--- a/src/main/java/org/example/shield/admin/application/AdminService.java
+++ b/src/main/java/org/example/shield/admin/application/AdminService.java
@@ -1,20 +1,70 @@
 package org.example.shield.admin.application;
 
-/**
- * 관리자 서비스 — 대시보드, 변호사 심사, 처리 이력.
- *
- * Layer: application
- * Called by: AdminController
- * Calls: LawyerReader, LawyerWriter, UserReader, VerificationCheckReader,
- *        VerificationLogWriter, LawyerDocumentReader
- *
- * TODO: getDashboardStats()                          — 상태별 카운트 조회
- * TODO: getDashboardAlerts()                         — 긴급 알림 (24시간 미처리, 서류 누락, 중복 의심)
- * TODO: getPendingLawyers(keyword, status, page, size) — 심사 목록 (검색 + 필터 + 페이징)
- * TODO: processVerification(lawyerId, adminId, status, reason) — 승인/보완요청/거절 + 로그 자동 생성
- * TODO: getVerificationChecks(lawyerId)              — 자동 검증 결과 조회
- * TODO: getVerificationLogs(period, status, page, size) — 처리 이력 조회
- * TODO: getLawyerDocuments(lawyerId)                  — 변호사 서류 목록 조회
- */
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.shield.admin.controller.dto.PendingLawyerResponse;
+import org.example.shield.common.response.PageResponse;
+import org.example.shield.lawyer.domain.LawyerProfile;
+import org.example.shield.lawyer.domain.LawyerReader;
+import org.example.shield.lawyer.infrastructure.LawyerDocumentRepository;
+import org.example.shield.user.domain.User;
+import org.example.shield.user.domain.UserReader;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AdminService {
+
+    private final LawyerReader lawyerReader;
+    private final UserReader userReader;
+    private final LawyerDocumentRepository lawyerDocumentRepository;
+
+    public PageResponse<PendingLawyerResponse> getPendingLawyers(String keyword, String status,
+                                                                  Pageable pageable) {
+        log.info("변호사 심사 목록 조회. keyword={}, status={}", keyword, status);
+
+        Page<LawyerProfile> lawyerPage = lawyerReader.searchByStatusAndKeyword(
+                status, keyword, pageable);
+
+        List<LawyerProfile> lawyers = lawyerPage.getContent();
+        if (lawyers.isEmpty()) {
+            return PageResponse.from(lawyerPage.map(lp -> null));
+        }
+
+        // N+1 방지: batch fetch users
+        List<UUID> userIds = lawyers.stream()
+                .map(LawyerProfile::getUserId)
+                .toList();
+        Map<UUID, User> userMap = userReader.findAllByIds(userIds).stream()
+                .collect(Collectors.toMap(User::getId, u -> u));
+
+        // N+1 방지: batch fetch document counts
+        List<UUID> lawyerIds = lawyers.stream()
+                .map(LawyerProfile::getId)
+                .toList();
+        Map<UUID, Long> documentCountMap = lawyerDocumentRepository.countByLawyerIds(lawyerIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (UUID) row[0],
+                        row -> (Long) row[1]
+                ));
+
+        Page<PendingLawyerResponse> responsePage = lawyerPage.map(lawyer -> {
+            User user = userMap.get(lawyer.getUserId());
+            long docCount = documentCountMap.getOrDefault(lawyer.getId(), 0L);
+            return PendingLawyerResponse.from(lawyer, user, docCount);
+        });
+
+        return PageResponse.from(responsePage);
+    }
+
 }

--- a/src/main/java/org/example/shield/admin/application/AdminService.java
+++ b/src/main/java/org/example/shield/admin/application/AdminService.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.shield.admin.controller.dto.LawyerDetailResponse;
 import org.example.shield.admin.controller.dto.PendingLawyerResponse;
+import org.example.shield.admin.controller.dto.VerificationChecksResponse;
 import org.example.shield.admin.controller.dto.VerificationResponse;
+import org.example.shield.admin.domain.VerificationCheckReader;
 import org.example.shield.admin.domain.VerificationLog;
 import org.example.shield.admin.domain.VerificationLogWriter;
 import org.example.shield.common.enums.VerificationStatus;
@@ -38,6 +40,7 @@ public class AdminService {
     private final UserReader userReader;
     private final LawyerDocumentRepository lawyerDocumentRepository;
     private final VerificationLogWriter verificationLogWriter;
+    private final VerificationCheckReader verificationCheckReader;
 
     public PageResponse<PendingLawyerResponse> getPendingLawyers(String keyword, String status,
                                                                   Pageable pageable) {
@@ -106,6 +109,13 @@ public class AdminService {
                 reason,
                 log.getCreatedAt()
         );
+    }
+
+    public VerificationChecksResponse getVerificationChecks(UUID lawyerId) {
+        log.info("검증 체크리스트 조회. lawyerId={}", lawyerId);
+        return verificationCheckReader.findOptionalByLawyerId(lawyerId)
+                .map(VerificationChecksResponse::from)
+                .orElse(VerificationChecksResponse.empty(lawyerId));
     }
 
     private VerificationStatus parseVerificationStatus(String status) {

--- a/src/main/java/org/example/shield/admin/controller/AdminController.java
+++ b/src/main/java/org/example/shield/admin/controller/AdminController.java
@@ -10,6 +10,7 @@ import org.example.shield.admin.controller.dto.DashboardStatsResponse;
 import org.example.shield.admin.controller.dto.LawyerDetailResponse;
 import org.example.shield.admin.controller.dto.PendingLawyerResponse;
 import org.example.shield.admin.controller.dto.VerificationChecksResponse;
+import org.example.shield.admin.controller.dto.VerificationLogResponse;
 import org.example.shield.admin.controller.dto.VerificationRequest;
 import org.example.shield.admin.controller.dto.VerificationResponse;
 import org.example.shield.common.response.ApiResponse;
@@ -99,6 +100,17 @@ public class AdminController {
         return ApiResponse.success("조회 성공", result);
     }
 
-    // TODO: GET  /api/admin/verification-logs                      — 처리 이력
+    @Operation(summary = "처리 이력 조회", description = "변호사 인증 상태 변경 이력을 조회합니다 (기간/상태 필터, 페이징)")
+    @GetMapping("/verification-logs")
+    public ApiResponse<PageResponse<VerificationLogResponse>> getVerificationLogs(
+            @RequestParam(required = false) String period,
+            @RequestParam(required = false) String status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        PageResponse<VerificationLogResponse> result = adminService.getVerificationLogs(period, status, pageable);
+        return ApiResponse.success("조회 성공", result);
+    }
+
     // TODO: GET  /api/admin/consultations                          — 상담 모니터링 (차후)
 }

--- a/src/main/java/org/example/shield/admin/controller/AdminController.java
+++ b/src/main/java/org/example/shield/admin/controller/AdminController.java
@@ -4,15 +4,21 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.shield.admin.application.AdminService;
+import jakarta.validation.Valid;
 import org.example.shield.admin.controller.dto.LawyerDetailResponse;
 import org.example.shield.admin.controller.dto.PendingLawyerResponse;
+import org.example.shield.admin.controller.dto.VerificationRequest;
+import org.example.shield.admin.controller.dto.VerificationResponse;
 import org.example.shield.common.response.ApiResponse;
 import org.example.shield.common.response.PageResponse;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -47,9 +53,19 @@ public class AdminController {
         return ApiResponse.success("조회 성공", result);
     }
 
+    @Operation(summary = "변호사 인증 심사 처리", description = "변호사 인증 상태를 변경합니다 (승인/검토 중/보완요청/거절)")
+    @PatchMapping("/lawyers/{lawyerId}/verification")
+    public ApiResponse<VerificationResponse> processVerification(
+            @PathVariable UUID lawyerId,
+            @AuthenticationPrincipal UUID adminId,
+            @Valid @RequestBody VerificationRequest request) {
+        VerificationResponse result = adminService.processVerification(
+                lawyerId, adminId, request.status(), request.reason());
+        return ApiResponse.success("처리 완료", result);
+    }
+
     // TODO: GET  /api/admin/dashboard/stats                        — 대시보드 통계
     // TODO: GET  /api/admin/dashboard/alerts                       — 긴급 알림
-    // TODO: PATCH /api/admin/lawyers/{lawyerId}/verification       — 승인/보완요청/거절
     // TODO: GET  /api/admin/lawyers/{lawyerId}/verification-checks — 자동 검증 결과
     // TODO: GET  /api/admin/lawyers/{lawyerId}/documents           — 서류 조회
     // TODO: GET  /api/admin/verification-logs                      — 처리 이력

--- a/src/main/java/org/example/shield/admin/controller/AdminController.java
+++ b/src/main/java/org/example/shield/admin/controller/AdminController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.shield.admin.application.AdminService;
+import org.example.shield.admin.controller.dto.LawyerDetailResponse;
 import org.example.shield.admin.controller.dto.PendingLawyerResponse;
 import org.example.shield.common.response.ApiResponse;
 import org.example.shield.common.response.PageResponse;
@@ -11,9 +12,12 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
 
 @Tag(name = "Admin", description = "관리자 API")
 @RestController
@@ -33,6 +37,13 @@ public class AdminController {
             @RequestParam(defaultValue = "20") int size) {
         Pageable pageable = PageRequest.of(page, size);
         PageResponse<PendingLawyerResponse> result = adminService.getPendingLawyers(keyword, status, pageable);
+        return ApiResponse.success("조회 성공", result);
+    }
+
+    @Operation(summary = "변호사 가입 신청 상세", description = "변호사의 상세 프로필 정보를 조회합니다 (관리자 전용)")
+    @GetMapping("/lawyers/{lawyerId}")
+    public ApiResponse<LawyerDetailResponse> getLawyerDetail(@PathVariable UUID lawyerId) {
+        LawyerDetailResponse result = adminService.getLawyerDetail(lawyerId);
         return ApiResponse.success("조회 성공", result);
     }
 

--- a/src/main/java/org/example/shield/admin/controller/AdminController.java
+++ b/src/main/java/org/example/shield/admin/controller/AdminController.java
@@ -7,10 +7,16 @@ package org.example.shield.admin.controller;
  * Called by: 프론트엔드 (관리자 화면)
  * Calls: AdminService
  *
- * API 목록 (3개, 전부 차후 구현):
- * - GET   /api/admin/lawyers/pending              검증 대기 변호사 목록
- * - PATCH /api/admin/lawyers/{lawyerId}/verification  변호사 검증 처리
- * - GET   /api/admin/consultations                상담 모니터링
+ * API 목록 (Issue #12):
+ *
+ * TODO: GET  /api/admin/dashboard/stats                        — 대시보드 통계 (승인 대기/검토 중/보완 요청/오늘 처리 카운트)
+ * TODO: GET  /api/admin/dashboard/alerts                       — 긴급 알림 (24시간 미처리/서류 누락/중복 의심)
+ * TODO: GET  /api/admin/lawyers/pending                        — 변호사 가입 심사 목록 (검색 + 상태 필터 + 페이징)
+ * TODO: PATCH /api/admin/lawyers/{lawyerId}/verification       — 승인/보완요청/거절 처리 → verification_logs 자동 생성
+ * TODO: GET  /api/admin/lawyers/{lawyerId}/verification-checks — 자동 검증 결과 + 체크리스트 조회
+ * TODO: GET  /api/admin/lawyers/{lawyerId}/documents           — 변호사 서류 조회/다운로드
+ * TODO: GET  /api/admin/verification-logs                      — 처리 이력 (기간/상태 필터 + 페이징)
+ * TODO: GET  /api/admin/consultations                          — 상담 모니터링 (차후 구현)
  */
 public class AdminController {
 }

--- a/src/main/java/org/example/shield/admin/controller/AdminController.java
+++ b/src/main/java/org/example/shield/admin/controller/AdminController.java
@@ -7,6 +7,7 @@ import org.example.shield.admin.application.AdminService;
 import jakarta.validation.Valid;
 import org.example.shield.admin.controller.dto.LawyerDetailResponse;
 import org.example.shield.admin.controller.dto.PendingLawyerResponse;
+import org.example.shield.admin.controller.dto.VerificationChecksResponse;
 import org.example.shield.admin.controller.dto.VerificationRequest;
 import org.example.shield.admin.controller.dto.VerificationResponse;
 import org.example.shield.common.response.ApiResponse;
@@ -64,9 +65,15 @@ public class AdminController {
         return ApiResponse.success("처리 완료", result);
     }
 
+    @Operation(summary = "자동 검증 결과 조회", description = "변호사 인증 신청의 자동 검증 결과와 체크리스트를 조회합니다")
+    @GetMapping("/lawyers/{lawyerId}/verification-checks")
+    public ApiResponse<VerificationChecksResponse> getVerificationChecks(@PathVariable UUID lawyerId) {
+        VerificationChecksResponse result = adminService.getVerificationChecks(lawyerId);
+        return ApiResponse.success("조회 성공", result);
+    }
+
     // TODO: GET  /api/admin/dashboard/stats                        — 대시보드 통계
     // TODO: GET  /api/admin/dashboard/alerts                       — 긴급 알림
-    // TODO: GET  /api/admin/lawyers/{lawyerId}/verification-checks — 자동 검증 결과
     // TODO: GET  /api/admin/lawyers/{lawyerId}/documents           — 서류 조회
     // TODO: GET  /api/admin/verification-logs                      — 처리 이력
     // TODO: GET  /api/admin/consultations                          — 상담 모니터링 (차후)

--- a/src/main/java/org/example/shield/admin/controller/AdminController.java
+++ b/src/main/java/org/example/shield/admin/controller/AdminController.java
@@ -12,6 +12,8 @@ import org.example.shield.admin.controller.dto.VerificationRequest;
 import org.example.shield.admin.controller.dto.VerificationResponse;
 import org.example.shield.common.response.ApiResponse;
 import org.example.shield.common.response.PageResponse;
+import org.example.shield.lawyer.application.LawyerDocumentService;
+import org.example.shield.lawyer.controller.dto.DocumentResponse;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 import java.util.UUID;
 
 @Tag(name = "Admin", description = "관리자 API")
@@ -34,6 +37,7 @@ import java.util.UUID;
 public class AdminController {
 
     private final AdminService adminService;
+    private final LawyerDocumentService lawyerDocumentService;
 
     @Operation(summary = "변호사 가입 심사 목록", description = "검색, 상태 필터, 페이징을 지원하는 변호사 심사 목록을 조회합니다")
     @GetMapping("/lawyers/pending")
@@ -72,9 +76,15 @@ public class AdminController {
         return ApiResponse.success("조회 성공", result);
     }
 
+    @Operation(summary = "변호사 서류 조회", description = "변호사가 업로드한 서류 목록을 조회합니다")
+    @GetMapping("/lawyers/{lawyerId}/documents")
+    public ApiResponse<List<DocumentResponse>> getLawyerDocuments(@PathVariable UUID lawyerId) {
+        List<DocumentResponse> result = lawyerDocumentService.getDocuments(lawyerId);
+        return ApiResponse.success("조회 성공", result);
+    }
+
     // TODO: GET  /api/admin/dashboard/stats                        — 대시보드 통계
     // TODO: GET  /api/admin/dashboard/alerts                       — 긴급 알림
-    // TODO: GET  /api/admin/lawyers/{lawyerId}/documents           — 서류 조회
     // TODO: GET  /api/admin/verification-logs                      — 처리 이력
     // TODO: GET  /api/admin/consultations                          — 상담 모니터링 (차후)
 }

--- a/src/main/java/org/example/shield/admin/controller/AdminController.java
+++ b/src/main/java/org/example/shield/admin/controller/AdminController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.shield.admin.application.AdminService;
 import jakarta.validation.Valid;
+import org.example.shield.admin.controller.dto.DashboardAlertsResponse;
 import org.example.shield.admin.controller.dto.DashboardStatsResponse;
 import org.example.shield.admin.controller.dto.LawyerDetailResponse;
 import org.example.shield.admin.controller.dto.PendingLawyerResponse;
@@ -91,7 +92,13 @@ public class AdminController {
         return ApiResponse.success("조회 성공", result);
     }
 
-    // TODO: GET  /api/admin/dashboard/alerts                       — 긴급 알림
+    @Operation(summary = "대시보드 긴급 알림", description = "24시간 미처리, 서류 미제출, 중복 의심 건수를 조회합니다")
+    @GetMapping("/dashboard/alerts")
+    public ApiResponse<DashboardAlertsResponse> getDashboardAlerts() {
+        DashboardAlertsResponse result = adminService.getDashboardAlerts();
+        return ApiResponse.success("조회 성공", result);
+    }
+
     // TODO: GET  /api/admin/verification-logs                      — 처리 이력
     // TODO: GET  /api/admin/consultations                          — 상담 모니터링 (차후)
 }

--- a/src/main/java/org/example/shield/admin/controller/AdminController.java
+++ b/src/main/java/org/example/shield/admin/controller/AdminController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.shield.admin.application.AdminService;
 import jakarta.validation.Valid;
+import org.example.shield.admin.controller.dto.DashboardStatsResponse;
 import org.example.shield.admin.controller.dto.LawyerDetailResponse;
 import org.example.shield.admin.controller.dto.PendingLawyerResponse;
 import org.example.shield.admin.controller.dto.VerificationChecksResponse;
@@ -83,7 +84,13 @@ public class AdminController {
         return ApiResponse.success("조회 성공", result);
     }
 
-    // TODO: GET  /api/admin/dashboard/stats                        — 대시보드 통계
+    @Operation(summary = "대시보드 통계", description = "상태별 변호사 카운트 및 오늘 처리 건수를 조회합니다")
+    @GetMapping("/dashboard/stats")
+    public ApiResponse<DashboardStatsResponse> getDashboardStats() {
+        DashboardStatsResponse result = adminService.getDashboardStats();
+        return ApiResponse.success("조회 성공", result);
+    }
+
     // TODO: GET  /api/admin/dashboard/alerts                       — 긴급 알림
     // TODO: GET  /api/admin/verification-logs                      — 처리 이력
     // TODO: GET  /api/admin/consultations                          — 상담 모니터링 (차후)

--- a/src/main/java/org/example/shield/admin/controller/AdminController.java
+++ b/src/main/java/org/example/shield/admin/controller/AdminController.java
@@ -1,22 +1,46 @@
 package org.example.shield.admin.controller;
 
-/**
- * 관리자 API 컨트롤러.
- *
- * Layer: controller
- * Called by: 프론트엔드 (관리자 화면)
- * Calls: AdminService
- *
- * API 목록 (Issue #12):
- *
- * TODO: GET  /api/admin/dashboard/stats                        — 대시보드 통계 (승인 대기/검토 중/보완 요청/오늘 처리 카운트)
- * TODO: GET  /api/admin/dashboard/alerts                       — 긴급 알림 (24시간 미처리/서류 누락/중복 의심)
- * TODO: GET  /api/admin/lawyers/pending                        — 변호사 가입 심사 목록 (검색 + 상태 필터 + 페이징)
- * TODO: PATCH /api/admin/lawyers/{lawyerId}/verification       — 승인/보완요청/거절 처리 → verification_logs 자동 생성
- * TODO: GET  /api/admin/lawyers/{lawyerId}/verification-checks — 자동 검증 결과 + 체크리스트 조회
- * TODO: GET  /api/admin/lawyers/{lawyerId}/documents           — 변호사 서류 조회/다운로드
- * TODO: GET  /api/admin/verification-logs                      — 처리 이력 (기간/상태 필터 + 페이징)
- * TODO: GET  /api/admin/consultations                          — 상담 모니터링 (차후 구현)
- */
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.example.shield.admin.application.AdminService;
+import org.example.shield.admin.controller.dto.PendingLawyerResponse;
+import org.example.shield.common.response.ApiResponse;
+import org.example.shield.common.response.PageResponse;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Admin", description = "관리자 API")
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
 public class AdminController {
+
+    private final AdminService adminService;
+
+    @Operation(summary = "변호사 가입 심사 목록", description = "검색, 상태 필터, 페이징을 지원하는 변호사 심사 목록을 조회합니다")
+    @GetMapping("/lawyers/pending")
+    public ApiResponse<PageResponse<PendingLawyerResponse>> getPendingLawyers(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        PageResponse<PendingLawyerResponse> result = adminService.getPendingLawyers(keyword, status, pageable);
+        return ApiResponse.success("조회 성공", result);
+    }
+
+    // TODO: GET  /api/admin/dashboard/stats                        — 대시보드 통계
+    // TODO: GET  /api/admin/dashboard/alerts                       — 긴급 알림
+    // TODO: PATCH /api/admin/lawyers/{lawyerId}/verification       — 승인/보완요청/거절
+    // TODO: GET  /api/admin/lawyers/{lawyerId}/verification-checks — 자동 검증 결과
+    // TODO: GET  /api/admin/lawyers/{lawyerId}/documents           — 서류 조회
+    // TODO: GET  /api/admin/verification-logs                      — 처리 이력
+    // TODO: GET  /api/admin/consultations                          — 상담 모니터링 (차후)
 }

--- a/src/main/java/org/example/shield/admin/controller/dto/DashboardAlertsResponse.java
+++ b/src/main/java/org/example/shield/admin/controller/dto/DashboardAlertsResponse.java
@@ -1,0 +1,7 @@
+package org.example.shield.admin.controller.dto;
+
+public record DashboardAlertsResponse(
+        long overdueCount,
+        long missingDocumentCount,
+        long duplicateSuspectCount
+) {}

--- a/src/main/java/org/example/shield/admin/controller/dto/DashboardStatsResponse.java
+++ b/src/main/java/org/example/shield/admin/controller/dto/DashboardStatsResponse.java
@@ -1,0 +1,8 @@
+package org.example.shield.admin.controller.dto;
+
+public record DashboardStatsResponse(
+        long pendingCount,
+        long reviewingCount,
+        long supplementRequestedCount,
+        long todayProcessedCount
+) {}

--- a/src/main/java/org/example/shield/admin/controller/dto/LawyerDetailResponse.java
+++ b/src/main/java/org/example/shield/admin/controller/dto/LawyerDetailResponse.java
@@ -1,0 +1,46 @@
+package org.example.shield.admin.controller.dto;
+
+import org.example.shield.lawyer.domain.LawyerProfile;
+import org.example.shield.user.domain.User;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record LawyerDetailResponse(
+        UUID lawyerId,
+        UUID userId,
+        String name,
+        String email,
+        String phone,
+        String specializations,
+        Integer experienceYears,
+        List<String> certifications,
+        String barAssociationNumber,
+        String verificationStatus,
+        String region,
+        String bio,
+        Integer caseCount,
+        List<String> tags,
+        LocalDateTime createdAt
+) {
+    public static LawyerDetailResponse from(LawyerProfile lawyer, User user) {
+        return new LawyerDetailResponse(
+                lawyer.getId(),
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getPhone(),
+                lawyer.getSpecializations(),
+                lawyer.getExperienceYears(),
+                lawyer.getCertifications(),
+                lawyer.getBarAssociationNumber(),
+                lawyer.getVerificationStatus().name(),
+                lawyer.getRegion(),
+                lawyer.getBio(),
+                lawyer.getCaseCount(),
+                lawyer.getTags(),
+                lawyer.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/org/example/shield/admin/controller/dto/PendingLawyerResponse.java
+++ b/src/main/java/org/example/shield/admin/controller/dto/PendingLawyerResponse.java
@@ -1,16 +1,33 @@
 package org.example.shield.admin.controller.dto;
 
-/**
- * 검증 대기 변호사 응답 DTO.
- *
- * TODO:
- * - lawyerId: String
- * - name: String
- * - email: String
- * - specializations: List<String>
- * - experienceYears: int
- * - certifications: String
- * - barAssociationNumber: String
- */
-public class PendingLawyerResponse {
+import org.example.shield.lawyer.domain.LawyerProfile;
+import org.example.shield.user.domain.User;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record PendingLawyerResponse(
+        UUID lawyerId,
+        String name,
+        String email,
+        String phone,
+        String specializations,
+        Integer experienceYears,
+        String verificationStatus,
+        long documentCount,
+        LocalDateTime createdAt
+) {
+    public static PendingLawyerResponse from(LawyerProfile lawyer, User user, long documentCount) {
+        return new PendingLawyerResponse(
+                lawyer.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getPhone(),
+                lawyer.getSpecializations(),
+                lawyer.getExperienceYears(),
+                lawyer.getVerificationStatus().name(),
+                documentCount,
+                lawyer.getCreatedAt()
+        );
+    }
 }

--- a/src/main/java/org/example/shield/admin/controller/dto/VerificationChecksResponse.java
+++ b/src/main/java/org/example/shield/admin/controller/dto/VerificationChecksResponse.java
@@ -1,0 +1,53 @@
+package org.example.shield.admin.controller.dto;
+
+import org.example.shield.admin.domain.VerificationCheck;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record VerificationChecksResponse(
+        UUID lawyerId,
+        boolean emailDuplicate,
+        boolean phoneDuplicate,
+        boolean nameDuplicate,
+        boolean requiredFields,
+        boolean licenseVerified,
+        boolean documentMatched,
+        boolean specializationValid,
+        boolean experienceVerified,
+        boolean duplicateSignup,
+        boolean documentComplete,
+        int completedCount,
+        int totalCount,
+        LocalDateTime updatedAt
+) {
+    public static VerificationChecksResponse from(VerificationCheck check) {
+        return new VerificationChecksResponse(
+                check.getLawyerId(),
+                check.isEmailDuplicate(),
+                check.isPhoneDuplicate(),
+                check.isNameDuplicate(),
+                check.isRequiredFields(),
+                check.isLicenseVerified(),
+                check.isDocumentMatched(),
+                check.isSpecializationValid(),
+                check.isExperienceVerified(),
+                check.isDuplicateSignup(),
+                check.isDocumentComplete(),
+                check.getCompletedCount(),
+                check.getTotalCount(),
+                check.getUpdatedAt()
+        );
+    }
+
+    public static VerificationChecksResponse empty(UUID lawyerId) {
+        return new VerificationChecksResponse(
+                lawyerId,
+                false, false, false, false,
+                false, false, false, false,
+                false, false,
+                0, 10,
+                null
+        );
+    }
+}

--- a/src/main/java/org/example/shield/admin/controller/dto/VerificationLogResponse.java
+++ b/src/main/java/org/example/shield/admin/controller/dto/VerificationLogResponse.java
@@ -1,0 +1,15 @@
+package org.example.shield.admin.controller.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record VerificationLogResponse(
+        UUID logId,
+        String lawyerName,
+        String fromStatus,
+        String toStatus,
+        String specializations,
+        String adminName,
+        String reason,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/org/example/shield/admin/controller/dto/VerificationRequest.java
+++ b/src/main/java/org/example/shield/admin/controller/dto/VerificationRequest.java
@@ -1,11 +1,9 @@
 package org.example.shield.admin.controller.dto;
 
-/**
- * 변호사 검증 처리 요청 DTO.
- *
- * TODO:
- * - action: String (APPROVE / REJECT)
- * - reason: String (거절 시 사유, 선택)
- */
-public class VerificationRequest {
-}
+import jakarta.validation.constraints.NotBlank;
+
+public record VerificationRequest(
+        @NotBlank(message = "상태는 필수입니다")
+        String status,
+        String reason
+) {}

--- a/src/main/java/org/example/shield/admin/controller/dto/VerificationResponse.java
+++ b/src/main/java/org/example/shield/admin/controller/dto/VerificationResponse.java
@@ -1,0 +1,12 @@
+package org.example.shield.admin.controller.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record VerificationResponse(
+        UUID lawyerId,
+        String previousStatus,
+        String newStatus,
+        String reason,
+        LocalDateTime processedAt
+) {}

--- a/src/main/java/org/example/shield/admin/domain/VerificationCheck.java
+++ b/src/main/java/org/example/shield/admin/domain/VerificationCheck.java
@@ -1,0 +1,24 @@
+package org.example.shield.admin.domain;
+
+/**
+ * 변호사 자동 검증 결과 + 관리자 체크리스트 엔티티.
+ *
+ * Table: verification_checks
+ *
+ * TODO: @Entity 구현
+ * - id (UUID PK)
+ * - lawyerId (UUID FK → lawyers, UNIQUE 1:1)
+ * - emailDuplicate (boolean, 이메일 중복 없음)
+ * - phoneDuplicate (boolean, 전화번호 중복 없음)
+ * - nameDuplicate (boolean, 동일 이름 계정 없음)
+ * - requiredFields (boolean, 필수 항목 누락 없음)
+ * - licenseVerified (boolean, 변호사 자격 증빙 확인)
+ * - documentMatched (boolean, 서류 정보 일치)
+ * - specializationValid (boolean, 전문 분야 기재 적절)
+ * - experienceVerified (boolean, 경력 정보 확인)
+ * - duplicateSignup (boolean, 중복 가입 여부 확인)
+ * - documentComplete (boolean, 필수 서류 누락 없음)
+ * - updatedAt (LocalDateTime)
+ */
+public class VerificationCheck {
+}

--- a/src/main/java/org/example/shield/admin/domain/VerificationCheck.java
+++ b/src/main/java/org/example/shield/admin/domain/VerificationCheck.java
@@ -1,24 +1,108 @@
 package org.example.shield.admin.domain;
 
-/**
- * 변호사 자동 검증 결과 + 관리자 체크리스트 엔티티.
- *
- * Table: verification_checks
- *
- * TODO: @Entity 구현
- * - id (UUID PK)
- * - lawyerId (UUID FK → lawyers, UNIQUE 1:1)
- * - emailDuplicate (boolean, 이메일 중복 없음)
- * - phoneDuplicate (boolean, 전화번호 중복 없음)
- * - nameDuplicate (boolean, 동일 이름 계정 없음)
- * - requiredFields (boolean, 필수 항목 누락 없음)
- * - licenseVerified (boolean, 변호사 자격 증빙 확인)
- * - documentMatched (boolean, 서류 정보 일치)
- * - specializationValid (boolean, 전문 분야 기재 적절)
- * - experienceVerified (boolean, 경력 정보 확인)
- * - duplicateSignup (boolean, 중복 가입 여부 확인)
- * - documentComplete (boolean, 필수 서류 누락 없음)
- * - updatedAt (LocalDateTime)
- */
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "verification_checks")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class VerificationCheck {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private UUID lawyerId;
+
+    @Column(nullable = false)
+    private boolean emailDuplicate;
+
+    @Column(nullable = false)
+    private boolean phoneDuplicate;
+
+    @Column(nullable = false)
+    private boolean nameDuplicate;
+
+    @Column(nullable = false)
+    private boolean requiredFields;
+
+    @Column(nullable = false)
+    private boolean licenseVerified;
+
+    @Column(nullable = false)
+    private boolean documentMatched;
+
+    @Column(nullable = false)
+    private boolean specializationValid;
+
+    @Column(nullable = false)
+    private boolean experienceVerified;
+
+    @Column(nullable = false)
+    private boolean duplicateSignup;
+
+    @Column(nullable = false)
+    private boolean documentComplete;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static VerificationCheck create(UUID lawyerId) {
+        VerificationCheck check = new VerificationCheck();
+        check.lawyerId = lawyerId;
+        check.updatedAt = LocalDateTime.now();
+        return check;
+    }
+
+    public void updateAutoChecks(boolean emailDuplicate, boolean phoneDuplicate,
+                                 boolean nameDuplicate, boolean requiredFields) {
+        this.emailDuplicate = emailDuplicate;
+        this.phoneDuplicate = phoneDuplicate;
+        this.nameDuplicate = nameDuplicate;
+        this.requiredFields = requiredFields;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateManualChecks(boolean licenseVerified, boolean documentMatched,
+                                   boolean specializationValid, boolean experienceVerified,
+                                   boolean duplicateSignup, boolean documentComplete) {
+        this.licenseVerified = licenseVerified;
+        this.documentMatched = documentMatched;
+        this.specializationValid = specializationValid;
+        this.experienceVerified = experienceVerified;
+        this.duplicateSignup = duplicateSignup;
+        this.documentComplete = documentComplete;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public int getCompletedCount() {
+        int count = 0;
+        if (emailDuplicate) count++;
+        if (phoneDuplicate) count++;
+        if (nameDuplicate) count++;
+        if (requiredFields) count++;
+        if (licenseVerified) count++;
+        if (documentMatched) count++;
+        if (specializationValid) count++;
+        if (experienceVerified) count++;
+        if (duplicateSignup) count++;
+        if (documentComplete) count++;
+        return count;
+    }
+
+    public int getTotalCount() {
+        return 10;
+    }
 }

--- a/src/main/java/org/example/shield/admin/domain/VerificationCheckReader.java
+++ b/src/main/java/org/example/shield/admin/domain/VerificationCheckReader.java
@@ -1,0 +1,8 @@
+package org.example.shield.admin.domain;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface VerificationCheckReader {
+    Optional<VerificationCheck> findOptionalByLawyerId(UUID lawyerId);
+}

--- a/src/main/java/org/example/shield/admin/domain/VerificationCheckWriter.java
+++ b/src/main/java/org/example/shield/admin/domain/VerificationCheckWriter.java
@@ -1,0 +1,5 @@
+package org.example.shield.admin.domain;
+
+public interface VerificationCheckWriter {
+    VerificationCheck save(VerificationCheck check);
+}

--- a/src/main/java/org/example/shield/admin/domain/VerificationLog.java
+++ b/src/main/java/org/example/shield/admin/domain/VerificationLog.java
@@ -1,0 +1,18 @@
+package org.example.shield.admin.domain;
+
+/**
+ * 변호사 인증 상태 변경 이력 엔티티.
+ *
+ * Table: verification_logs
+ *
+ * TODO: @Entity 구현
+ * - id (UUID PK)
+ * - lawyerId (UUID FK → lawyers)
+ * - adminId (UUID FK → users, 처리한 관리자)
+ * - fromStatus (String, 이전 상태)
+ * - toStatus (String, 변경된 상태)
+ * - reason (String, 처리 사유)
+ * - createdAt (LocalDateTime)
+ */
+public class VerificationLog {
+}

--- a/src/main/java/org/example/shield/admin/domain/VerificationLog.java
+++ b/src/main/java/org/example/shield/admin/domain/VerificationLog.java
@@ -1,18 +1,70 @@
 package org.example.shield.admin.domain;
 
-/**
- * 변호사 인증 상태 변경 이력 엔티티.
- *
- * Table: verification_logs
- *
- * TODO: @Entity 구현
- * - id (UUID PK)
- * - lawyerId (UUID FK → lawyers)
- * - adminId (UUID FK → users, 처리한 관리자)
- * - fromStatus (String, 이전 상태)
- * - toStatus (String, 변경된 상태)
- * - reason (String, 처리 사유)
- * - createdAt (LocalDateTime)
- */
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "verification_logs")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class VerificationLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID lawyerId;
+
+    @Column(nullable = false)
+    private UUID adminId;
+
+    @Column(nullable = false, length = 30)
+    private String fromStatus;
+
+    @Column(nullable = false, length = 30)
+    private String toStatus;
+
+    @Column(columnDefinition = "text")
+    private String reason;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    private VerificationLog(UUID lawyerId, UUID adminId,
+                            String fromStatus, String toStatus, String reason) {
+        this.lawyerId = lawyerId;
+        this.adminId = adminId;
+        this.fromStatus = fromStatus;
+        this.toStatus = toStatus;
+        this.reason = reason;
+    }
+
+    public static VerificationLog create(UUID lawyerId, UUID adminId,
+                                         String fromStatus, String toStatus, String reason) {
+        return VerificationLog.builder()
+                .lawyerId(lawyerId)
+                .adminId(adminId)
+                .fromStatus(fromStatus)
+                .toStatus(toStatus)
+                .reason(reason)
+                .build();
+    }
 }

--- a/src/main/java/org/example/shield/admin/domain/VerificationLogReader.java
+++ b/src/main/java/org/example/shield/admin/domain/VerificationLogReader.java
@@ -1,0 +1,14 @@
+package org.example.shield.admin.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public interface VerificationLogReader {
+    Page<VerificationLog> findAll(Pageable pageable);
+    Page<VerificationLog> findAllByToStatus(String toStatus, Pageable pageable);
+    Page<VerificationLog> findAllByCreatedAtAfter(LocalDateTime after, Pageable pageable);
+    Page<VerificationLog> findAllByToStatusAndCreatedAtAfter(String toStatus, LocalDateTime after, Pageable pageable);
+}

--- a/src/main/java/org/example/shield/admin/domain/VerificationLogWriter.java
+++ b/src/main/java/org/example/shield/admin/domain/VerificationLogWriter.java
@@ -1,0 +1,5 @@
+package org.example.shield.admin.domain;
+
+public interface VerificationLogWriter {
+    VerificationLog save(VerificationLog log);
+}

--- a/src/main/java/org/example/shield/admin/infrastructure/VerificationCheckReaderImpl.java
+++ b/src/main/java/org/example/shield/admin/infrastructure/VerificationCheckReaderImpl.java
@@ -1,0 +1,21 @@
+package org.example.shield.admin.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.example.shield.admin.domain.VerificationCheck;
+import org.example.shield.admin.domain.VerificationCheckReader;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class VerificationCheckReaderImpl implements VerificationCheckReader {
+
+    private final VerificationCheckRepository verificationCheckRepository;
+
+    @Override
+    public Optional<VerificationCheck> findOptionalByLawyerId(UUID lawyerId) {
+        return verificationCheckRepository.findByLawyerId(lawyerId);
+    }
+}

--- a/src/main/java/org/example/shield/admin/infrastructure/VerificationCheckRepository.java
+++ b/src/main/java/org/example/shield/admin/infrastructure/VerificationCheckRepository.java
@@ -1,0 +1,11 @@
+package org.example.shield.admin.infrastructure;
+
+import org.example.shield.admin.domain.VerificationCheck;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface VerificationCheckRepository extends JpaRepository<VerificationCheck, UUID> {
+    Optional<VerificationCheck> findByLawyerId(UUID lawyerId);
+}

--- a/src/main/java/org/example/shield/admin/infrastructure/VerificationCheckWriterImpl.java
+++ b/src/main/java/org/example/shield/admin/infrastructure/VerificationCheckWriterImpl.java
@@ -1,0 +1,18 @@
+package org.example.shield.admin.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.example.shield.admin.domain.VerificationCheck;
+import org.example.shield.admin.domain.VerificationCheckWriter;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class VerificationCheckWriterImpl implements VerificationCheckWriter {
+
+    private final VerificationCheckRepository verificationCheckRepository;
+
+    @Override
+    public VerificationCheck save(VerificationCheck check) {
+        return verificationCheckRepository.save(check);
+    }
+}

--- a/src/main/java/org/example/shield/admin/infrastructure/VerificationLogReaderImpl.java
+++ b/src/main/java/org/example/shield/admin/infrastructure/VerificationLogReaderImpl.java
@@ -1,0 +1,38 @@
+package org.example.shield.admin.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.example.shield.admin.domain.VerificationLog;
+import org.example.shield.admin.domain.VerificationLogReader;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+@RequiredArgsConstructor
+public class VerificationLogReaderImpl implements VerificationLogReader {
+
+    private final VerificationLogRepository verificationLogRepository;
+
+    @Override
+    public Page<VerificationLog> findAll(Pageable pageable) {
+        return verificationLogRepository.findAll(pageable);
+    }
+
+    @Override
+    public Page<VerificationLog> findAllByToStatus(String toStatus, Pageable pageable) {
+        return verificationLogRepository.findAllByToStatus(toStatus, pageable);
+    }
+
+    @Override
+    public Page<VerificationLog> findAllByCreatedAtAfter(LocalDateTime after, Pageable pageable) {
+        return verificationLogRepository.findAllByCreatedAtAfter(after, pageable);
+    }
+
+    @Override
+    public Page<VerificationLog> findAllByToStatusAndCreatedAtAfter(String toStatus, LocalDateTime after,
+                                                                     Pageable pageable) {
+        return verificationLogRepository.findAllByToStatusAndCreatedAtAfter(toStatus, after, pageable);
+    }
+}

--- a/src/main/java/org/example/shield/admin/infrastructure/VerificationLogRepository.java
+++ b/src/main/java/org/example/shield/admin/infrastructure/VerificationLogRepository.java
@@ -1,0 +1,16 @@
+package org.example.shield.admin.infrastructure;
+
+import org.example.shield.admin.domain.VerificationLog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public interface VerificationLogRepository extends JpaRepository<VerificationLog, UUID> {
+    Page<VerificationLog> findAllByToStatus(String toStatus, Pageable pageable);
+    Page<VerificationLog> findAllByCreatedAtAfter(LocalDateTime after, Pageable pageable);
+    Page<VerificationLog> findAllByToStatusAndCreatedAtAfter(String toStatus, LocalDateTime after, Pageable pageable);
+    long countByCreatedAtAfterAndToStatusIn(LocalDateTime after, java.util.List<String> statuses);
+}

--- a/src/main/java/org/example/shield/admin/infrastructure/VerificationLogWriterImpl.java
+++ b/src/main/java/org/example/shield/admin/infrastructure/VerificationLogWriterImpl.java
@@ -1,0 +1,18 @@
+package org.example.shield.admin.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.example.shield.admin.domain.VerificationLog;
+import org.example.shield.admin.domain.VerificationLogWriter;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class VerificationLogWriterImpl implements VerificationLogWriter {
+
+    private final VerificationLogRepository verificationLogRepository;
+
+    @Override
+    public VerificationLog save(VerificationLog log) {
+        return verificationLogRepository.save(log);
+    }
+}

--- a/src/main/java/org/example/shield/brief/application/DeliveryService.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryService.java
@@ -11,8 +11,10 @@ import org.example.shield.brief.domain.BriefReader;
 import org.example.shield.brief.exception.BriefNotFoundException;
 import org.example.shield.brief.infrastructure.BriefDeliveryRepository;
 import org.example.shield.common.enums.BriefStatus;
-import org.example.shield.common.enums.UserRole;
 import org.example.shield.common.enums.PrivacySetting;
+import org.example.shield.common.enums.VerificationStatus;
+import org.example.shield.lawyer.domain.LawyerProfile;
+import org.example.shield.lawyer.domain.LawyerReader;
 import org.example.shield.common.exception.BusinessException;
 import org.example.shield.common.exception.ErrorCode;
 import org.example.shield.common.response.PageResponse;
@@ -37,6 +39,7 @@ public class DeliveryService {
     private final BriefReader briefReader;
     private final BriefDeliveryRepository deliveryRepository;
     private final UserReader userReader;
+    private final LawyerReader lawyerReader;
 
     @Transactional
     public DeliveryResponse createDelivery(UUID briefId, UUID lawyerId, UUID userId) {
@@ -48,8 +51,9 @@ public class DeliveryService {
         }
 
         User lawyer = userReader.findById(lawyerId);
-        if (lawyer.getRole() != UserRole.LAWYER) {
-            throw new BusinessException(ErrorCode.INVALID_ROLE) {};
+        LawyerProfile lawyerProfile = lawyerReader.findByUserId(lawyerId);
+        if (lawyerProfile.getVerificationStatus() != VerificationStatus.VERIFIED) {
+            throw new BusinessException(ErrorCode.LAWYER_NOT_VERIFIED) {};
         }
 
         if (deliveryRepository.existsByBriefIdAndLawyerId(briefId, lawyerId)) {

--- a/src/main/java/org/example/shield/brief/application/DeliveryService.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryService.java
@@ -7,9 +7,10 @@ import org.example.shield.brief.controller.dto.InboxDetailResponse;
 import org.example.shield.brief.controller.dto.InboxResponse;
 import org.example.shield.brief.domain.Brief;
 import org.example.shield.brief.domain.BriefDelivery;
+import org.example.shield.brief.domain.BriefDeliveryReader;
+import org.example.shield.brief.domain.BriefDeliveryWriter;
 import org.example.shield.brief.domain.BriefReader;
 import org.example.shield.brief.exception.BriefNotFoundException;
-import org.example.shield.brief.infrastructure.BriefDeliveryRepository;
 import org.example.shield.common.enums.BriefStatus;
 import org.example.shield.common.enums.PrivacySetting;
 import org.example.shield.common.enums.VerificationStatus;
@@ -37,7 +38,8 @@ import java.util.stream.Collectors;
 public class DeliveryService {
 
     private final BriefReader briefReader;
-    private final BriefDeliveryRepository deliveryRepository;
+    private final BriefDeliveryReader deliveryReader;
+    private final BriefDeliveryWriter deliveryWriter;
     private final UserReader userReader;
     private final LawyerReader lawyerReader;
 
@@ -45,6 +47,10 @@ public class DeliveryService {
     public DeliveryResponse createDelivery(UUID briefId, UUID lawyerId, UUID userId) {
         Brief brief = briefReader.findById(briefId);
         validateOwner(brief, userId);
+
+        if (deliveryReader.existsByBriefIdAndLawyerId(briefId, lawyerId)) {
+            throw new BusinessException(ErrorCode.DELIVERY_ALREADY_EXISTS) {};
+        }
 
         if (brief.getStatus() != BriefStatus.CONFIRMED) {
             throw new BusinessException(ErrorCode.BRIEF_NOT_CONFIRMED) {};
@@ -56,12 +62,8 @@ public class DeliveryService {
             throw new BusinessException(ErrorCode.LAWYER_NOT_VERIFIED) {};
         }
 
-        if (deliveryRepository.existsByBriefIdAndLawyerId(briefId, lawyerId)) {
-            throw new BusinessException(ErrorCode.DELIVERY_ALREADY_EXISTS) {};
-        }
-
         BriefDelivery delivery = BriefDelivery.create(briefId, lawyerId);
-        BriefDelivery saved = deliveryRepository.save(delivery);
+        BriefDelivery saved = deliveryWriter.save(delivery);
 
         brief.markDelivered();
 
@@ -72,7 +74,7 @@ public class DeliveryService {
         Brief brief = briefReader.findById(briefId);
         validateOwner(brief, userId);
 
-        List<BriefDelivery> deliveries = deliveryRepository.findAllByBriefId(briefId);
+        List<BriefDelivery> deliveries = deliveryReader.findAllByBriefId(briefId);
 
         // N+1 방지: 변호사 ID를 모아서 한 번에 조회
         List<UUID> lawyerIds = deliveries.stream().map(BriefDelivery::getLawyerId).toList();
@@ -90,7 +92,7 @@ public class DeliveryService {
     }
 
     public PageResponse<InboxResponse> getInbox(UUID lawyerId, Pageable pageable) {
-        Page<BriefDelivery> deliveries = deliveryRepository.findAllByLawyerId(lawyerId, pageable);
+        Page<BriefDelivery> deliveries = deliveryReader.findAllByLawyerId(lawyerId, pageable);
 
         List<UUID> briefIds = deliveries.getContent().stream()
                 .map(BriefDelivery::getBriefId).toList();
@@ -107,8 +109,7 @@ public class DeliveryService {
 
     @Transactional
     public InboxDetailResponse getInboxDetail(UUID deliveryId, UUID lawyerId) {
-        BriefDelivery delivery = deliveryRepository.findById(deliveryId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.DELIVERY_NOT_FOUND) {});
+        BriefDelivery delivery = deliveryReader.findById(deliveryId);
 
         if (!delivery.getLawyerId().equals(lawyerId)) {
             throw new BusinessException(ErrorCode.DELIVERY_NOT_FOUND) {};

--- a/src/main/java/org/example/shield/brief/domain/BriefDeliveryReader.java
+++ b/src/main/java/org/example/shield/brief/domain/BriefDeliveryReader.java
@@ -1,0 +1,14 @@
+package org.example.shield.brief.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface BriefDeliveryReader {
+    BriefDelivery findById(UUID id);
+    List<BriefDelivery> findAllByBriefId(UUID briefId);
+    Page<BriefDelivery> findAllByLawyerId(UUID lawyerId, Pageable pageable);
+    boolean existsByBriefIdAndLawyerId(UUID briefId, UUID lawyerId);
+}

--- a/src/main/java/org/example/shield/brief/domain/BriefDeliveryWriter.java
+++ b/src/main/java/org/example/shield/brief/domain/BriefDeliveryWriter.java
@@ -1,0 +1,5 @@
+package org.example.shield.brief.domain;
+
+public interface BriefDeliveryWriter {
+    BriefDelivery save(BriefDelivery delivery);
+}

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryReaderImpl.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryReaderImpl.java
@@ -1,0 +1,41 @@
+package org.example.shield.brief.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.example.shield.brief.domain.BriefDelivery;
+import org.example.shield.brief.domain.BriefDeliveryReader;
+import org.example.shield.common.exception.BusinessException;
+import org.example.shield.common.exception.ErrorCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class BriefDeliveryReaderImpl implements BriefDeliveryReader {
+
+    private final BriefDeliveryRepository briefDeliveryRepository;
+
+    @Override
+    public BriefDelivery findById(UUID id) {
+        return briefDeliveryRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DELIVERY_NOT_FOUND) {});
+    }
+
+    @Override
+    public List<BriefDelivery> findAllByBriefId(UUID briefId) {
+        return briefDeliveryRepository.findAllByBriefId(briefId);
+    }
+
+    @Override
+    public Page<BriefDelivery> findAllByLawyerId(UUID lawyerId, Pageable pageable) {
+        return briefDeliveryRepository.findAllByLawyerId(lawyerId, pageable);
+    }
+
+    @Override
+    public boolean existsByBriefIdAndLawyerId(UUID briefId, UUID lawyerId) {
+        return briefDeliveryRepository.existsByBriefIdAndLawyerId(briefId, lawyerId);
+    }
+}

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryWriterImpl.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryWriterImpl.java
@@ -1,0 +1,18 @@
+package org.example.shield.brief.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.example.shield.brief.domain.BriefDelivery;
+import org.example.shield.brief.domain.BriefDeliveryWriter;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BriefDeliveryWriterImpl implements BriefDeliveryWriter {
+
+    private final BriefDeliveryRepository briefDeliveryRepository;
+
+    @Override
+    public BriefDelivery save(BriefDelivery delivery) {
+        return briefDeliveryRepository.save(delivery);
+    }
+}

--- a/src/main/java/org/example/shield/common/config/SecurityConfig.java
+++ b/src/main/java/org/example/shield/common/config/SecurityConfig.java
@@ -32,9 +32,11 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/auth/**",
                                 "/swagger-ui/**",
+                                "/swagger-ui.html",
                                 "/api-docs/**",
                                 "/v3/api-docs/**"
                         ).permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/org/example/shield/common/enums/VerificationStatus.java
+++ b/src/main/java/org/example/shield/common/enums/VerificationStatus.java
@@ -3,12 +3,16 @@ package org.example.shield.common.enums;
 /**
  * 변호사 검증 상태 ENUM.
  *
- * PENDING  - 인증 대기
- * VERIFIED - 인증 완료
- * REJECTED - 인증 거절
+ * PENDING              - 승인 대기
+ * REVIEWING            - 검토 중
+ * SUPPLEMENT_REQUESTED - 보완 요청
+ * VERIFIED             - 승인 완료
+ * REJECTED             - 거절
  */
 public enum VerificationStatus {
     PENDING,
+    REVIEWING,
+    SUPPLEMENT_REQUESTED,
     VERIFIED,
     REJECTED
 }

--- a/src/main/java/org/example/shield/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/shield/common/exception/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
 
     // Admin
     ADMIN_ACCESS_DENIED(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다"),
+    VERIFICATION_CONFLICT(HttpStatus.CONFLICT, "다른 관리자가 이미 처리한 건입니다. 새로고침 후 다시 시도해주세요"),
 
     // Document
     DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "서류를 찾을 수 없습니다"),

--- a/src/main/java/org/example/shield/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/shield/common/exception/ErrorCode.java
@@ -48,7 +48,15 @@ public enum ErrorCode {
     BRIEF_NOT_CONFIRMED(HttpStatus.BAD_REQUEST, "의뢰서를 먼저 확정해 주세요"),
 
     // Verification
-    VERIFICATION_ALREADY_SUBMITTED(HttpStatus.CONFLICT, "이미 검증 신청된 상태입니다");
+    VERIFICATION_ALREADY_SUBMITTED(HttpStatus.CONFLICT, "이미 검증 신청된 상태입니다"),
+
+    // Admin
+    ADMIN_ACCESS_DENIED(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다"),
+
+    // Document
+    DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "서류를 찾을 수 없습니다"),
+    DOCUMENT_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기가 10MB를 초과합니다"),
+    DOCUMENT_TYPE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/example/shield/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/shield/common/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
 
     // Lawyer
     LAWYER_NOT_FOUND(HttpStatus.NOT_FOUND, "변호사를 찾을 수 없습니다"),
+    LAWYER_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "인증되지 않은 변호사에게는 전달할 수 없습니다"),
 
     // Consultation
     CONSULTATION_NOT_FOUND(HttpStatus.NOT_FOUND, "상담을 찾을 수 없습니다"),

--- a/src/main/java/org/example/shield/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/shield/common/exception/GlobalExceptionHandler.java
@@ -2,7 +2,9 @@ package org.example.shield.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.example.shield.common.response.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -29,6 +31,13 @@ public class GlobalExceptionHandler {
         log.warn("Validation failed: {}", message);
         return ResponseEntity.badRequest()
                 .body(ApiResponse.error(message));
+    }
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ResponseEntity<ApiResponse<Void>> handleOptimisticLock(ObjectOptimisticLockingFailureException e) {
+        log.warn("Optimistic lock conflict: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error(ErrorCode.VERIFICATION_CONFLICT.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/org/example/shield/common/storage/StorageClient.java
+++ b/src/main/java/org/example/shield/common/storage/StorageClient.java
@@ -1,0 +1,9 @@
+package org.example.shield.common.storage;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface StorageClient {
+    String upload(String path, MultipartFile file);
+    void delete(String path);
+    String getSignedUrl(String path, int expiresInSeconds);
+}

--- a/src/main/java/org/example/shield/common/storage/SupabaseStorageClient.java
+++ b/src/main/java/org/example/shield/common/storage/SupabaseStorageClient.java
@@ -1,0 +1,79 @@
+package org.example.shield.common.storage;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class SupabaseStorageClient implements StorageClient {
+
+    private final WebClient webClient;
+    private final String bucket;
+    private final String baseUrl;
+
+    public SupabaseStorageClient(
+            @Value("${supabase.url}") String supabaseUrl,
+            @Value("${supabase.service-role-key}") String serviceRoleKey,
+            @Value("${supabase.storage.bucket}") String bucket) {
+        this.bucket = bucket;
+        this.baseUrl = supabaseUrl + "/storage/v1";
+        this.webClient = WebClient.builder()
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + serviceRoleKey)
+                .defaultHeader("apikey", serviceRoleKey)
+                .build();
+    }
+
+    @Override
+    public String upload(String path, MultipartFile file) {
+        try {
+            byte[] fileBytes = file.getBytes();
+            String contentType = file.getContentType() != null ? file.getContentType() : "application/octet-stream";
+
+            webClient.post()
+                    .uri(URI.create(baseUrl + "/object/" + bucket + "/" + path))
+                    .header(HttpHeaders.CONTENT_TYPE, contentType)
+                    .header("x-upsert", "true")
+                    .bodyValue(fileBytes)
+                    .retrieve()
+                    .toBodilessEntity()
+                    .block();
+
+            log.info("파일 업로드 완료. bucket={}, path={}", bucket, path);
+            return path;
+        } catch (IOException e) {
+            throw new RuntimeException("파일 읽기 실패", e);
+        }
+    }
+
+    @Override
+    public void delete(String path) {
+        webClient.delete()
+                .uri(URI.create(baseUrl + "/object/" + bucket + "/" + path))
+                .retrieve()
+                .toBodilessEntity()
+                .block();
+
+        log.info("파일 삭제 완료. bucket={}, path={}", bucket, path);
+    }
+
+    @Override
+    public String getSignedUrl(String path, int expiresInSeconds) {
+        Map<String, Object> response = webClient.post()
+                .uri(URI.create(baseUrl + "/object/sign/" + bucket + "/" + path))
+                .bodyValue(Map.of("expiresIn", expiresInSeconds))
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+
+        String signedUrl = (String) response.get("signedURL");
+        return baseUrl + signedUrl;
+    }
+}

--- a/src/main/java/org/example/shield/lawyer/application/LawyerDocumentService.java
+++ b/src/main/java/org/example/shield/lawyer/application/LawyerDocumentService.java
@@ -1,0 +1,103 @@
+package org.example.shield.lawyer.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.shield.common.exception.BusinessException;
+import org.example.shield.common.exception.ErrorCode;
+import org.example.shield.common.storage.StorageClient;
+import org.example.shield.lawyer.controller.dto.DocumentResponse;
+import org.example.shield.lawyer.domain.LawyerDocument;
+import org.example.shield.lawyer.domain.LawyerDocumentReader;
+import org.example.shield.lawyer.domain.LawyerDocumentWriter;
+import org.example.shield.lawyer.domain.LawyerReader;
+import org.example.shield.user.domain.UserReader;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LawyerDocumentService {
+
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024;
+    private static final Set<String> ALLOWED_TYPES = Set.of("PDF", "JPG", "JPEG", "PNG");
+
+    private final StorageClient storageClient;
+    private final LawyerReader lawyerReader;
+    private final UserReader userReader;
+    private final LawyerDocumentReader lawyerDocumentReader;
+    private final LawyerDocumentWriter lawyerDocumentWriter;
+
+    @Transactional
+    public DocumentResponse uploadDocument(UUID userId, MultipartFile file) {
+        log.info("서류 업로드 요청. userId={}, fileName={}", userId, file.getOriginalFilename());
+
+        validateFile(file);
+
+        var lawyer = lawyerReader.findByUserId(userId);
+        var user = userReader.findById(userId);
+        String fileType = extractFileType(file.getOriginalFilename());
+        String sanitizedName = sanitizeFileName(file.getOriginalFilename());
+        String userName = sanitizeFileName(user.getName());
+        String storagePath = lawyer.getId() + "/" + userName + "_" + sanitizedName;
+
+        String filePath = storageClient.upload(storagePath, file);
+
+        LawyerDocument document = LawyerDocument.create(
+                lawyer.getId(),
+                file.getOriginalFilename(),
+                filePath,
+                file.getSize(),
+                fileType
+        );
+        LawyerDocument saved = lawyerDocumentWriter.save(document);
+
+        String signedUrl = storageClient.getSignedUrl(filePath, 3600);
+
+        log.info("서류 업로드 완료. documentId={}, lawyerId={}", saved.getId(), lawyer.getId());
+        return DocumentResponse.fromWithUrl(saved, signedUrl);
+    }
+
+    private static final int SIGNED_URL_EXPIRY = 3600;
+
+    public List<DocumentResponse> getDocuments(UUID lawyerId) {
+        log.info("서류 목록 조회. lawyerId={}", lawyerId);
+        return lawyerDocumentReader.findAllByLawyerId(lawyerId).stream()
+                .map(doc -> {
+                    String signedUrl = storageClient.getSignedUrl(doc.getFileUrl(), SIGNED_URL_EXPIRY);
+                    return DocumentResponse.fromWithUrl(doc, signedUrl);
+                })
+                .toList();
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE) {};
+        }
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new BusinessException(ErrorCode.DOCUMENT_SIZE_EXCEEDED) {};
+        }
+        String fileType = extractFileType(file.getOriginalFilename());
+        if (!ALLOWED_TYPES.contains(fileType.toUpperCase())) {
+            throw new BusinessException(ErrorCode.DOCUMENT_TYPE_NOT_SUPPORTED) {};
+        }
+    }
+
+    private String sanitizeFileName(String fileName) {
+        if (fileName == null) return "file";
+        return fileName.replaceAll("[^a-zA-Z0-9가-힣._-]", "_");
+    }
+
+    private String extractFileType(String fileName) {
+        if (fileName == null || !fileName.contains(".")) {
+            throw new BusinessException(ErrorCode.DOCUMENT_TYPE_NOT_SUPPORTED) {};
+        }
+        return fileName.substring(fileName.lastIndexOf(".") + 1).toUpperCase();
+    }
+}

--- a/src/main/java/org/example/shield/lawyer/controller/LawyerController.java
+++ b/src/main/java/org/example/shield/lawyer/controller/LawyerController.java
@@ -1,20 +1,41 @@
 package org.example.shield.lawyer.controller;
 
-/**
- * 변호사 API 컨트롤러.
- *
- * Layer: controller
- * Called by: 프론트엔드
- * Calls: LawyerService, VerificationService
- *
- * API 목록 (Issue #12 포함):
- * TODO: GET   /api/lawyers                             — 변호사 목록 조회
- * TODO: GET   /api/lawyers/{lawyerId}                  — 변호사 프로필 상세 (의뢰인/관리자 공용)
- * TODO: GET   /api/lawyers/me                          — 내 프로필 조회 (차후 구현)
- * TODO: PATCH /api/lawyers/me                          — 내 프로필 수정 (차후 구현)
- * TODO: POST  /api/lawyers/me/verification-request     — 검증 신청 (body: barAssociationNumber)
- * TODO: GET   /api/lawyers/me/verification-status      — 검증 상태 확인
- * TODO: POST  /api/lawyers/me/documents                — 서류 업로드 (MultipartFile → Supabase Storage)
- */
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.example.shield.common.response.ApiResponse;
+import org.example.shield.lawyer.application.LawyerDocumentService;
+import org.example.shield.lawyer.controller.dto.DocumentResponse;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@Tag(name = "Lawyer", description = "변호사 API")
+@RestController
+@RequestMapping("/api/lawyers")
+@RequiredArgsConstructor
 public class LawyerController {
+
+    private final LawyerDocumentService lawyerDocumentService;
+
+    @Operation(summary = "서류 업로드", description = "변호사 자격증 등 서류를 업로드합니다 (PDF, JPG, PNG / 최대 10MB)")
+    @PostMapping("/me/documents")
+    public ApiResponse<DocumentResponse> uploadDocument(
+            @AuthenticationPrincipal UUID userId,
+            @RequestParam("file") MultipartFile file) {
+        DocumentResponse result = lawyerDocumentService.uploadDocument(userId, file);
+        return ApiResponse.success("서류가 업로드되었습니다", result);
+    }
+
+    // TODO: GET   /api/lawyers                             — 변호사 목록 조회
+    // TODO: GET   /api/lawyers/{lawyerId}                  — 변호사 프로필 상세 (의뢰인용)
+    // TODO: GET   /api/lawyers/me                          — 내 프로필 조회 (차후 구현)
+    // TODO: PATCH /api/lawyers/me                          — 내 프로필 수정 (차후 구현)
+    // TODO: POST  /api/lawyers/me/verification-request     — 검증 신청
+    // TODO: GET   /api/lawyers/me/verification-status      — 검증 상태 확인
 }

--- a/src/main/java/org/example/shield/lawyer/controller/LawyerController.java
+++ b/src/main/java/org/example/shield/lawyer/controller/LawyerController.java
@@ -7,13 +7,14 @@ package org.example.shield.lawyer.controller;
  * Called by: 프론트엔드
  * Calls: LawyerService, VerificationService
  *
- * API 목록 (6개):
- * - GET   /api/lawyers                             변호사 목록 조회
- * - GET   /api/lawyers/{lawyerId}                  변호사 프로필 상세
- * - GET   /api/lawyers/me                          내 프로필 조회
- * - PATCH /api/lawyers/me                          내 프로필 수정 (차후 구현)
- * - POST  /api/lawyers/me/verification-request     검증 신청 (body: barAssociationNumber)
- * - GET   /api/lawyers/me/verification-status      검증 상태 확인
+ * API 목록 (Issue #12 포함):
+ * TODO: GET   /api/lawyers                             — 변호사 목록 조회
+ * TODO: GET   /api/lawyers/{lawyerId}                  — 변호사 프로필 상세 (의뢰인/관리자 공용)
+ * TODO: GET   /api/lawyers/me                          — 내 프로필 조회 (차후 구현)
+ * TODO: PATCH /api/lawyers/me                          — 내 프로필 수정 (차후 구현)
+ * TODO: POST  /api/lawyers/me/verification-request     — 검증 신청 (body: barAssociationNumber)
+ * TODO: GET   /api/lawyers/me/verification-status      — 검증 상태 확인
+ * TODO: POST  /api/lawyers/me/documents                — 서류 업로드 (MultipartFile → Supabase Storage)
  */
 public class LawyerController {
 }

--- a/src/main/java/org/example/shield/lawyer/controller/dto/DocumentResponse.java
+++ b/src/main/java/org/example/shield/lawyer/controller/dto/DocumentResponse.java
@@ -1,0 +1,26 @@
+package org.example.shield.lawyer.controller.dto;
+
+import org.example.shield.lawyer.domain.LawyerDocument;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record DocumentResponse(
+        UUID documentId,
+        String fileName,
+        Long fileSize,
+        String fileType,
+        String fileUrl,
+        LocalDateTime createdAt
+) {
+    public static DocumentResponse fromWithUrl(LawyerDocument document, String signedUrl) {
+        return new DocumentResponse(
+                document.getId(),
+                document.getFileName(),
+                document.getFileSize(),
+                document.getFileType(),
+                signedUrl,
+                document.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/org/example/shield/lawyer/domain/LawyerDocument.java
+++ b/src/main/java/org/example/shield/lawyer/domain/LawyerDocument.java
@@ -1,18 +1,70 @@
 package org.example.shield.lawyer.domain;
 
-/**
- * 변호사 제출 서류 엔티티.
- *
- * Table: lawyer_documents
- *
- * TODO: @Entity 구현
- * - id (UUID PK)
- * - lawyerId (UUID FK → lawyers)
- * - fileName (String, 원본 파일명)
- * - fileUrl (String, Supabase Storage URL)
- * - fileSize (Long, bytes)
- * - fileType (String, PDF/JPG/PNG)
- * - createdAt (LocalDateTime)
- */
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "lawyer_documents")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LawyerDocument {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID lawyerId;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String fileUrl;
+
+    @Column(nullable = false)
+    private Long fileSize;
+
+    @Column(nullable = false, length = 20)
+    private String fileType;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    private LawyerDocument(UUID lawyerId, String fileName, String fileUrl,
+                           Long fileSize, String fileType) {
+        this.lawyerId = lawyerId;
+        this.fileName = fileName;
+        this.fileUrl = fileUrl;
+        this.fileSize = fileSize;
+        this.fileType = fileType;
+    }
+
+    public static LawyerDocument create(UUID lawyerId, String fileName, String fileUrl,
+                                        Long fileSize, String fileType) {
+        return LawyerDocument.builder()
+                .lawyerId(lawyerId)
+                .fileName(fileName)
+                .fileUrl(fileUrl)
+                .fileSize(fileSize)
+                .fileType(fileType)
+                .build();
+    }
 }

--- a/src/main/java/org/example/shield/lawyer/domain/LawyerDocument.java
+++ b/src/main/java/org/example/shield/lawyer/domain/LawyerDocument.java
@@ -1,0 +1,18 @@
+package org.example.shield.lawyer.domain;
+
+/**
+ * 변호사 제출 서류 엔티티.
+ *
+ * Table: lawyer_documents
+ *
+ * TODO: @Entity 구현
+ * - id (UUID PK)
+ * - lawyerId (UUID FK → lawyers)
+ * - fileName (String, 원본 파일명)
+ * - fileUrl (String, Supabase Storage URL)
+ * - fileSize (Long, bytes)
+ * - fileType (String, PDF/JPG/PNG)
+ * - createdAt (LocalDateTime)
+ */
+public class LawyerDocument {
+}

--- a/src/main/java/org/example/shield/lawyer/domain/LawyerDocumentReader.java
+++ b/src/main/java/org/example/shield/lawyer/domain/LawyerDocumentReader.java
@@ -1,0 +1,8 @@
+package org.example.shield.lawyer.domain;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface LawyerDocumentReader {
+    List<LawyerDocument> findAllByLawyerId(UUID lawyerId);
+}

--- a/src/main/java/org/example/shield/lawyer/domain/LawyerDocumentWriter.java
+++ b/src/main/java/org/example/shield/lawyer/domain/LawyerDocumentWriter.java
@@ -1,0 +1,6 @@
+package org.example.shield.lawyer.domain;
+
+public interface LawyerDocumentWriter {
+    LawyerDocument save(LawyerDocument document);
+    void deleteById(java.util.UUID id);
+}

--- a/src/main/java/org/example/shield/lawyer/domain/LawyerProfile.java
+++ b/src/main/java/org/example/shield/lawyer/domain/LawyerProfile.java
@@ -54,4 +54,11 @@ public class LawyerProfile extends BaseEntity {
 
     @Column(length = 50)
     private String region;
+
+    public void updateVerificationStatus(VerificationStatus newStatus) {
+        this.verificationStatus = newStatus;
+        if (newStatus == VerificationStatus.VERIFIED) {
+            this.verifiedAt = LocalDateTime.now();
+        }
+    }
 }

--- a/src/main/java/org/example/shield/lawyer/domain/LawyerProfile.java
+++ b/src/main/java/org/example/shield/lawyer/domain/LawyerProfile.java
@@ -51,4 +51,7 @@ public class LawyerProfile extends BaseEntity {
     private List<String> certifications;
 
     private Integer caseCount;
+
+    @Column(length = 50)
+    private String region;
 }

--- a/src/main/java/org/example/shield/lawyer/domain/LawyerProfile.java
+++ b/src/main/java/org/example/shield/lawyer/domain/LawyerProfile.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -54,6 +55,9 @@ public class LawyerProfile extends BaseEntity {
 
     @Column(length = 50)
     private String region;
+
+    @Version
+    private Long version;
 
     public void updateVerificationStatus(VerificationStatus newStatus) {
         this.verificationStatus = newStatus;

--- a/src/main/java/org/example/shield/lawyer/domain/LawyerReader.java
+++ b/src/main/java/org/example/shield/lawyer/domain/LawyerReader.java
@@ -10,4 +10,6 @@ public interface LawyerReader {
     LawyerProfile findById(UUID id);
     LawyerProfile findByUserId(UUID userId);
     Page<LawyerProfile> findAllByVerificationStatus(VerificationStatus status, Pageable pageable);
+    Page<LawyerProfile> searchByStatusAndKeyword(String status, String keyword, Pageable pageable);
+    long countByVerificationStatus(VerificationStatus status);
 }

--- a/src/main/java/org/example/shield/lawyer/domain/LawyerWriter.java
+++ b/src/main/java/org/example/shield/lawyer/domain/LawyerWriter.java
@@ -1,10 +1,5 @@
 package org.example.shield.lawyer.domain;
 
-/**
- * Lawyer 저장 인터페이스.
- *
- * TODO:
- * - save(LawyerProfile profile): LawyerProfile
- */
 public interface LawyerWriter {
+    LawyerProfile save(LawyerProfile profile);
 }

--- a/src/main/java/org/example/shield/lawyer/infrastructure/LawyerDocumentReaderImpl.java
+++ b/src/main/java/org/example/shield/lawyer/infrastructure/LawyerDocumentReaderImpl.java
@@ -1,0 +1,21 @@
+package org.example.shield.lawyer.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.example.shield.lawyer.domain.LawyerDocument;
+import org.example.shield.lawyer.domain.LawyerDocumentReader;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class LawyerDocumentReaderImpl implements LawyerDocumentReader {
+
+    private final LawyerDocumentRepository lawyerDocumentRepository;
+
+    @Override
+    public List<LawyerDocument> findAllByLawyerId(UUID lawyerId) {
+        return lawyerDocumentRepository.findAllByLawyerId(lawyerId);
+    }
+}

--- a/src/main/java/org/example/shield/lawyer/infrastructure/LawyerDocumentRepository.java
+++ b/src/main/java/org/example/shield/lawyer/infrastructure/LawyerDocumentRepository.java
@@ -3,9 +3,17 @@ package org.example.shield.lawyer.infrastructure;
 import org.example.shield.lawyer.domain.LawyerDocument;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface LawyerDocumentRepository extends JpaRepository<LawyerDocument, UUID> {
     List<LawyerDocument> findAllByLawyerId(UUID lawyerId);
+    long countByLawyerId(UUID lawyerId);
+
+    @Query("SELECT ld.lawyerId, COUNT(ld) FROM LawyerDocument ld WHERE ld.lawyerId IN :lawyerIds GROUP BY ld.lawyerId")
+    List<Object[]> countByLawyerIds(@Param("lawyerIds") List<UUID> lawyerIds);
 }

--- a/src/main/java/org/example/shield/lawyer/infrastructure/LawyerDocumentRepository.java
+++ b/src/main/java/org/example/shield/lawyer/infrastructure/LawyerDocumentRepository.java
@@ -1,0 +1,11 @@
+package org.example.shield.lawyer.infrastructure;
+
+import org.example.shield.lawyer.domain.LawyerDocument;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface LawyerDocumentRepository extends JpaRepository<LawyerDocument, UUID> {
+    List<LawyerDocument> findAllByLawyerId(UUID lawyerId);
+}

--- a/src/main/java/org/example/shield/lawyer/infrastructure/LawyerDocumentWriterImpl.java
+++ b/src/main/java/org/example/shield/lawyer/infrastructure/LawyerDocumentWriterImpl.java
@@ -1,0 +1,25 @@
+package org.example.shield.lawyer.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.example.shield.lawyer.domain.LawyerDocument;
+import org.example.shield.lawyer.domain.LawyerDocumentWriter;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class LawyerDocumentWriterImpl implements LawyerDocumentWriter {
+
+    private final LawyerDocumentRepository lawyerDocumentRepository;
+
+    @Override
+    public LawyerDocument save(LawyerDocument document) {
+        return lawyerDocumentRepository.save(document);
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+        lawyerDocumentRepository.deleteById(id);
+    }
+}

--- a/src/main/java/org/example/shield/lawyer/infrastructure/LawyerProfileRepository.java
+++ b/src/main/java/org/example/shield/lawyer/infrastructure/LawyerProfileRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -41,4 +42,21 @@ public interface LawyerProfileRepository extends JpaRepository<LawyerProfile, UU
             Pageable pageable);
 
     long countByVerificationStatus(VerificationStatus status);
+
+    long countByVerificationStatusAndCreatedAtBefore(VerificationStatus status, LocalDateTime before);
+
+    @Query(value = """
+            SELECT COUNT(*) FROM lawyers lp
+            WHERE NOT EXISTS (SELECT 1 FROM lawyer_documents ld WHERE ld.lawyer_id = lp.id)
+            AND CAST(lp.verification_status AS TEXT) IN ('PENDING', 'REVIEWING', 'SUPPLEMENT_REQUESTED')
+            """, nativeQuery = true)
+    long countMissingDocuments();
+
+    @Query(value = """
+            SELECT COUNT(*) FROM (
+                SELECT bar_association_number FROM lawyers
+                GROUP BY bar_association_number HAVING COUNT(*) > 1
+            ) duplicates
+            """, nativeQuery = true)
+    long countDuplicateBarNumbers();
 }

--- a/src/main/java/org/example/shield/lawyer/infrastructure/LawyerProfileRepository.java
+++ b/src/main/java/org/example/shield/lawyer/infrastructure/LawyerProfileRepository.java
@@ -5,6 +5,8 @@ import org.example.shield.lawyer.domain.LawyerProfile;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -12,4 +14,31 @@ import java.util.UUID;
 public interface LawyerProfileRepository extends JpaRepository<LawyerProfile, UUID> {
     Optional<LawyerProfile> findByUserId(UUID userId);
     Page<LawyerProfile> findAllByVerificationStatus(VerificationStatus status, Pageable pageable);
+
+    @Query(value = """
+            SELECT lp.* FROM lawyers lp
+            JOIN users u ON u.id = lp.user_id
+            WHERE (CAST(:status AS TEXT) IS NULL OR CAST(lp.verification_status AS TEXT) = :status)
+            AND (CAST(:keyword AS TEXT) IS NULL
+                 OR LOWER(u.name) LIKE LOWER('%' || CAST(:keyword AS TEXT) || '%')
+                 OR LOWER(u.email) LIKE LOWER('%' || CAST(:keyword AS TEXT) || '%')
+                 OR u.phone LIKE '%' || CAST(:keyword AS TEXT) || '%')
+            ORDER BY lp.created_at DESC
+            """,
+            countQuery = """
+            SELECT COUNT(*) FROM lawyers lp
+            JOIN users u ON u.id = lp.user_id
+            WHERE (CAST(:status AS TEXT) IS NULL OR CAST(lp.verification_status AS TEXT) = :status)
+            AND (CAST(:keyword AS TEXT) IS NULL
+                 OR LOWER(u.name) LIKE LOWER('%' || CAST(:keyword AS TEXT) || '%')
+                 OR LOWER(u.email) LIKE LOWER('%' || CAST(:keyword AS TEXT) || '%')
+                 OR u.phone LIKE '%' || CAST(:keyword AS TEXT) || '%')
+            """,
+            nativeQuery = true)
+    Page<LawyerProfile> searchByStatusAndKeyword(
+            @Param("status") String status,
+            @Param("keyword") String keyword,
+            Pageable pageable);
+
+    long countByVerificationStatus(VerificationStatus status);
 }

--- a/src/main/java/org/example/shield/lawyer/infrastructure/LawyerReaderImpl.java
+++ b/src/main/java/org/example/shield/lawyer/infrastructure/LawyerReaderImpl.java
@@ -34,4 +34,14 @@ public class LawyerReaderImpl implements LawyerReader {
     public Page<LawyerProfile> findAllByVerificationStatus(VerificationStatus status, Pageable pageable) {
         return lawyerProfileRepository.findAllByVerificationStatus(status, pageable);
     }
+
+    @Override
+    public Page<LawyerProfile> searchByStatusAndKeyword(String status, String keyword, Pageable pageable) {
+        return lawyerProfileRepository.searchByStatusAndKeyword(status, keyword, pageable);
+    }
+
+    @Override
+    public long countByVerificationStatus(VerificationStatus status) {
+        return lawyerProfileRepository.countByVerificationStatus(status);
+    }
 }

--- a/src/main/java/org/example/shield/lawyer/infrastructure/LawyerWriterImpl.java
+++ b/src/main/java/org/example/shield/lawyer/infrastructure/LawyerWriterImpl.java
@@ -1,10 +1,18 @@
 package org.example.shield.lawyer.infrastructure;
 
-/**
- * LawyerWriter 구현체.
- *
- * TODO: @Repository + implements LawyerWriter
- * - LawyerProfileRepository 주입
- */
-public class LawyerWriterImpl {
+import lombok.RequiredArgsConstructor;
+import org.example.shield.lawyer.domain.LawyerProfile;
+import org.example.shield.lawyer.domain.LawyerWriter;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LawyerWriterImpl implements LawyerWriter {
+
+    private final LawyerProfileRepository lawyerProfileRepository;
+
+    @Override
+    public LawyerProfile save(LawyerProfile profile) {
+        return lawyerProfileRepository.save(profile);
+    }
 }

--- a/src/main/java/org/example/shield/user/domain/User.java
+++ b/src/main/java/org/example/shield/user/domain/User.java
@@ -46,15 +46,19 @@ public class User {
 
     private String profileImageUrl;
 
+    @Column(length = 20)
+    private String phone;
+
     @Builder
     public User(String email, String name, UserRole role, String provider,
-                String googleId, String profileImageUrl) {
+                String googleId, String profileImageUrl, String phone) {
         this.email = email;
         this.name = name;
         this.role = role;
         this.provider = provider;
         this.googleId = googleId;
         this.profileImageUrl = profileImageUrl;
+        this.phone = phone;
     }
 
     public void updateRefreshToken(String refreshToken) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,9 @@ spring:
       charset: UTF-8
       enabled: true
       force: true
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
   # PostgreSQL
   datasource:
@@ -35,6 +38,13 @@ google:
   client-id: ${GOOGLE_CLIENT_ID}
   client-secret: ${GOOGLE_CLIENT_SECRET}
   redirect-uri: ${GOOGLE_REDIRECT_URI}
+
+# Supabase Storage
+supabase:
+  url: ${SUPABASE_URL}
+  service-role-key: ${SUPABASE_SERVICE_ROLE_KEY}
+  storage:
+    bucket: lawyer_documents
 
 # Swagger
 springdoc:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,8 @@ spring:
     url: ${DB_URL}?prepareThreshold=0&stringtype=unspecified
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+    hikari:
+      maximum-pool-size: 5
 
   jpa:
     hibernate:


### PR DESCRIPTION
## 📌 개요

Issue #12 — 관리자 대시보드 UI에 필요한 백엔드 API 9개 구현 + DB 스키마 확장

UI 참고: [Figma - Admin Dashboard](https://www.figma.com/design/qRDIfF7Y6VK27oBKcVKXbn/캡스톤디자인)

---

## 🗄️ DB 변경

### enum 확장
- `verification_status`에 `REVIEWING`, `SUPPLEMENT_REQUESTED` 추가

### 기존 테이블 컬럼 추가
| 테이블 | 컬럼 | 타입 | 설명 |
|--------|------|------|------|
| `users` | `phone` | varchar(20) | 전화번호 |
| `lawyers` | `region` | varchar(50) | 활동 지역 |
| `lawyers` | `version` | bigint | 낙관적 락 |

### 신규 테이블 3개
| 테이블 | 설명 |
|--------|------|
| `lawyer_documents` | 변호사 서류 파일 메타 (Supabase Storage 연동) |
| `verification_checks` | 자동 검증 결과 + 관리자 체크리스트 (boolean 10개) |
| `verification_logs` | 인증 상태 변경 이력 (관리자 ID, 이전/이후 상태, 사유) |

---

## 🔧 API 구현 (9개)

### 관리자 대시보드
| Method | Endpoint | 기능 |
|--------|----------|------|
| GET | `/api/admin/dashboard/stats` | 상태별 카운트 (승인 대기/검토 중/보완 요청/오늘 처리) |
| GET | `/api/admin/dashboard/alerts` | 긴급 알림 (24시간 미처리/서류 미제출/중복 의심) |

### 변호사 가입 심사
| Method | Endpoint | 기능 |
|--------|----------|------|
| GET | `/api/admin/lawyers/pending` | 심사 목록 (이름/이메일/연락처 검색 + 상태 필터 + 페이징) |
| GET | `/api/admin/lawyers/{lawyerId}` | 가입 신청 상세 (민감 정보 포함, 관리자 전용) |
| PATCH | `/api/admin/lawyers/{lawyerId}/verification` | 승인/검토중/보완요청/거절 처리 + 이력 자동 생성 |
| GET | `/api/admin/lawyers/{lawyerId}/verification-checks` | 자동 검증 결과 + 체크리스트 (completedCount/totalCount) |

### 서류 관리
| Method | Endpoint | 기능 |
|--------|----------|------|
| POST | `/api/lawyers/me/documents` | 변호사 서류 업로드 (PDF/JPG/PNG, 10MB 제한, Supabase Storage) |
| GET | `/api/admin/lawyers/{lawyerId}/documents` | 관리자 서류 조회 (Signed URL, 1시간 유효) |

### 처리 이력
| Method | Endpoint | 기능 |
|--------|----------|------|
| GET | `/api/admin/verification-logs` | 처리 이력 (기간/상태 필터 + 페이징) |

---

## 🛡️ 보안 및 안정성

| 항목 | 설명 |
|------|------|
| ADMIN 권한 체크 | `@PreAuthorize("hasRole('ADMIN')")` + SecurityConfig `/api/admin/**` |
| 낙관적 락 | LawyerProfile `@Version` 적용, 동시 심사 시 409 Conflict |
| N+1 방지 | batch user fetch + batch document count |
| Swagger UI | `/swagger-ui.html` permitAll 추가 |
| Supabase Storage | service_role 키 인증, Signed URL로 비공개 버킷 접근 |
| 파일 업로드 검증 | 크기 10MB 제한, 확장자 PDF/JPG/PNG만 허용 |

---

## 📁 신규 Entity / Infrastructure

| 파일 | 설명 |
|------|------|
| `LawyerDocument` | 서류 파일 메타 엔티티 + Reader/Writer/Repository |
| `VerificationCheck` | 자동 검증 + 체크리스트 엔티티 (boolean 10개, getCompletedCount) |
| `VerificationLog` | 상태 변경 이력 엔티티 + Reader/Writer/Repository |
| `StorageClient` | 파일 저장소 인터페이스 (향후 S3 교체 대비) |
| `SupabaseStorageClient` | Supabase Storage REST API 구현체 (upload, delete, getSignedUrl) |
| `LawyerDocumentService` | 업로드 로직 + 파일 검증 + 메타 저장 |
| `AdminService` | 대시보드/심사/검증/이력 비즈니스 로직 |
| `AdminController` | 관리자 API 엔드포인트 9개 |

---

## ✅ 테스트 결과

| # | API | 결과 |
|---|-----|------|
| 1 | `GET /api/admin/dashboard/stats` | ✅ |
| 2 | `GET /api/admin/dashboard/alerts` | ✅ |
| 3 | `GET /api/admin/lawyers/pending` (필터 없음) | ✅ |
| 4 | `GET /api/admin/lawyers/pending?status=PENDING` | ✅ |
| 5 | `GET /api/admin/lawyers/pending?keyword=Kim` | ✅ |
| 6 | `GET /api/admin/lawyers/{lawyerId}` | ✅ |
| 7 | `GET /api/admin/lawyers/{lawyerId}` (404) | ✅ |
| 8 | `PATCH verification` PENDING→REVIEWING | ✅ |
| 9 | `PATCH verification` REVIEWING→SUPPLEMENT (reason) | ✅ |
| 10 | `PATCH verification` →VERIFIED | ✅ |
| 11 | `PATCH verification` REJECTED without reason (400) | ✅ |
| 12 | `GET verification-checks` (빈 데이터) | ✅ |
| 13 | `GET verification-checks` (7/10) | ✅ |
| 14 | `POST lawyers/me/documents` (PDF 업로드) | ✅ |
| 15 | `GET admin/lawyers/{id}/documents` (Signed URL) | ✅ |
| 16 | `GET verification-logs` (전체) | ✅ |
| 17 | `GET verification-logs?period=today` | ✅ |
| 18 | `GET verification-logs?status=REJECTED` | ✅ |
| 19 | USER → admin API (403) | ✅ |
| 20 | LAWYER → admin API (403) | ✅ |
| 21 | 낙관적 락 (@Version) | ✅ |

---

## 📝 Notion 동기화

- API 명세서: 신규 9개 API 추가 + 기존 3개 비고 업데이트
- Status Enums: REVIEWING, SUPPLEMENT_REQUESTED 추가
- Response 필드: 전체 nullable/NOT NULL 표기 완료
- 변경사항 페이지: DB 변경 이력 기록