### PR TITLE
[CHORE] EC2 배포를 위한 백엔드 리팩토링 (Issue #22)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-json'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# SHIELD Backend 배포 스크립트
+# 사용: ./deploy/deploy.sh
+
+set -e
+
+EC2_HOST="ec2-user@13.125.245.5"
+EC2_KEY="$HOME/.ssh/shield-key.pem"
+REMOTE_DIR="/home/ec2-user/shield"
+JAR_NAME="shield.jar"
+
+echo "[1/4] Gradle 빌드 중..."
+./gradlew clean bootJar -x test
+
+BUILD_JAR=$(find build/libs -name "*.jar" ! -name "*-plain.jar" | head -1)
+if [ -z "$BUILD_JAR" ]; then
+    echo "빌드 실패: jar 파일을 찾을 수 없음"
+    exit 1
+fi
+echo "빌드 완료: $BUILD_JAR"
+
+echo "[2/4] EC2로 jar 전송 중..."
+scp -i "$EC2_KEY" "$BUILD_JAR" "$EC2_HOST:$REMOTE_DIR/$JAR_NAME"
+
+echo "[3/4] 서비스 재시작 중..."
+ssh -i "$EC2_KEY" "$EC2_HOST" "sudo systemctl restart shield-backend"
+
+echo "[4/4] 헬스체크 중..."
+sleep 15
+HEALTH=$(curl -s -o /dev/null -w "%{http_code}" https://shieldai.kr/actuator/health || echo "000")
+if [ "$HEALTH" = "200" ]; then
+    echo "배포 성공! HTTP $HEALTH"
+else
+    echo "배포 확인 필요: HTTP $HEALTH"
+    echo "로그 확인: ssh -i $EC2_KEY $EC2_HOST 'sudo journalctl -u shield-backend -n 50'"
+fi

--- a/deploy/shield-backend.service
+++ b/deploy/shield-backend.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=SHIELD Backend Spring Boot Application
+After=network.target
+
+[Service]
+Type=simple
+User=ec2-user
+WorkingDirectory=/home/ec2-user/shield
+EnvironmentFile=/etc/shield/shield.env
+ExecStart=/usr/bin/java \
+  -Xms256m -Xmx512m \
+  -XX:+UseG1GC \
+  -XX:+ExitOnOutOfMemoryError \
+  -Dspring.profiles.active=prod \
+  -Dfile.encoding=UTF-8 \
+  -jar /home/ec2-user/shield/shield.jar
+SuccessExitStatus=143
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=shield-backend
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/shield.env.example
+++ b/deploy/shield.env.example
@@ -1,0 +1,37 @@
+# SHIELD Backend 환경변수 (프로덕션)
+# /etc/shield/shield.env 로 복사 후 값 채우기
+# chmod 600 /etc/shield/shield.env
+
+# Spring
+SPRING_PROFILES_ACTIVE=prod
+
+# PostgreSQL (Supabase)
+DB_URL=jdbc:postgresql://aws-1-ap-northeast-2.pooler.supabase.com:5432/postgres
+DB_USERNAME=
+DB_PASSWORD=
+
+# JWT (32 bytes 이상)
+JWT_SECRET=
+
+# Google OAuth
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=https://shieldai.kr/auth/callback
+
+# Supabase Storage
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Gmail SMTP
+GMAIL_USERNAME=
+GMAIL_APP_PASSWORD=
+
+# Groq API (AI)
+GROQ_API_KEY=
+
+# MongoDB (RAG)
+MONGODB_URI=
+MONGODB_DATABASE=shield
+
+# RAG (true=스텁모드, false=실제 검색)
+RAG_STUB=true

--- a/src/main/java/org/example/shield/auth/infrastructure/JwtAuthFilter.java
+++ b/src/main/java/org/example/shield/auth/infrastructure/JwtAuthFilter.java
@@ -62,6 +62,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         return path.startsWith("/api/auth/")
                 || path.startsWith("/swagger-ui/")
                 || path.startsWith("/api-docs")
-                || path.startsWith("/v3/api-docs");
+                || path.startsWith("/v3/api-docs")
+                || path.startsWith("/actuator/");
     }
 }

--- a/src/main/java/org/example/shield/common/config/SecurityConfig.java
+++ b/src/main/java/org/example/shield/common/config/SecurityConfig.java
@@ -34,7 +34,9 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
                                 "/api-docs/**",
