### PR TITLE
[FEAT] 변호사 수신함 및 의뢰서 처리 API 구현 (Issue #16)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 

--- a/src/main/java/org/example/shield/brief/application/DeliveryService.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryService.java
@@ -1,8 +1,10 @@
 package org.example.shield.brief.application;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.shield.brief.controller.dto.DeliveryListResponse;
 import org.example.shield.brief.controller.dto.DeliveryResponse;
+import org.example.shield.brief.controller.dto.DeliveryStatusResponse;
 import org.example.shield.brief.controller.dto.InboxDetailResponse;
 import org.example.shield.brief.controller.dto.InboxResponse;
 import org.example.shield.brief.domain.Brief;
@@ -12,6 +14,7 @@ import org.example.shield.brief.domain.BriefDeliveryWriter;
 import org.example.shield.brief.domain.BriefReader;
 import org.example.shield.brief.exception.BriefNotFoundException;
 import org.example.shield.common.enums.BriefStatus;
+import org.example.shield.common.enums.DeliveryStatus;
 import org.example.shield.common.enums.PrivacySetting;
 import org.example.shield.common.enums.VerificationStatus;
 import org.example.shield.lawyer.domain.LawyerProfile;
@@ -23,6 +26,7 @@ import org.example.shield.user.domain.User;
 import org.example.shield.user.domain.UserReader;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +36,7 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -42,6 +47,55 @@ public class DeliveryService {
     private final BriefDeliveryWriter deliveryWriter;
     private final UserReader userReader;
     private final LawyerReader lawyerReader;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public DeliveryStatusResponse updateDeliveryStatus(UUID deliveryId, UUID lawyerId,
+                                                        String statusStr, String rejectionReason) {
+        log.info("의뢰서 수락/거절 요청. deliveryId={}, lawyerId={}, status={}", deliveryId, lawyerId, statusStr);
+
+        BriefDelivery delivery = deliveryReader.findById(deliveryId);
+
+        if (!delivery.getLawyerId().equals(lawyerId)) {
+            throw new BusinessException(ErrorCode.DELIVERY_NOT_FOUND) {};
+        }
+
+        if (delivery.getStatus() != DeliveryStatus.DELIVERED) {
+            throw new BusinessException(ErrorCode.DELIVERY_ALREADY_PROCESSED) {};
+        }
+
+        switch (statusStr.toUpperCase()) {
+            case "CONFIRMED" -> delivery.accept();
+            case "REJECTED" -> {
+                if (rejectionReason == null || rejectionReason.isBlank()) {
+                    throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE) {};
+                }
+                delivery.reject(rejectionReason);
+            }
+            default -> throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE) {};
+        }
+
+        deliveryWriter.save(delivery);
+
+        Brief brief = briefReader.findById(delivery.getBriefId());
+        User client = userReader.findById(brief.getUserId());
+        User lawyer = userReader.findById(lawyerId);
+
+        eventPublisher.publishEvent(new DeliveryStatusEvent(
+                client.getEmail(),
+                client.getName(),
+                lawyer.getName(),
+                brief.getTitle(),
+                delivery.getStatus().name(),
+                rejectionReason
+        ));
+
+        return new DeliveryStatusResponse(
+                delivery.getId(),
+                delivery.getStatus().name(),
+                delivery.getRespondedAt()
+        );
+    }
 
     @Transactional
     public DeliveryResponse createDelivery(UUID briefId, UUID lawyerId, UUID userId) {

--- a/src/main/java/org/example/shield/brief/application/DeliveryService.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryService.java
@@ -7,6 +7,7 @@ import org.example.shield.brief.controller.dto.DeliveryResponse;
 import org.example.shield.brief.controller.dto.DeliveryStatusResponse;
 import org.example.shield.brief.controller.dto.InboxDetailResponse;
 import org.example.shield.brief.controller.dto.InboxResponse;
+import org.example.shield.brief.controller.dto.InboxStatsResponse;
 import org.example.shield.brief.domain.Brief;
 import org.example.shield.brief.domain.BriefDelivery;
 import org.example.shield.brief.domain.BriefDeliveryReader;
@@ -145,8 +146,10 @@ public class DeliveryService {
         return new DeliveryListResponse(responses);
     }
 
-    public PageResponse<InboxResponse> getInbox(UUID lawyerId, Pageable pageable) {
-        Page<BriefDelivery> deliveries = deliveryReader.findAllByLawyerId(lawyerId, pageable);
+    public PageResponse<InboxResponse> getInbox(UUID lawyerId, DeliveryStatus status, Pageable pageable) {
+        Page<BriefDelivery> deliveries = (status != null)
+                ? deliveryReader.findAllByLawyerIdAndStatus(lawyerId, status, pageable)
+                : deliveryReader.findAllByLawyerId(lawyerId, pageable);
 
         List<UUID> briefIds = deliveries.getContent().stream()
                 .map(BriefDelivery::getBriefId).toList();
@@ -159,6 +162,14 @@ public class DeliveryService {
         });
 
         return PageResponse.from(responsePage);
+    }
+
+    public InboxStatsResponse getInboxStats(UUID lawyerId) {
+        long total = deliveryReader.countByLawyerId(lawyerId);
+        long pending = deliveryReader.countByLawyerIdAndStatus(lawyerId, DeliveryStatus.DELIVERED);
+        long confirmed = deliveryReader.countByLawyerIdAndStatus(lawyerId, DeliveryStatus.CONFIRMED);
+        long rejected = deliveryReader.countByLawyerIdAndStatus(lawyerId, DeliveryStatus.REJECTED);
+        return new InboxStatsResponse(total, pending, confirmed, rejected);
     }
 
     @Transactional

--- a/src/main/java/org/example/shield/brief/application/DeliveryService.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryService.java
@@ -52,8 +52,8 @@ public class DeliveryService {
 
     @Transactional
     public DeliveryStatusResponse updateDeliveryStatus(UUID deliveryId, UUID lawyerId,
-                                                        String statusStr, String rejectionReason) {
-        log.info("의뢰서 수락/거절 요청. deliveryId={}, lawyerId={}, status={}", deliveryId, lawyerId, statusStr);
+                                                        DeliveryStatus status, String rejectionReason) {
+        log.info("의뢰서 수락/거절 요청. deliveryId={}, lawyerId={}, status={}", deliveryId, lawyerId, status);
 
         BriefDelivery delivery = deliveryReader.findById(deliveryId);
 
@@ -65,9 +65,9 @@ public class DeliveryService {
             throw new BusinessException(ErrorCode.DELIVERY_ALREADY_PROCESSED) {};
         }
 
-        switch (statusStr.toUpperCase()) {
-            case "CONFIRMED" -> delivery.accept();
-            case "REJECTED" -> {
+        switch (status) {
+            case CONFIRMED -> delivery.accept();
+            case REJECTED -> {
                 if (rejectionReason == null || rejectionReason.isBlank()) {
                     throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE) {};
                 }
@@ -165,11 +165,11 @@ public class DeliveryService {
     }
 
     public InboxStatsResponse getInboxStats(UUID lawyerId) {
-        long total = deliveryReader.countByLawyerId(lawyerId);
-        long pending = deliveryReader.countByLawyerIdAndStatus(lawyerId, DeliveryStatus.DELIVERED);
-        long confirmed = deliveryReader.countByLawyerIdAndStatus(lawyerId, DeliveryStatus.CONFIRMED);
-        long rejected = deliveryReader.countByLawyerIdAndStatus(lawyerId, DeliveryStatus.REJECTED);
-        return new InboxStatsResponse(total, pending, confirmed, rejected);
+        Map<DeliveryStatus, Long> statusCountMap = deliveryReader.countGroupByStatus(lawyerId);
+        long pending = statusCountMap.getOrDefault(DeliveryStatus.DELIVERED, 0L);
+        long confirmed = statusCountMap.getOrDefault(DeliveryStatus.CONFIRMED, 0L);
+        long rejected = statusCountMap.getOrDefault(DeliveryStatus.REJECTED, 0L);
+        return new InboxStatsResponse(pending + confirmed + rejected, pending, confirmed, rejected);
     }
 
     @Transactional

--- a/src/main/java/org/example/shield/brief/application/DeliveryStatusEvent.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryStatusEvent.java
@@ -1,0 +1,10 @@
+package org.example.shield.brief.application;
+
+public record DeliveryStatusEvent(
+        String clientEmail,
+        String clientName,
+        String lawyerName,
+        String briefTitle,
+        String status,
+        String rejectionReason
+) {}

--- a/src/main/java/org/example/shield/brief/controller/LawyerInboxController.java
+++ b/src/main/java/org/example/shield/brief/controller/LawyerInboxController.java
@@ -9,6 +9,8 @@ import org.example.shield.brief.controller.dto.DeliveryStatusRequest;
 import org.example.shield.brief.controller.dto.DeliveryStatusResponse;
 import org.example.shield.brief.controller.dto.InboxDetailResponse;
 import org.example.shield.brief.controller.dto.InboxResponse;
+import org.example.shield.brief.controller.dto.InboxStatsResponse;
+import org.example.shield.common.enums.DeliveryStatus;
 import org.example.shield.common.response.ApiResponse;
 import org.example.shield.common.response.PageResponse;
 import org.springframework.data.domain.PageRequest;
@@ -34,14 +36,23 @@ public class LawyerInboxController {
 
     private final DeliveryService deliveryService;
 
-    @Operation(summary = "수신 의뢰서 목록", description = "변호사에게 전달된 의뢰서 목록을 조회합니다")
+    @Operation(summary = "수신 의뢰서 목록", description = "변호사에게 전달된 의뢰서 목록을 조회합니다. status 파라미터로 필터링 가능")
     @GetMapping
     public ApiResponse<PageResponse<InboxResponse>> getInbox(
             @AuthenticationPrincipal UUID lawyerId,
+            @RequestParam(required = false) DeliveryStatus status,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "sentAt"));
-        PageResponse<InboxResponse> result = deliveryService.getInbox(lawyerId, pageable);
+        PageResponse<InboxResponse> result = deliveryService.getInbox(lawyerId, status, pageable);
+        return ApiResponse.success("조회 성공", result);
+    }
+
+    @Operation(summary = "수신함 통계", description = "변호사 수신함의 상태별 통계를 조회합니다")
+    @GetMapping("/stats")
+    public ApiResponse<InboxStatsResponse> getInboxStats(
+            @AuthenticationPrincipal UUID lawyerId) {
+        InboxStatsResponse result = deliveryService.getInboxStats(lawyerId);
         return ApiResponse.success("조회 성공", result);
     }
 

--- a/src/main/java/org/example/shield/brief/controller/LawyerInboxController.java
+++ b/src/main/java/org/example/shield/brief/controller/LawyerInboxController.java
@@ -2,8 +2,11 @@ package org.example.shield.brief.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.shield.brief.application.DeliveryService;
+import org.example.shield.brief.controller.dto.DeliveryStatusRequest;
+import org.example.shield.brief.controller.dto.DeliveryStatusResponse;
 import org.example.shield.brief.controller.dto.InboxDetailResponse;
 import org.example.shield.brief.controller.dto.InboxResponse;
 import org.example.shield.common.response.ApiResponse;
@@ -11,9 +14,12 @@ import org.example.shield.common.response.PageResponse;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -46,5 +52,17 @@ public class LawyerInboxController {
             @AuthenticationPrincipal UUID lawyerId) {
         InboxDetailResponse result = deliveryService.getInboxDetail(deliveryId, lawyerId);
         return ApiResponse.success("조회 성공", result);
+    }
+
+    @Operation(summary = "수신 의뢰서 수락/거절", description = "전달받은 의뢰서를 수락하거나 거절합니다")
+    @PreAuthorize("hasRole('LAWYER')")
+    @PatchMapping("/{deliveryId}/status")
+    public ApiResponse<DeliveryStatusResponse> updateDeliveryStatus(
+            @PathVariable UUID deliveryId,
+            @AuthenticationPrincipal UUID lawyerId,
+            @Valid @RequestBody DeliveryStatusRequest request) {
+        DeliveryStatusResponse result = deliveryService.updateDeliveryStatus(
+                deliveryId, lawyerId, request.status(), request.rejectionReason());
+        return ApiResponse.success("처리 완료", result);
     }
 }

--- a/src/main/java/org/example/shield/brief/controller/dto/DeliveryStatusRequest.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/DeliveryStatusRequest.java
@@ -1,9 +1,10 @@
 package org.example.shield.brief.controller.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.example.shield.common.enums.DeliveryStatus;
 
 public record DeliveryStatusRequest(
-        @NotBlank(message = "상태는 필수입니다")
-        String status,
+        @NotNull(message = "상태는 필수입니다")
+        DeliveryStatus status,
         String rejectionReason
 ) {}

--- a/src/main/java/org/example/shield/brief/controller/dto/DeliveryStatusRequest.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/DeliveryStatusRequest.java
@@ -1,0 +1,9 @@
+package org.example.shield.brief.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record DeliveryStatusRequest(
+        @NotBlank(message = "상태는 필수입니다")
+        String status,
+        String rejectionReason
+) {}

--- a/src/main/java/org/example/shield/brief/controller/dto/DeliveryStatusResponse.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/DeliveryStatusResponse.java
@@ -1,0 +1,10 @@
+package org.example.shield.brief.controller.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record DeliveryStatusResponse(
+        UUID deliveryId,
+        String status,
+        LocalDateTime respondedAt
+) {}

--- a/src/main/java/org/example/shield/brief/controller/dto/InboxDetailResponse.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/InboxDetailResponse.java
@@ -7,14 +7,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
-/**
- * TODO [Issue #16] keyIssues 필드 추가
- *
- * - record에 List<String> keyIssues 필드 추가 (keywords 다음 위치)
- * - of() 메서드에 brief.getKeyIssues() 전달
- * - Notion 수신 의뢰서 상세 Response에도 keyIssues 필드 추가
- * - nullable: brief에 keyIssues가 없을 수 있음 (List<String> | null)
- */
 public record InboxDetailResponse(
         UUID deliveryId,
         UUID briefId,
@@ -22,6 +14,7 @@ public record InboxDetailResponse(
         String legalField,
         String content,
         List<String> keywords,
+        List<String> keyIssues,
         String status,
         String clientName,
         String clientEmail,
@@ -36,6 +29,7 @@ public record InboxDetailResponse(
                 brief.getLegalField(),
                 brief.getContent(),
                 brief.getKeywords(),
+                brief.getKeyIssues(),
                 delivery.getStatus().name(),
                 clientName,
                 clientEmail,

--- a/src/main/java/org/example/shield/brief/controller/dto/InboxDetailResponse.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/InboxDetailResponse.java
@@ -7,6 +7,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * TODO [Issue #16] keyIssues 필드 추가
+ *
+ * - record에 List<String> keyIssues 필드 추가 (keywords 다음 위치)
+ * - of() 메서드에 brief.getKeyIssues() 전달
+ * - Notion 수신 의뢰서 상세 Response에도 keyIssues 필드 추가
+ * - nullable: brief에 keyIssues가 없을 수 있음 (List<String> | null)
+ */
 public record InboxDetailResponse(
         UUID deliveryId,
         UUID briefId,

--- a/src/main/java/org/example/shield/brief/controller/dto/InboxStatsResponse.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/InboxStatsResponse.java
@@ -1,0 +1,8 @@
+package org.example.shield.brief.controller.dto;
+
+public record InboxStatsResponse(
+        long total,
+        long pending,
+        long confirmed,
+        long rejected
+) {}

--- a/src/main/java/org/example/shield/brief/domain/BriefDeliveryReader.java
+++ b/src/main/java/org/example/shield/brief/domain/BriefDeliveryReader.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface BriefDeliveryReader {
@@ -13,6 +14,5 @@ public interface BriefDeliveryReader {
     Page<BriefDelivery> findAllByLawyerId(UUID lawyerId, Pageable pageable);
     Page<BriefDelivery> findAllByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status, Pageable pageable);
     boolean existsByBriefIdAndLawyerId(UUID briefId, UUID lawyerId);
-    long countByLawyerId(UUID lawyerId);
-    long countByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status);
+    Map<DeliveryStatus, Long> countGroupByStatus(UUID lawyerId);
 }

--- a/src/main/java/org/example/shield/brief/domain/BriefDeliveryReader.java
+++ b/src/main/java/org/example/shield/brief/domain/BriefDeliveryReader.java
@@ -1,22 +1,18 @@
 package org.example.shield.brief.domain;
 
+import org.example.shield.common.enums.DeliveryStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.UUID;
 
-/**
- * TODO [Issue #16] status 필터 메서드 추가
- *
- * - Page<BriefDelivery> findAllByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status, Pageable pageable)
- * - BriefDeliveryRepository + BriefDeliveryReaderImpl에도 동일 추가
- * - long countByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status) — 대시보드 통계용
- * - long countByLawyerIdAndRespondedAtAfter(UUID lawyerId, LocalDateTime after) — 이번 주 완료 카운트용
- */
 public interface BriefDeliveryReader {
     BriefDelivery findById(UUID id);
     List<BriefDelivery> findAllByBriefId(UUID briefId);
     Page<BriefDelivery> findAllByLawyerId(UUID lawyerId, Pageable pageable);
+    Page<BriefDelivery> findAllByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status, Pageable pageable);
     boolean existsByBriefIdAndLawyerId(UUID briefId, UUID lawyerId);
+    long countByLawyerId(UUID lawyerId);
+    long countByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status);
 }

--- a/src/main/java/org/example/shield/brief/domain/BriefDeliveryReader.java
+++ b/src/main/java/org/example/shield/brief/domain/BriefDeliveryReader.java
@@ -6,6 +6,14 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * TODO [Issue #16] status 필터 메서드 추가
+ *
+ * - Page<BriefDelivery> findAllByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status, Pageable pageable)
+ * - BriefDeliveryRepository + BriefDeliveryReaderImpl에도 동일 추가
+ * - long countByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status) — 대시보드 통계용
+ * - long countByLawyerIdAndRespondedAtAfter(UUID lawyerId, LocalDateTime after) — 이번 주 완료 카운트용
+ */
 public interface BriefDeliveryReader {
     BriefDelivery findById(UUID id);
     List<BriefDelivery> findAllByBriefId(UUID briefId);

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryReaderImpl.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryReaderImpl.java
@@ -11,7 +11,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -46,12 +48,11 @@ public class BriefDeliveryReaderImpl implements BriefDeliveryReader {
     }
 
     @Override
-    public long countByLawyerId(UUID lawyerId) {
-        return briefDeliveryRepository.countByLawyerId(lawyerId);
-    }
-
-    @Override
-    public long countByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status) {
-        return briefDeliveryRepository.countByLawyerIdAndStatus(lawyerId, status);
+    public Map<DeliveryStatus, Long> countGroupByStatus(UUID lawyerId) {
+        return briefDeliveryRepository.countGroupByStatus(lawyerId).stream()
+                .collect(Collectors.toMap(
+                        row -> (DeliveryStatus) row[0],
+                        row -> (Long) row[1]
+                ));
     }
 }

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryReaderImpl.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryReaderImpl.java
@@ -3,6 +3,7 @@ package org.example.shield.brief.infrastructure;
 import lombok.RequiredArgsConstructor;
 import org.example.shield.brief.domain.BriefDelivery;
 import org.example.shield.brief.domain.BriefDeliveryReader;
+import org.example.shield.common.enums.DeliveryStatus;
 import org.example.shield.common.exception.BusinessException;
 import org.example.shield.common.exception.ErrorCode;
 import org.springframework.data.domain.Page;
@@ -35,7 +36,22 @@ public class BriefDeliveryReaderImpl implements BriefDeliveryReader {
     }
 
     @Override
+    public Page<BriefDelivery> findAllByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status, Pageable pageable) {
+        return briefDeliveryRepository.findAllByLawyerIdAndStatus(lawyerId, status, pageable);
+    }
+
+    @Override
     public boolean existsByBriefIdAndLawyerId(UUID briefId, UUID lawyerId) {
         return briefDeliveryRepository.existsByBriefIdAndLawyerId(briefId, lawyerId);
+    }
+
+    @Override
+    public long countByLawyerId(UUID lawyerId) {
+        return briefDeliveryRepository.countByLawyerId(lawyerId);
+    }
+
+    @Override
+    public long countByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status) {
+        return briefDeliveryRepository.countByLawyerIdAndStatus(lawyerId, status);
     }
 }

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryRepository.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryRepository.java
@@ -1,6 +1,7 @@
 package org.example.shield.brief.infrastructure;
 
 import org.example.shield.brief.domain.BriefDelivery;
+import org.example.shield.common.enums.DeliveryStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,5 +12,8 @@ import java.util.UUID;
 public interface BriefDeliveryRepository extends JpaRepository<BriefDelivery, UUID> {
     List<BriefDelivery> findAllByBriefId(UUID briefId);
     Page<BriefDelivery> findAllByLawyerId(UUID lawyerId, Pageable pageable);
+    Page<BriefDelivery> findAllByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status, Pageable pageable);
     boolean existsByBriefIdAndLawyerId(UUID briefId, UUID lawyerId);
+    long countByLawyerId(UUID lawyerId);
+    long countByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status);
 }

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryRepository.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryRepository.java
@@ -5,6 +5,7 @@ import org.example.shield.common.enums.DeliveryStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.UUID;
@@ -14,6 +15,7 @@ public interface BriefDeliveryRepository extends JpaRepository<BriefDelivery, UU
     Page<BriefDelivery> findAllByLawyerId(UUID lawyerId, Pageable pageable);
     Page<BriefDelivery> findAllByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status, Pageable pageable);
     boolean existsByBriefIdAndLawyerId(UUID briefId, UUID lawyerId);
