### PR TITLE
[FIX] prod 서버 기동 실패 수정 - Redis 자동설정 비활성화

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,6 +13,11 @@ spring:
       hibernate:
         format_sql: false
 
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration
+      - org.springframework.boot.data.redis.autoconfigure.DataRedisReactiveAutoConfiguration
+
 # ALB 뒤에서 HTTPS 프록시 처리
 server:
   forward-headers-strategy: framework


### PR DESCRIPTION
## Summary
- prod에서 미사용 Redis 자동설정으로 인한 서버 크래시 수정
- EC2 env에 COHERE_API_KEY 수동 추가 완료

## Test plan
- [ ] Jenkins 빌드 성공 확인
- [ ] EC2 서버 정상 기동 확인