### PR TITLE
[FEAT] 변호사(Lawyer) API 구현 (Issue #14)

### DIFF
--- a/src/main/java/org/example/shield/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/shield/common/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.example.shield.common.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -31,6 +32,13 @@ public class GlobalExceptionHandler {
         log.warn("Validation failed: {}", message);
         return ResponseEntity.badRequest()
                 .body(ApiResponse.error(message));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAccessDenied(AccessDeniedException e) {
+        log.warn("Access denied: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(ApiResponse.error(ErrorCode.ACCESS_DENIED.getMessage()));
     }
 
     @ExceptionHandler(ObjectOptimisticLockingFailureException.class)

--- a/src/main/java/org/example/shield/lawyer/application/LawyerService.java
+++ b/src/main/java/org/example/shield/lawyer/application/LawyerService.java
@@ -1,19 +1,77 @@
 package org.example.shield.lawyer.application;
 
-/**
- * 변호사 서비스 - 변호사 목록/프로필 조회/수정.
- *
- * Layer: application
- * Called by: LawyerController
- * Calls: LawyerReader, LawyerWriter
- *
- * TODO:
- * - getLawyers(pageable, specialization, minExperience, sort):
- *   변호사 목록 (VERIFIED만, 필터/정렬/페이징)
- *   기본 정렬: 경력순
- * - getLawyer(lawyerId): 변호사 프로필 상세
- * - getMyProfile(userId): 변호사 본인 프로필
- * - updateMyProfile(userId, request): 전문분야/경력/자격증/소개글 수정
- */
+import lombok.RequiredArgsConstructor;
+import org.example.shield.common.enums.VerificationStatus;
+import org.example.shield.common.response.PageResponse;
+import org.example.shield.lawyer.controller.dto.LawyerResponse;
+import org.example.shield.lawyer.controller.dto.ProfileUpdateRequest;
+import org.example.shield.lawyer.domain.LawyerProfile;
+import org.example.shield.lawyer.domain.LawyerReader;
+import org.example.shield.lawyer.domain.LawyerWriter;
+import org.example.shield.user.domain.User;
+import org.example.shield.user.domain.UserReader;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class LawyerService {
+
+    private final LawyerReader lawyerReader;
+    private final LawyerWriter lawyerWriter;
+    private final UserReader userReader;
+
+    public PageResponse<LawyerResponse> getLawyers(Pageable pageable) {
+        Page<LawyerProfile> profiles = lawyerReader.findAllByVerificationStatus(
+                VerificationStatus.VERIFIED, pageable);
+
+        List<UUID> userIds = profiles.getContent().stream()
+                .map(LawyerProfile::getUserId)
+                .toList();
+        Map<UUID, User> userMap = userReader.findAllByIds(userIds).stream()
+                .collect(Collectors.toMap(User::getId, u -> u));
+
+        Page<LawyerResponse> responsePage = profiles.map(profile -> {
+            User user = userMap.get(profile.getUserId());
+            return LawyerResponse.from(profile,
+                    user != null ? user.getName() : null,
+                    user != null ? user.getProfileImageUrl() : null);
+        });
+        return PageResponse.from(responsePage);
+    }
+
+    public LawyerResponse getLawyer(UUID lawyerId) {
+        LawyerProfile profile = lawyerReader.findById(lawyerId);
+        User user = userReader.findById(profile.getUserId());
+        return LawyerResponse.from(profile, user.getName(), user.getProfileImageUrl());
+    }
+
+    public LawyerResponse getMyProfile(UUID userId) {
+        LawyerProfile profile = lawyerReader.findByUserId(userId);
+        User user = userReader.findById(userId);
+        return LawyerResponse.from(profile, user.getName(), user.getProfileImageUrl());
+    }
+
+    @Transactional
+    public LawyerResponse updateMyProfile(UUID userId, ProfileUpdateRequest request) {
+        LawyerProfile profile = lawyerReader.findByUserId(userId);
+        profile.updateProfile(
+                request.specializations(),
+                request.experienceYears(),
+                request.certifications(),
+                request.tags(),
+                request.bio(),
+                request.region()
+        );
+        User user = userReader.findById(userId);
+        return LawyerResponse.from(profile, user.getName(), user.getProfileImageUrl());
+    }
 }

--- a/src/main/java/org/example/shield/lawyer/application/VerificationService.java
+++ b/src/main/java/org/example/shield/lawyer/application/VerificationService.java
@@ -28,7 +28,7 @@ public class VerificationService {
                     || existing.getVerificationStatus() == VerificationStatus.REVIEWING) {
                 throw new BusinessException(ErrorCode.VERIFICATION_ALREADY_SUBMITTED) {};
             }
-            existing.updateVerificationStatus(VerificationStatus.PENDING);
+            existing.requestVerification(barAssociationNumber);
             return VerificationResponse.from(existing);
         } catch (BusinessException e) {
             if (e.getErrorCode() == ErrorCode.LAWYER_NOT_FOUND) {

--- a/src/main/java/org/example/shield/lawyer/application/VerificationService.java
+++ b/src/main/java/org/example/shield/lawyer/application/VerificationService.java
@@ -1,25 +1,51 @@
 package org.example.shield.lawyer.application;
 
-/**
- * 변호사 검증 서비스 - 검증 신청/상태 확인/관리자 처리.
- *
- * Layer: application
- * Called by: LawyerController (신청/상태), AdminController (처리)
- * Calls: LawyerReader, LawyerWriter, NotificationSender
- *
- * TODO:
- * - requestVerification(userId, barAssociationNumber):
- *   1. lawyers에 barAssociationNumber 저장
- *   2. verificationStatus를 PENDING으로 설정
- *   3. 이미 PENDING이면 409 에러
- *
- * - getVerificationStatus(userId): verificationStatus + verifiedAt 반환
- *
- * - processVerification(lawyerId, action, reason):
- *   1. action이 APPROVE → VERIFIED + verifiedAt 설정
- *   2. action이 REJECT → REJECTED
- *   3. 관리자(ADMIN)만 호출 가능
- *   4. NotificationSender로 변호사에게 이메일 알림
- */
+import lombok.RequiredArgsConstructor;
+import org.example.shield.common.enums.VerificationStatus;
+import org.example.shield.common.exception.BusinessException;
+import org.example.shield.common.exception.ErrorCode;
+import org.example.shield.lawyer.controller.dto.VerificationResponse;
+import org.example.shield.lawyer.domain.LawyerProfile;
+import org.example.shield.lawyer.domain.LawyerReader;
+import org.example.shield.lawyer.domain.LawyerWriter;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class VerificationService {
+
+    private final LawyerReader lawyerReader;
+    private final LawyerWriter lawyerWriter;
+
+    public VerificationResponse requestVerification(UUID userId, String barAssociationNumber) {
+        try {
+            LawyerProfile existing = lawyerReader.findByUserId(userId);
+            if (existing.getVerificationStatus() == VerificationStatus.PENDING
+                    || existing.getVerificationStatus() == VerificationStatus.REVIEWING) {
+                throw new BusinessException(ErrorCode.VERIFICATION_ALREADY_SUBMITTED) {};
+            }
+            existing.updateVerificationStatus(VerificationStatus.PENDING);
+            return VerificationResponse.from(existing);
+        } catch (BusinessException e) {
+            if (e.getErrorCode() == ErrorCode.LAWYER_NOT_FOUND) {
+                LawyerProfile profile = LawyerProfile.builder()
+                        .userId(userId)
+                        .barAssociationNumber(barAssociationNumber)
+                        .build();
+                LawyerProfile saved = lawyerWriter.save(profile);
+                return VerificationResponse.from(saved);
+            }
+            throw e;
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public VerificationResponse getVerificationStatus(UUID userId) {
+        LawyerProfile profile = lawyerReader.findByUserId(userId);
+        return VerificationResponse.from(profile);
+    }
 }

--- a/src/main/java/org/example/shield/lawyer/controller/LawyerController.java
+++ b/src/main/java/org/example/shield/lawyer/controller/LawyerController.java
@@ -2,12 +2,27 @@ package org.example.shield.lawyer.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.shield.common.response.ApiResponse;
+import org.example.shield.common.response.PageResponse;
 import org.example.shield.lawyer.application.LawyerDocumentService;
+import org.example.shield.lawyer.application.LawyerService;
+import org.example.shield.lawyer.application.VerificationService;
 import org.example.shield.lawyer.controller.dto.DocumentResponse;
+import org.example.shield.lawyer.controller.dto.LawyerResponse;
+import org.example.shield.lawyer.controller.dto.ProfileUpdateRequest;
+import org.example.shield.lawyer.controller.dto.VerificationRequest;
+import org.example.shield.lawyer.controller.dto.VerificationResponse;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,21 +36,68 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class LawyerController {
 
+    private final LawyerService lawyerService;
+    private final VerificationService verificationService;
     private final LawyerDocumentService lawyerDocumentService;
 
+    @Operation(summary = "변호사 목록 조회", description = "인증된 변호사 목록을 경력순으로 조회합니다")
+    @GetMapping
+    public ApiResponse<PageResponse<LawyerResponse>> getLawyers(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "experienceYears"));
+        PageResponse<LawyerResponse> result = lawyerService.getLawyers(pageable);
+        return ApiResponse.success("조회 성공", result);
+    }
+
+    @Operation(summary = "변호사 프로필 상세", description = "변호사 프로필을 상세 조회합니다 (의뢰인용)")
+    @GetMapping("/{lawyerId}")
+    public ApiResponse<LawyerResponse> getLawyer(@PathVariable UUID lawyerId) {
+        LawyerResponse result = lawyerService.getLawyer(lawyerId);
+        return ApiResponse.success("조회 성공", result);
+    }
+
+    @Operation(summary = "내 프로필 조회", description = "변호사 본인의 프로필을 조회합니다")
+    @GetMapping("/me")
+    public ApiResponse<LawyerResponse> getMyProfile(
+            @AuthenticationPrincipal UUID userId) {
+        LawyerResponse result = lawyerService.getMyProfile(userId);
+        return ApiResponse.success("조회 성공", result);
+    }
+
+    @Operation(summary = "내 프로필 수정", description = "변호사 본인의 프로필을 수정합니다")
+    @PatchMapping("/me")
+    public ApiResponse<LawyerResponse> updateMyProfile(
+            @AuthenticationPrincipal UUID userId,
+            @RequestBody ProfileUpdateRequest request) {
+        LawyerResponse result = lawyerService.updateMyProfile(userId, request);
+        return ApiResponse.success("프로필이 수정되었습니다", result);
+    }
+
+    @Operation(summary = "검증 상태 확인", description = "변호사 자격 검증 상태를 확인합니다")
+    @GetMapping("/me/verification-status")
+    public ApiResponse<VerificationResponse> getVerificationStatus(
+            @AuthenticationPrincipal UUID userId) {
+        VerificationResponse result = verificationService.getVerificationStatus(userId);
+        return ApiResponse.success("조회 성공", result);
+    }
+
+    @Operation(summary = "검증 신청", description = "대한변호사협회 등록번호로 자격 검증을 신청합니다")
+    @PostMapping("/me/verification-request")
+    public ApiResponse<VerificationResponse> requestVerification(
+            @AuthenticationPrincipal UUID userId,
+            @Valid @RequestBody VerificationRequest request) {
+        VerificationResponse result = verificationService.requestVerification(
+                userId, request.barAssociationNumber());
+        return ApiResponse.success("검증 신청이 완료되었습니다", result);
+    }
+
     @Operation(summary = "서류 업로드", description = "변호사 자격증 등 서류를 업로드합니다 (PDF, JPG, PNG / 최대 10MB)")
-    @PostMapping("/me/documents")
+    @PostMapping(value = "/me/documents", consumes = "multipart/form-data")
     public ApiResponse<DocumentResponse> uploadDocument(
             @AuthenticationPrincipal UUID userId,
             @RequestParam("file") MultipartFile file) {
         DocumentResponse result = lawyerDocumentService.uploadDocument(userId, file);
         return ApiResponse.success("서류가 업로드되었습니다", result);
     }
-
-    // TODO: GET   /api/lawyers                             — 변호사 목록 조회
-    // TODO: GET   /api/lawyers/{lawyerId}                  — 변호사 프로필 상세 (의뢰인용)
-    // TODO: GET   /api/lawyers/me                          — 내 프로필 조회 (차후 구현)
-    // TODO: PATCH /api/lawyers/me                          — 내 프로필 수정 (차후 구현)
-    // TODO: POST  /api/lawyers/me/verification-request     — 검증 신청
-    // TODO: GET   /api/lawyers/me/verification-status      — 검증 상태 확인
 }

--- a/src/main/java/org/example/shield/lawyer/controller/LawyerController.java
+++ b/src/main/java/org/example/shield/lawyer/controller/LawyerController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.shield.common.response.ApiResponse;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.example.shield.common.response.PageResponse;
 import org.example.shield.lawyer.application.LawyerDocumentService;
 import org.example.shield.lawyer.application.LawyerService;
@@ -58,6 +59,7 @@ public class LawyerController {
     }
 
     @Operation(summary = "내 프로필 조회", description = "변호사 본인의 프로필을 조회합니다")
+    @PreAuthorize("hasRole('LAWYER')")
     @GetMapping("/me")
     public ApiResponse<LawyerResponse> getMyProfile(
             @AuthenticationPrincipal UUID userId) {
@@ -66,6 +68,7 @@ public class LawyerController {
     }
 
     @Operation(summary = "내 프로필 수정", description = "변호사 본인의 프로필을 수정합니다")
+    @PreAuthorize("hasRole('LAWYER')")
     @PatchMapping("/me")
     public ApiResponse<LawyerResponse> updateMyProfile(
             @AuthenticationPrincipal UUID userId,
@@ -75,6 +78,7 @@ public class LawyerController {
     }
 
     @Operation(summary = "검증 상태 확인", description = "변호사 자격 검증 상태를 확인합니다")
+    @PreAuthorize("hasRole('LAWYER')")
     @GetMapping("/me/verification-status")
     public ApiResponse<VerificationResponse> getVerificationStatus(
             @AuthenticationPrincipal UUID userId) {
@@ -83,6 +87,7 @@ public class LawyerController {
     }
 
     @Operation(summary = "검증 신청", description = "대한변호사협회 등록번호로 자격 검증을 신청합니다")
+    @PreAuthorize("hasRole('LAWYER')")
     @PostMapping("/me/verification-request")
     public ApiResponse<VerificationResponse> requestVerification(
             @AuthenticationPrincipal UUID userId,
@@ -93,6 +98,7 @@ public class LawyerController {
     }
 
     @Operation(summary = "서류 업로드", description = "변호사 자격증 등 서류를 업로드합니다 (PDF, JPG, PNG / 최대 10MB)")
+    @PreAuthorize("hasRole('LAWYER')")
     @PostMapping(value = "/me/documents", consumes = "multipart/form-data")
     public ApiResponse<DocumentResponse> uploadDocument(
             @AuthenticationPrincipal UUID userId,

--- a/src/main/java/org/example/shield/lawyer/controller/dto/LawyerResponse.java
+++ b/src/main/java/org/example/shield/lawyer/controller/dto/LawyerResponse.java
@@ -1,20 +1,36 @@
 package org.example.shield.lawyer.controller.dto;
 
-/**
- * 변호사 프로필 응답 DTO.
- *
- * TODO: record로 구현
- * - lawyerId: UUID
- * - name: String
- * - profileImageUrl: String (nullable)
- * - specializations: String
- * - experienceYears: int
- * - tags: List<String>
- * - matchedKeywords: List<String>
- * - certifications: List<String>
- * - caseCount: int
- * - bio: String (nullable)
- * - verificationStatus: String (PENDING / VERIFIED / REJECTED)
- */
-public class LawyerResponse {
+import org.example.shield.lawyer.domain.LawyerProfile;
+
+import java.util.List;
+import java.util.UUID;
+
+public record LawyerResponse(
+        UUID lawyerId,
+        String name,
+        String profileImageUrl,
+        String specializations,
+        Integer experienceYears,
+        List<String> tags,
+        List<String> certifications,
+        Integer caseCount,
+        String bio,
+        String region,
+        String verificationStatus
+) {
+    public static LawyerResponse from(LawyerProfile profile, String name, String profileImageUrl) {
+        return new LawyerResponse(
+                profile.getId(),
+                name,
+                profileImageUrl,
+                profile.getSpecializations(),
+                profile.getExperienceYears(),
+                profile.getTags(),
+                profile.getCertifications(),
+                profile.getCaseCount(),
+                profile.getBio(),
+                profile.getRegion(),
+                profile.getVerificationStatus().name()
+        );
+    }
 }

--- a/src/main/java/org/example/shield/lawyer/controller/dto/ProfileUpdateRequest.java
+++ b/src/main/java/org/example/shield/lawyer/controller/dto/ProfileUpdateRequest.java
@@ -1,12 +1,12 @@
 package org.example.shield.lawyer.controller.dto;
 
-/**
- * 변호사 프로필 수정 요청 DTO.
- *
- * TODO:
- * - specializations: List<String> (전문분야)
- * - experienceYears: int (경력)
- * - certifications: String (자격증)
- */
-public class ProfileUpdateRequest {
-}
+import java.util.List;
+
+public record ProfileUpdateRequest(
+        String specializations,
+        Integer experienceYears,
+        List<String> certifications,
+        List<String> tags,
+        String bio,
+        String region
+) {}

--- a/src/main/java/org/example/shield/lawyer/controller/dto/VerificationRequest.java
+++ b/src/main/java/org/example/shield/lawyer/controller/dto/VerificationRequest.java
@@ -1,0 +1,8 @@
+package org.example.shield.lawyer.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record VerificationRequest(
+        @NotBlank(message = "대한변호사협회 등록번호는 필수입니다")
+        String barAssociationNumber
+) {}

--- a/src/main/java/org/example/shield/lawyer/controller/dto/VerificationResponse.java
+++ b/src/main/java/org/example/shield/lawyer/controller/dto/VerificationResponse.java
@@ -1,12 +1,19 @@
 package org.example.shield.lawyer.controller.dto;
 
-/**
- * 변호사 검증 상태 응답 DTO.
- *
- * TODO: record로 구현
- * - verificationStatus: String (PENDING / VERIFIED / REJECTED)
- * - barAssociationNumber: String
- * - verifiedAt: LocalDateTime (nullable)
- */
-public class VerificationResponse {
+import org.example.shield.lawyer.domain.LawyerProfile;
+
+import java.time.LocalDateTime;
+
+public record VerificationResponse(
+        String verificationStatus,
+        String barAssociationNumber,
+        LocalDateTime verifiedAt
+) {
+    public static VerificationResponse from(LawyerProfile profile) {
+        return new VerificationResponse(
+                profile.getVerificationStatus().name(),
+                profile.getBarAssociationNumber(),
+                profile.getVerifiedAt()
+        );
+    }
 }

--- a/src/main/java/org/example/shield/lawyer/domain/LawyerProfile.java
+++ b/src/main/java/org/example/shield/lawyer/domain/LawyerProfile.java
@@ -87,6 +87,11 @@ public class LawyerProfile extends BaseEntity {
         this.region = region;
     }
 
+    public void requestVerification(String barAssociationNumber) {
+        this.barAssociationNumber = barAssociationNumber;
+        this.verificationStatus = VerificationStatus.PENDING;
+    }
+
     public void updateVerificationStatus(VerificationStatus newStatus) {
         this.verificationStatus = newStatus;
         if (newStatus == VerificationStatus.VERIFIED) {

--- a/src/main/java/org/example/shield/lawyer/domain/LawyerProfile.java
+++ b/src/main/java/org/example/shield/lawyer/domain/LawyerProfile.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.shield.common.domain.BaseEntity;
@@ -58,6 +59,33 @@ public class LawyerProfile extends BaseEntity {
 
     @Version
     private Long version;
+
+    @Builder
+    public LawyerProfile(UUID userId, String barAssociationNumber, String specializations,
+                         Integer experienceYears, List<String> tags, String bio,
+                         List<String> certifications, String region) {
+        this.userId = userId;
+        this.barAssociationNumber = barAssociationNumber;
+        this.specializations = specializations;
+        this.experienceYears = experienceYears;
+        this.tags = tags;
+        this.bio = bio;
+        this.certifications = certifications;
+        this.region = region;
+        this.verificationStatus = VerificationStatus.PENDING;
+        this.caseCount = 0;
+    }
+
+    public void updateProfile(String specializations, Integer experienceYears,
+                              List<String> certifications, List<String> tags,
+                              String bio, String region) {
+        this.specializations = specializations;
+        this.experienceYears = experienceYears;
+        this.certifications = certifications;
+        this.tags = tags;
+        this.bio = bio;
+        this.region = region;
+    }
 
     public void updateVerificationStatus(VerificationStatus newStatus) {
         this.verificationStatus = newStatus;

--- a/src/main/java/org/example/shield/lawyer/exception/LawyerNotFoundException.java
+++ b/src/main/java/org/example/shield/lawyer/exception/LawyerNotFoundException.java
@@ -1,8 +1,11 @@
 package org.example.shield.lawyer.exception;
 
-/**
- * 변호사 없음 예외.
- * lawyerId로 조회했는데 없을 때 발생.
- */
-public class LawyerNotFoundException {
+import org.example.shield.common.exception.BusinessException;
+import org.example.shield.common.exception.ErrorCode;
+
+public class LawyerNotFoundException extends BusinessException {
+
+    public LawyerNotFoundException() {
+        super(ErrorCode.LAWYER_NOT_FOUND);
+    }
 }


### PR DESCRIPTION
## 개요
변호사(Lawyer) 도메인 API 6개 구현 + 권한 검증 + AccessDeniedException 핸들러 추가

## 변경 사항

### API
- `GET /api/lawyers` - 변호사 목록 조회 (VERIFIED만, 경력순 정렬)
- `GET /api/lawyers/{lawyerId}` - 변호사 프로필 상세 (의뢰인용)
- `GET /api/lawyers/me` - 내 프로필 조회 (LAWYER만)
- `PATCH /api/lawyers/me` - 내 프로필 수정 (LAWYER만)
- `GET /api/lawyers/me/verification-status` - 검증 상태 확인 (LAWYER만)
- `POST /api/lawyers/me/verification-request` - 검증 신청 (LAWYER만, 변협 번호 제출)

### 구조
- LawyerService: 목록/상세/내 프로필/프로필 수정
- VerificationService: 검증 신청 (LawyerProfile 생성 + PENDING) / 상태 조회
- LawyerController: 6개 API + 서류 업로드 consumes 설정
- LawyerProfile: Builder, 생성자, updateProfile() 추가
- DTO: LawyerResponse, ProfileUpdateRequest, VerificationRequest, VerificationResponse (전부 record)

### 권한 검증
- `/api/lawyers/me/**` 엔드포인트에 `@PreAuthorize("hasRole(LAWYER)")` 적용
- USER/ADMIN 계정으로 변호사 전용 API 접근 시 403 반환
- GlobalExceptionHandler에 AccessDeniedException 핸들러 추가 (500 -> 403 수정)

### 검증 플로우
- LAWYER 로그인 -> PATCH /me (프로필 작성) -> POST /me/verification-request (검증 신청) -> PENDING
- 중복 신청 차단 (PENDING/REVIEWING 상태에서 재신청 시 409)
- LawyerProfile 없으면 자동 생성, 있으면 상태만 변경

## 참고
- 서류 업로드 API는 기존 구현(PR #13), consumes 설정만 추가
- LawyerNotFoundException 구현 (BusinessException 상속)
- N+1 방지: User 정보 bulk fetch (findAllByIds)

## 테스트
- OK 전체 36개 API 테스트 통과 (AUTH 6 + USER 2 + CONSULTATION 6 + BRIEF 4 + INBOX 1 + LAWYER 9 + ADMIN 8)
- OK 변호사 검증 신청/중복 차단/프로필 CRUD 검증
- OK USER/ADMIN -> LAWYER 전용 API 접근 403 차단 확인
- OK 토큰 없이 접근 403 확인