-    long countByLawyerId(UUID lawyerId);
-    long countByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status);
+
+    @Query("SELECT d.status, COUNT(d) FROM BriefDelivery d WHERE d.lawyerId = :lawyerId GROUP BY d.status")
+    List<Object[]> countGroupByStatus(UUID lawyerId);
 }

--- a/src/main/java/org/example/shield/common/config/AsyncConfig.java
+++ b/src/main/java/org/example/shield/common/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package org.example.shield.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "emailExecutor")
+    public Executor emailExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("email-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/org/example/shield/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/shield/common/exception/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     // Delivery
     DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 전달 건입니다"),
     DELIVERY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 전달된 변호사입니다"),
+    DELIVERY_ALREADY_PROCESSED(HttpStatus.CONFLICT, "이미 처리된 의뢰서입니다"),
 
     // Brief - Delivery
     BRIEF_NOT_CONFIRMED(HttpStatus.BAD_REQUEST, "의뢰서를 먼저 확정해 주세요"),

--- a/src/main/java/org/example/shield/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/shield/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.shield.common.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -32,6 +33,13 @@ public class GlobalExceptionHandler {
         log.warn("Validation failed: {}", message);
         return ResponseEntity.badRequest()
                 .body(ApiResponse.error(message));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMessageNotReadable(HttpMessageNotReadableException e) {
+        log.warn("Message not readable: {}", e.getMessage());
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.error(ErrorCode.INVALID_INPUT_VALUE.getMessage()));
     }
 
     @ExceptionHandler(AccessDeniedException.class)

--- a/src/main/java/org/example/shield/common/notification/EmailNotificationSender.java
+++ b/src/main/java/org/example/shield/common/notification/EmailNotificationSender.java
@@ -1,35 +1,57 @@
 package org.example.shield.common.notification;
 
-/**
- * TODO [Issue #16] Gmail SMTP 이메일 발송 구현
- *
- * 1. 클래스 설정
- *    - @Component + @RequiredArgsConstructor
- *    - JavaMailSender 주입
- *
- * 2. onDeliveryStatusChanged(DeliveryStatusEvent event)
- *    - @Async("emailExecutor")
- *    - @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
- *    - 수락: "{lawyerName} 변호사가 귀하의 의뢰서를 수락하였습니다."
- *    - 거절: "{lawyerName} 변호사가 귀하의 의뢰서를 거절하였습니다. 사유: {reason}"
- *    - 발송 실패 시 log.error만 남기고 예외 전파하지 않음
- *
- * 3. 의존성 추가 필요
- *    - build.gradle: spring-boot-starter-mail
- *    - application.yml: spring.mail.host/port/username/password
- *    - .env: GMAIL_USERNAME, GMAIL_APP_PASSWORD
- *
- * 4. AsyncConfig 신규 생성 (common/config/)
- *    - @Configuration + @EnableAsync
- *    - emailExecutor Bean: corePoolSize=2, maxPoolSize=5, queueCapacity=50
- *
- * 5. DeliveryStatusEvent 신규 생성 (brief/application/)
- *    - record: clientEmail, clientName, lawyerName, briefTitle, status, reason
- */
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.shield.brief.application.DeliveryStatusEvent;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class EmailNotificationSender implements NotificationSender {
+
+    private final JavaMailSender mailSender;
 
     @Override
     public void send(String to, String subject, String content) {
-        // TODO: JavaMailSender를 이용한 이메일 발송 구현
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(to);
+            message.setSubject(subject);
+            message.setText(content);
+            mailSender.send(message);
+            log.info("이메일 발송 완료. to={}, subject={}", to, subject);
+        } catch (Exception e) {
+            log.error("이메일 발송 실패. to={}, subject={}", to, subject, e);
+        }
+    }
+
+    @Async("emailExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onDeliveryStatusChanged(DeliveryStatusEvent event) {
+        log.info("의뢰서 상태 변경 이메일 발송. clientEmail={}, status={}", event.clientEmail(), event.status());
+
+        String subject;
+        String body;
+
+        if ("CONFIRMED".equals(event.status())) {
+            subject = "[SHIELD] " + event.lawyerName() + " 변호사가 의뢰서를 수락하였습니다";
+            body = event.clientName() + "님, 안녕하세요.\n\n"
+                    + event.lawyerName() + " 변호사가 \"" + event.briefTitle() + "\" 의뢰서를 수락하였습니다.\n\n"
+                    + "SHIELD에서 자세한 내용을 확인해 주세요.";
+        } else {
+            subject = "[SHIELD] " + event.lawyerName() + " 변호사가 의뢰서를 거절하였습니다";
+            body = event.clientName() + "님, 안녕하세요.\n\n"
+                    + event.lawyerName() + " 변호사가 \"" + event.briefTitle() + "\" 의뢰서를 거절하였습니다.\n"
+                    + "사유: " + event.rejectionReason() + "\n\n"
+                    + "다른 변호사에게 의뢰서를 전달해 보세요.";
+        }
+
+        send(event.clientEmail(), subject, body);
     }
 }