-                                "/v3/api-docs/**"
+                                "/v3/api-docs/**",
+                                "/actuator/health",
+                                "/actuator/info"
                         ).permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    hikari:
+      maximum-pool-size: 5
+
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+# 로컬 CORS
+app:
+  cors:
+    allowed-origins: http://localhost:3000,http://localhost:5173,http://localhost:5174
+
+logging:
+  level:
+    org.example.shield: DEBUG
+    org.springframework.web: INFO

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -24,7 +24,7 @@ logging:
     root: WARN
     org.example.shield: INFO
   file:
-    name: /var/log/shield/application.log
+    name: logs/application.log
   logback:
     rollingpolicy:
       max-file-size: 10MB

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -44,3 +44,5 @@ management:
   health:
     db:
       enabled: true
+    mongodb:
+      enabled: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,46 @@
+spring:
+  datasource:
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 2
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+
+  jpa:
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+
+# 프로덕션 CORS
+app:
+  cors:
+    allowed-origins: https://shieldai.kr,https://www.shieldai.kr
+
+# 프로덕션 로깅
+logging:
+  level:
+    root: WARN
+    org.example.shield: INFO
+  file:
+    name: /var/log/shield/application.log
+  logback:
+    rollingpolicy:
+      max-file-size: 10MB
+      max-history: 30
+      total-size-cap: 500MB
+
+# Actuator (ALB 헬스체크)
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+      base-path: /actuator
+  endpoint:
+    health:
+      show-details: never
+  health:
+    db:
+      enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,9 @@ spring:
   application:
     name: shield
 
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:local}
+
   servlet:
     encoding:
       charset: UTF-8
@@ -22,8 +25,6 @@ spring:
     url: ${DB_URL}?prepareThreshold=0&stringtype=unspecified
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-    hikari:
-      maximum-pool-size: 5
 
   mail:
     host: smtp.gmail.com
@@ -42,10 +43,6 @@ spring:
       ddl-auto: none
       naming:
         physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
 
 # JWT
 jwt:
@@ -75,7 +72,7 @@ springdoc:
   api-docs:
     path: /api-docs
 
-# Groq API (replaces xAI Grok)
+# Groq API
 groq:
   api-key: ${GROQ_API_KEY}
   base-url: https://api.groq.com/openai
@@ -104,11 +101,6 @@ rag:
 ontology:
   slim-json-path: classpath:ontology/legal-ontology-slim.json
   cache-ttl-minutes: 60
-
-# CORS
-app:
-  cors:
-    allowed-origins: http://localhost:3000,http://localhost:5173,http://localhost:5174
 
 server:
   port: 8080


### PR DESCRIPTION
## 개요
EC2 배포를 위한 백엔드 리팩토링 (Issue #22)

## 변경 사항

### 프로파일 분리
- `application.yml`: 공통 설정만 유지, `SPRING_PROFILES_ACTIVE` 기본값 local
- `application-local.yml`: SQL 로깅 ON, CORS localhost, DEBUG 로깅
- `application-prod.yml`: SQL 로깅 OFF, CORS shieldai.kr, 파일 로깅, Actuator, MongoDB health check 비활성화

### Actuator
- `spring-boot-starter-actuator` 의존성 추가
- `/actuator/health`, `/actuator/info` 인증 없이 접근 허용 (ALB 헬스체크용)
- SecurityConfig + JwtAuthFilter에 actuator 경로 permitAll

### 배포 파일
- `deploy/shield-backend.service`: systemd 서비스 (-Xms256m -Xmx512m, auto restart)
- `deploy/shield.env.example`: 프로덕션 환경변수 템플릿
- `deploy/deploy.sh`: 빌드 -> scp -> systemctl restart -> 헬스체크 자동화

## EC2 환경
- Amazon Linux 2023, t3.micro
- 도메인: shieldai.kr (ALB + Route53 + HTTPS)
- JVM: -Xms256m -Xmx512m (1GB RAM 최적화)

## 테스트
- OK /actuator/health 토큰 없이 접근 가능
- OK dev login 정상 동작
- OK Swagger 정상 접근
- OK bootJar 빌드 성공 (97MB)
- OK 기존 API 영향 없음