--- a/src/main/java/org/example/shield/common/notification/EmailNotificationSender.java
+++ b/src/main/java/org/example/shield/common/notification/EmailNotificationSender.java
@@ -1,5 +1,31 @@
 package org.example.shield.common.notification;
 
+/**
+ * TODO [Issue #16] Gmail SMTP 이메일 발송 구현
+ *
+ * 1. 클래스 설정
+ *    - @Component + @RequiredArgsConstructor
+ *    - JavaMailSender 주입
+ *
+ * 2. onDeliveryStatusChanged(DeliveryStatusEvent event)
+ *    - @Async("emailExecutor")
+ *    - @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+ *    - 수락: "{lawyerName} 변호사가 귀하의 의뢰서를 수락하였습니다."
+ *    - 거절: "{lawyerName} 변호사가 귀하의 의뢰서를 거절하였습니다. 사유: {reason}"
+ *    - 발송 실패 시 log.error만 남기고 예외 전파하지 않음
+ *
+ * 3. 의존성 추가 필요
+ *    - build.gradle: spring-boot-starter-mail
+ *    - application.yml: spring.mail.host/port/username/password
+ *    - .env: GMAIL_USERNAME, GMAIL_APP_PASSWORD
+ *
+ * 4. AsyncConfig 신규 생성 (common/config/)
+ *    - @Configuration + @EnableAsync
+ *    - emailExecutor Bean: corePoolSize=2, maxPoolSize=5, queueCapacity=50
+ *
+ * 5. DeliveryStatusEvent 신규 생성 (brief/application/)
+ *    - record: clientEmail, clientName, lawyerName, briefTitle, status, reason
+ */
 public class EmailNotificationSender implements NotificationSender {
 
     @Override

--- a/src/main/java/org/example/shield/lawyer/application/LawyerDocumentService.java
+++ b/src/main/java/org/example/shield/lawyer/application/LawyerDocumentService.java
@@ -76,6 +76,11 @@ public class LawyerDocumentService {
                 .toList();
     }
 
+    public List<DocumentResponse> getMyDocuments(UUID userId) {
+        var lawyer = lawyerReader.findByUserId(userId);
+        return getDocuments(lawyer.getId());
+    }
+
     private void validateFile(MultipartFile file) {
         if (file.isEmpty()) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE) {};

--- a/src/main/java/org/example/shield/lawyer/controller/LawyerController.java
+++ b/src/main/java/org/example/shield/lawyer/controller/LawyerController.java
@@ -29,27 +29,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.UUID;
 
 @Tag(name = "Lawyer", description = "변호사 API")
 @RestController
 @RequestMapping("/api/lawyers")
 @RequiredArgsConstructor
-/**
- * TODO [Issue #16]
- *
- * 1. GET /api/lawyers/me/documents — 변호사 본인 서류 조회
- *    - @PreAuthorize("hasRole('LAWYER')")
- *    - JWT userId → lawyerReader.findByUserId() → lawyerDocumentService.getDocuments(lawyer.getId())
- *    - Signed URL 포함 반환 (기존 admin 서류 조회와 동일 로직)
- *    - Response: List<DocumentResponse>
- *
- * 2. GET /api/lawyer/dashboard/stats — 변호사 대시보드 통계
- *    - 별도 LawyerDashboardController 또는 이 컨트롤러에 추가
- *    - Response: LawyerDashboardStatsResponse { newCount, reviewingCount, inProgressCount, weeklyCompletedCount }
- *    - delivery status 기준 카운트: DELIVERED=신규, 진행중=CONFIRMED, 이번 주 완료=respondedAt 기준
- *    - Notion API 명세서에 신규 추가 필요
- */
 public class LawyerController {
 
     private final LawyerService lawyerService;
@@ -120,5 +106,14 @@ public class LawyerController {
             @RequestParam("file") MultipartFile file) {
         DocumentResponse result = lawyerDocumentService.uploadDocument(userId, file);
         return ApiResponse.success("서류가 업로드되었습니다", result);
+    }
+
+    @Operation(summary = "내 서류 조회", description = "변호사 본인이 업로드한 서류 목록을 조회합니다")
+    @PreAuthorize("hasRole('LAWYER')")
+    @GetMapping("/me/documents")
+    public ApiResponse<List<DocumentResponse>> getMyDocuments(
+            @AuthenticationPrincipal UUID userId) {
+        List<DocumentResponse> result = lawyerDocumentService.getMyDocuments(userId);
+        return ApiResponse.success("조회 성공", result);
     }
 }

--- a/src/main/java/org/example/shield/lawyer/controller/LawyerController.java
+++ b/src/main/java/org/example/shield/lawyer/controller/LawyerController.java
@@ -35,6 +35,21 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/lawyers")
 @RequiredArgsConstructor
+/**
+ * TODO [Issue #16]
+ *
+ * 1. GET /api/lawyers/me/documents — 변호사 본인 서류 조회
+ *    - @PreAuthorize("hasRole('LAWYER')")
+ *    - JWT userId → lawyerReader.findByUserId() → lawyerDocumentService.getDocuments(lawyer.getId())
+ *    - Signed URL 포함 반환 (기존 admin 서류 조회와 동일 로직)
+ *    - Response: List<DocumentResponse>
+ *
+ * 2. GET /api/lawyer/dashboard/stats — 변호사 대시보드 통계
+ *    - 별도 LawyerDashboardController 또는 이 컨트롤러에 추가
+ *    - Response: LawyerDashboardStatsResponse { newCount, reviewingCount, inProgressCount, weeklyCompletedCount }
+ *    - delivery status 기준 카운트: DELIVERED=신규, 진행중=CONFIRMED, 이번 주 완료=respondedAt 기준
+ *    - Notion API 명세서에 신규 추가 필요
+ */
 public class LawyerController {
 
     private final LawyerService lawyerService;

--- a/src/main/java/org/example/shield/user/application/UserService.java
+++ b/src/main/java/org/example/shield/user/application/UserService.java
@@ -2,8 +2,10 @@ package org.example.shield.user.application;
 
 import lombok.RequiredArgsConstructor;
 import org.example.shield.user.controller.dto.UserResponse;
+import org.example.shield.user.controller.dto.UserUpdateRequest;
 import org.example.shield.user.domain.User;
 import org.example.shield.user.domain.UserReader;
+import org.example.shield.user.domain.UserWriter;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,9 +17,18 @@ import java.util.UUID;
 public class UserService {
 
     private final UserReader userReader;
+    private final UserWriter userWriter;
 
     public UserResponse getMyInfo(UUID userId) {
         User user = userReader.findById(userId);
+        return UserResponse.from(user);
+    }
+
+    @Transactional
+    public UserResponse updateMyInfo(UUID userId, UserUpdateRequest request) {
+        User user = userReader.findById(userId);
+        user.updateProfile(request.name(), request.phone());
+        userWriter.save(user);
         return UserResponse.from(user);
     }
 }

--- a/src/main/java/org/example/shield/user/controller/UserController.java
+++ b/src/main/java/org/example/shield/user/controller/UserController.java
@@ -18,6 +18,16 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
+/**
+ * TODO [Issue #16] PATCH /api/users/me — 내 정보 수정 추가
+ *
+ * - Request: UserUpdateRequest(record) { name (optional), phone (optional) }
+ * - User 엔티티에 updateProfile(String name, String phone) 비즈니스 메서드 추가
+ * - UserService에 updateMyInfo(UUID userId, UserUpdateRequest request) 추가
+ * - UserWriter 주입 필요 (현재 UserService에 UserReader만 있음)
+ * - Response: UserResponse (기존 from() 재활용)
+ * - Notion PATCH /api/users/me 페이지에 Request/Response 양식 작성 필요
+ */
 public class UserController {
 
     private final UserService userService;

--- a/src/main/java/org/example/shield/user/controller/UserController.java
+++ b/src/main/java/org/example/shield/user/controller/UserController.java
@@ -6,9 +6,11 @@ import lombok.RequiredArgsConstructor;
 import org.example.shield.common.response.ApiResponse;
 import org.example.shield.user.application.UserService;
 import org.example.shield.user.controller.dto.UserResponse;
-import org.springframework.http.ResponseEntity;
+import org.example.shield.user.controller.dto.UserUpdateRequest;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,25 +20,24 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
-/**
- * TODO [Issue #16] PATCH /api/users/me — 내 정보 수정 추가
- *
- * - Request: UserUpdateRequest(record) { name (optional), phone (optional) }
- * - User 엔티티에 updateProfile(String name, String phone) 비즈니스 메서드 추가
- * - UserService에 updateMyInfo(UUID userId, UserUpdateRequest request) 추가
- * - UserWriter 주입 필요 (현재 UserService에 UserReader만 있음)
- * - Response: UserResponse (기존 from() 재활용)
- * - Notion PATCH /api/users/me 페이지에 Request/Response 양식 작성 필요
- */
 public class UserController {
 
     private final UserService userService;
 
     @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자 정보 조회")
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<UserResponse>> getMyInfo(
+    public ApiResponse<UserResponse> getMyInfo(
             @AuthenticationPrincipal UUID userId) {
         UserResponse response = userService.getMyInfo(userId);
-        return ResponseEntity.ok(ApiResponse.success("사용자 정보 조회 성공", response));
+        return ApiResponse.success("조회 성공", response);
+    }
+
+    @Operation(summary = "내 정보 수정", description = "이름, 전화번호를 선택적으로 수정합니다")
+    @PatchMapping("/me")
+    public ApiResponse<UserResponse> updateMyInfo(
+            @AuthenticationPrincipal UUID userId,
+            @RequestBody UserUpdateRequest request) {
+        UserResponse response = userService.updateMyInfo(userId, request);
+        return ApiResponse.success("수정 완료", response);
     }
 }

--- a/src/main/java/org/example/shield/user/controller/dto/UserResponse.java
+++ b/src/main/java/org/example/shield/user/controller/dto/UserResponse.java
@@ -10,7 +10,8 @@ public record UserResponse(
         String name,
         String role,
         String provider,
-        String profileImageUrl
+        String profileImageUrl,
+        String phone
 ) {
     public static UserResponse from(User user) {
         return new UserResponse(
@@ -19,7 +20,8 @@ public record UserResponse(
                 user.getName(),
                 user.getRole().name(),
                 user.getProvider(),
-                user.getProfileImageUrl()
+                user.getProfileImageUrl(),
+                user.getPhone()
         );
     }
 }

--- a/src/main/java/org/example/shield/user/controller/dto/UserUpdateRequest.java
+++ b/src/main/java/org/example/shield/user/controller/dto/UserUpdateRequest.java
@@ -1,0 +1,6 @@
+package org.example.shield.user.controller.dto;
+
+public record UserUpdateRequest(
+        String name,
+        String phone
+) {}

--- a/src/main/java/org/example/shield/user/domain/User.java
+++ b/src/main/java/org/example/shield/user/domain/User.java
@@ -66,7 +66,7 @@ public class User {
     }
 
     public void updateProfile(String name, String phone) {
-        if (name != null) this.name = name;
-        if (phone != null) this.phone = phone;
+        if (name != null && !name.isBlank()) this.name = name;
+        if (phone != null && !phone.isBlank()) this.phone = phone;
     }
 }

--- a/src/main/java/org/example/shield/user/domain/User.java
+++ b/src/main/java/org/example/shield/user/domain/User.java
@@ -65,4 +65,8 @@ public class User {
         this.refreshToken = refreshToken;
     }
 
+    public void updateProfile(String name, String phone) {
+        if (name != null) this.name = name;
+        if (phone != null) this.phone = phone;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,18 @@ spring:
     hikari:
       maximum-pool-size: 5
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GMAIL_USERNAME}
+    password: ${GMAIL_APP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
   jpa:
     hibernate:
       ddl-auto: none


### PR DESCRIPTION
## Summary

- 변호사 의뢰서 수락/거절 API 구현 (PATCH /api/lawyer/inbox/{deliveryId}/status)
- 수락/거절 시 의뢰인에게 Gmail SMTP 이메일 알림 발송 (@Async + @TransactionalEventListener)
- 수신함 상태별 필터링 및 통계 API 추가 (GET /api/lawyer/inbox?status, GET /api/lawyer/inbox/stats)
- 수신 의뢰서 상세 응답에 keyIssues 필드 추가
- 변호사 본인 서류 조회 API 추가 (GET /api/lawyers/me/documents)
- 사용자 본인 정보 수정 API 추가 (PATCH /api/users/me)

## Changes

### 의뢰서 수락/거절
- `DeliveryService.updateDeliveryStatus()` — 상태 전이, 권한 검증, 중복 처리 방지(409)
- `DeliveryStatusEvent` 발행 → 이메일 알림 트리거
- 동일 의뢰서에 대해 각 변호사가 독립적으로 수락/거절 가능

### 이메일 알림
- `AsyncConfig` — 이메일 전용 스레드풀 (core=2, max=5)
- `EmailNotificationSender` — AFTER_COMMIT 후 비동기 Gmail 발송, 실패 시 log.error만

### 수신함 필터/통계
- `BriefDeliveryReader` — status 필터 조회 + 상태별 count 메서드 추가
- `InboxStatsResponse` — total, pending, confirmed, rejected 카운트

### 사용자/변호사
- `UserResponse`에 phone 필드 추가
- `User.updateProfile()` — name, phone 선택적 수정
- `LawyerDocumentService.getMyDocuments()` — 변호사 본인 서류 조회

## Test Plan

- [x] 의뢰서 수락 (CONFIRMED) → 200 + 이메일 발송
- [x] 의뢰서 거절 (REJECTED + reason) → 200 + 이메일 발송
- [x] 이미 처리된 의뢰서 재처리 → 409
- [x] 거절 시 사유 누락 → 400
- [x] USER 권한으로 수락/거절 → 403
- [x] 동일 의뢰서 다중 변호사 독립 수락/거절
- [x] 수신함 상태 필터 (DELIVERED, CONFIRMED, REJECTED)
- [x] 수신함 통계 조회
- [x] 변호사 본인 서류 조회 (Signed URL 포함)
- [x] 사용자 정보 수정 (name만, phone만, 둘 다)
- [x] ganzi2379@gmail.com 실제 이메일 수신 확인

Closes #16