### PR TITLE
[FEAT] 판례·법령 통합 RAG 검색 (Issue #42)

### DIFF
--- a/src/main/java/org/example/shield/ai/application/LegalRetrievalService.java
+++ b/src/main/java/org/example/shield/ai/application/LegalRetrievalService.java
@@ -1,7 +1,9 @@
 package org.example.shield.ai.application;
 
 import org.example.shield.ai.dto.LegalChunk;
+import org.example.shield.ai.dto.MixedRetrievalResult;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -70,4 +72,33 @@ public interface LegalRetrievalService {
             List<String> lawIds,
             int topK
     );
+
+    /**
+     * 법령 + 판례 병합 하이브리드 검색 (C-5, Issue #42).
+     *
+     * <p>각 코퍼스에서 top-K 를 뽑아 {@code score DESC} 기준으로 merge 한 뒤 상위 {@code topK} 만
+     * 반환한다. Phase C-4 벤치마크에서 MRR +0.246 / nDCG@5 +0.250 가 검증된 경로다.</p>
+     *
+     * <p>기본 구현은 기존 {@link #retrieve} 만 호출해 법령 결과만 담아 반환한다 — Stub 구현체
+     * 처럼 판례 검색을 지원하지 않는 구현체에서도 안전하게 동작하도록 하기 위함. 실제 DB
+     * 기반 구현체({@code PgLegalRetrievalService}) 가 override 해서 판례까지 포함한다.</p>
+     *
+     * @param vectorQuery   벡터/BM25 검색용 자연어 쿼리
+     * @param bm25Keywords  BM25 핵심 키워드
+     * @param categoryIds   카테고리 필터 (법령·판례 공통)
+     * @param lawIds        법령 ID 필터 — 판례에는 적용되지 않음
+     * @param topK          상위 반환 개수 (병합 결과 기준)
+     * @return 법령·판례 별도 리스트와 병합 리스트를 모두 가진 결과 객체
+     */
+    default MixedRetrievalResult retrieveMixed(
+            String vectorQuery,
+            List<String> bm25Keywords,
+            List<String> categoryIds,
+            List<String> lawIds,
+            int topK
+    ) {
+        List<LegalChunk> laws = retrieve(vectorQuery, bm25Keywords, categoryIds, lawIds, topK);
+        List<org.example.shield.ai.dto.RetrievedDocument> merged = new ArrayList<>(laws);
+        return new MixedRetrievalResult(laws, List.of(), List.copyOf(merged));
+    }
 }

--- a/src/main/java/org/example/shield/ai/application/RagContextBuilder.java
+++ b/src/main/java/org/example/shield/ai/application/RagContextBuilder.java
@@ -1,19 +1,21 @@
 package org.example.shield.ai.application;
 
 import org.example.shield.ai.dto.LegalChunk;
+import org.example.shield.ai.dto.MixedRetrievalResult;
+import org.example.shield.ai.dto.Precedent;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 /**
  * Layer 3: RAG 컨텍스트 빌더.
- * 검색된 법률 조문 청크를 시스템 프롬프트에 삽입할 문자열로 포맷.
+ * 검색된 법률 조문 청크 (및 C-5 이후 판례) 를 시스템 프롬프트에 삽입할 문자열로 포맷한다.
  */
 @Component
 public class RagContextBuilder {
 
     /**
-     * LegalChunk 목록을 프롬프트 컨텍스트 문자열로 변환.
+     * LegalChunk 목록을 프롬프트 컨텍스트 문자열로 변환 (법령 전용, 기존 호환).
      *
      * @param chunks        검색된 법률 조문 청크 목록
      * @param intentSummary 의도 분류 요약 (메타 정보로 포함)
@@ -23,12 +25,60 @@ public class RagContextBuilder {
         if (chunks == null || chunks.isEmpty()) {
             return "";
         }
+        StringBuilder sb = new StringBuilder();
+        appendLawsSection(sb, chunks, intentSummary, /*includeCasesHeader*/ false);
+        return sb.toString();
+    }
+
+    /**
+     * 법령 + 판례 병합 결과를 프롬프트 컨텍스트 문자열로 변환 (C-5, Issue #42).
+     *
+     * <p>출력 구조:
+     * <ol>
+     *   <li>{@code ## 참고 법령} — 법령 조문 (없으면 해당 섹션 생략)</li>
+     *   <li>{@code ## 참고 판례} — 대법원/하급심 판례 (없으면 해당 섹션 생략)</li>
+     * </ol>
+     * 두 섹션 모두 비어 있으면 빈 문자열을 반환한다.</p>
+     *
+     * @param mixed         법령·판례 병합 검색 결과
+     * @param intentSummary 의도 분류 요약
+     */
+    public String build(MixedRetrievalResult mixed, String intentSummary) {
+        if (mixed == null || mixed.isEmpty()) {
+            return "";
+        }
+
+        List<LegalChunk> laws = mixed.laws();
+        List<Precedent> cases = mixed.cases();
 
         StringBuilder sb = new StringBuilder();
+        boolean hasCases = cases != null && !cases.isEmpty();
+
+        if (laws != null && !laws.isEmpty()) {
+            appendLawsSection(sb, laws, intentSummary, hasCases);
+        }
+
+        if (hasCases) {
+            if (sb.length() > 0) {
+                sb.append("\n");
+            }
+            appendCasesSection(sb, cases);
+        }
+
+        return sb.toString();
+    }
+
+    private void appendLawsSection(StringBuilder sb,
+                                   List<LegalChunk> chunks,
+                                   String intentSummary,
+                                   boolean casesFollow) {
         sb.append("## 참고 법령 (출처는 반드시 응답에 인용할 것)\n\n");
         sb.append("분류: ").append(intentSummary).append("\n\n");
         sb.append("다음은 본 사건과 관련된 현행 법령 조문입니다. 응답 시 이 정보를 우선 참고하고,\n");
         sb.append("인용 시 반드시 법령명과 조항 번호를 함께 표시하세요.\n");
+        if (casesFollow) {
+            sb.append("아래 '참고 판례' 섹션은 법리 해석 근거로만 활용하고, 조문 내용과 명확히 구분해 인용하세요.\n");
+        }
         sb.append("법령에 없는 내용은 추측하지 말고 \"관련 법령에서 확인할 수 없습니다\"라고 답하세요.\n");
 
         for (int i = 0; i < chunks.size(); i++) {
@@ -44,7 +94,47 @@ public class RagContextBuilder {
             sb.append("\n\n");
             sb.append(chunk.content()).append("\n");
         }
+    }
 
-        return sb.toString();
+    private void appendCasesSection(StringBuilder sb, List<Precedent> cases) {
+        sb.append("## 참고 판례 (법리 해석 근거, 인용 시 사건번호·선고일 함께 표시)\n\n");
+        sb.append("다음은 본 사건과 유사한 쟁점의 판례입니다. 법령 조문과 구분해 인용하고,\n");
+        sb.append("판례의 사실관계가 본 사건과 다를 경우 그 차이를 명시하세요.\n");
+
+        for (int i = 0; i < cases.size(); i++) {
+            Precedent p = cases.get(i);
+            sb.append("\n---\n");
+            sb.append("[").append(i + 1).append("] ");
+            // 예: [대법원 2025다213466 · 2025-03-15]
+            sb.append("[").append(nz(p.court())).append(" ").append(nz(p.caseNo()));
+            if (p.decisionDate() != null && !p.decisionDate().isEmpty()) {
+                sb.append(" · ").append(p.decisionDate());
+            }
+            sb.append("]");
+            if (p.caseName() != null && !p.caseName().isEmpty()) {
+                sb.append(" ").append(p.caseName());
+            }
+            sb.append("\n");
+            if (p.caseType() != null && !p.caseType().isEmpty()) {
+                sb.append("유형: ").append(p.caseType());
+            }
+            if (p.sourceUrl() != null && !p.sourceUrl().isEmpty()) {
+                if (p.caseType() != null && !p.caseType().isEmpty()) {
+                    sb.append(" / ");
+                }
+                sb.append("출처: ").append(p.sourceUrl());
+            }
+            sb.append("\n\n");
+            if (p.headnote() != null && !p.headnote().isEmpty()) {
+                sb.append("판시사항: ").append(p.headnote()).append("\n");
+            }
+            if (p.holding() != null && !p.holding().isEmpty()) {
+                sb.append("판결요지: ").append(p.holding()).append("\n");
+            }
+        }
+    }
+
+    private String nz(String s) {
+        return s == null ? "" : s;
     }
 }

--- a/src/main/java/org/example/shield/ai/application/RagPipelineService.java
+++ b/src/main/java/org/example/shield/ai/application/RagPipelineService.java
@@ -1,20 +1,23 @@
 package org.example.shield.ai.application;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.shield.ai.dto.IntentClassificationResult;
 import org.example.shield.ai.dto.LegalChunk;
+import org.example.shield.ai.dto.MixedRetrievalResult;
 import org.example.shield.consultation.domain.Message;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 /**
  * RAG 파이프라인 오케스트레이터.
- * Layer 1(의도 분류) → Layer 2(법률 검색) → Layer 3(컨텍스트 빌드) 를 조율.
+ * Layer 1(의도 분류) → Layer 2(법률·판례 검색) → Layer 3(컨텍스트 빌드) 를 조율.
+ *
+ * <p>{@code rag.retrieval.include-cases=true} 인 경우 C-5 경로로 법령 + 판례를 병합해 불러온다.
+ * 기본값은 {@code false} 로 법령 전용 경로 유지 — Phase C-4 까지의 동작 호환성.</p>
  */
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class RagPipelineService {
 
@@ -22,6 +25,20 @@ public class RagPipelineService {
     private final CategoryLawMappingService categoryLawMappingService;
     private final LegalRetrievalService legalRetrievalService;
     private final RagContextBuilder ragContextBuilder;
+    private final boolean includeCases;
+
+    public RagPipelineService(IntentClassificationService intentClassificationService,
+                              CategoryLawMappingService categoryLawMappingService,
+                              LegalRetrievalService legalRetrievalService,
+                              RagContextBuilder ragContextBuilder,
+                              @Value("${rag.retrieval.include-cases:false}") boolean includeCases) {
+        this.intentClassificationService = intentClassificationService;
+        this.categoryLawMappingService = categoryLawMappingService;
+        this.legalRetrievalService = legalRetrievalService;
+        this.ragContextBuilder = ragContextBuilder;
+        this.includeCases = includeCases;
+        log.info("RagPipelineService 초기화 — include-cases={}", includeCases);
+    }
 
     /**
      * RAG 파이프라인 실행. 실패 시 빈 문자열 반환 (폴백).
@@ -37,21 +54,38 @@ public class RagPipelineService {
             IntentClassificationResult classification =
                     intentClassificationService.classify(chatHistory, domain);
 
-            // Layer 2: 법률 검색
+            // Layer 2: 법률 (+ 옵션: 판례) 검색
             List<String> lawIds = categoryLawMappingService.resolveLawIds(
                     classification.matchedNodeIds());
             String vectorQuery = classification.retrievalQueries().isEmpty()
                     ? domain + " 관련 법률"
                     : classification.retrievalQueries().get(0);
-            List<LegalChunk> chunks = legalRetrievalService.retrieve(
-                    vectorQuery,
-                    classification.keywords().core(),
-                    lawIds, 3);
 
-            // Layer 3: 컨텍스트 빌드
-            String ragContext = ragContextBuilder.build(chunks, classification.intentSummary());
-            if (!ragContext.isEmpty()) {
-                log.info("RAG 컨텍스트 생성 완료: consultationId={}, chunks={}", consultationId, chunks.size());
+            String ragContext;
+            int hits;
+            if (includeCases) {
+                MixedRetrievalResult mixed = legalRetrievalService.retrieveMixed(
+                        vectorQuery,
+                        classification.keywords().core(),
+                        classification.matchedNodeIds(),
+                        lawIds,
+                        3);
+                ragContext = ragContextBuilder.build(mixed, classification.intentSummary());
+                hits = mixed.size();
+                if (!ragContext.isEmpty()) {
+                    log.info("RAG 컨텍스트 생성 완료 (mixed): consultationId={}, laws={}, cases={}, merged={}",
+                            consultationId, mixed.laws().size(), mixed.cases().size(), hits);
+                }
+            } else {
+                List<LegalChunk> chunks = legalRetrievalService.retrieve(
+                        vectorQuery,
+                        classification.keywords().core(),
+                        lawIds, 3);
+                ragContext = ragContextBuilder.build(chunks, classification.intentSummary());
+                hits = chunks.size();
+                if (!ragContext.isEmpty()) {
+                    log.info("RAG 컨텍스트 생성 완료: consultationId={}, chunks={}", consultationId, hits);
+                }
             }
             return ragContext;
 

--- a/src/main/java/org/example/shield/ai/domain/LegalCaseJpaRepository.java
+++ b/src/main/java/org/example/shield/ai/domain/LegalCaseJpaRepository.java
@@ -11,9 +11,11 @@ import java.util.Optional;
 /**
  * legal_cases 테이블 JPA 리포지토리.
  *
- * <p>본 리포지토리는 C-3 스키마 단계에서 기본 CRUD, 자연키 조회, 단순 필터만 제공한다.
- * 하이브리드 검색(pgvector + BM25 + pg_trgm)은 C-4 인제스트 이후 별도 검색 서비스에서
- * 네이티브 쿼리로 구현한다 — {@code LegalChunkJpaRepository#searchHybrid*}와 동일 패턴.</p>
+ * <p>C-3 단계에서는 기본 CRUD/자연키/단순 필터만 제공했고, C-5 (Issue #42)에서
+ * 법령(legal_chunks) 과 동일한 3-way 하이브리드(pgvector + BM25 + pg_trgm) 검색 네이티브
+ * 쿼리를 추가하여 {@code PgLegalRetrievalService} 가 법령·판례를 병합 랭킹할 수 있게 한다.
+ * 하이브리드 SQL 은 {@code scripts/eval_rag.py} 의 {@code case_sql} 을 직접 이식한 것으로,
+ * trigram 은 판결요지(holding) 에만 적용한다 — 판례는 요지 중심 검색이기 때문.</p>
  */
 public interface LegalCaseJpaRepository extends JpaRepository<LegalCaseEntity, Long> {
 
@@ -66,4 +68,112 @@ public interface LegalCaseJpaRepository extends JpaRepository<LegalCaseEntity, L
              where lc.embedding is null
             """)
     long countMissingEmbedding();
+
+    // ---------------------------------------------------------------------
+    // C-5 (Issue #42) — 3-way 하이브리드 검색 (pgvector + BM25 + pg_trgm)
+    //
+    // 설계 (legal_chunks 대비 차이점):
+    //  - trigram 은 holding(판결요지) 컬럼에만 걸림. idx_legal_cases_holding_trgm 활용.
+    //  - content_tsv 는 case_name + case_no + headnote + holding + reasoning concat 의
+    //    GENERATED tsvector 라 BM25 는 법령과 동일 패턴.
+    //  - law_id 필터는 없음. 대신 case_type 필터를 선택적으로 걸 수 있도록 두 가지 시그니처 제공.
+    //  - Projection 은 LegalChunkRow 와 형태가 달라 별도 LegalCaseRow 인터페이스 제공.
+    // ---------------------------------------------------------------------
+
+    /**
+     * 3-way 하이브리드 검색 (case_type 필터 없음).
+     *
+     * <p>{@code :queryVector} 는 pgvector 리터럴 문자열 {@code "[0.1,0.2,...]"}.
+     * {@code :categoryIds} 는 {@code String[]}. null/빈 배열이면 카테고리 필터 미적용.</p>
+     */
+    @Query(value = """
+            SELECT lc.id              AS id,
+                   lc.case_no         AS caseNo,
+                   lc.court           AS court,
+                   lc.case_name       AS caseName,
+                   to_char(lc.decision_date, 'YYYY-MM-DD') AS decisionDate,
+                   lc.case_type       AS caseType,
+                   lc.headnote        AS headnote,
+                   lc.holding         AS holding,
+                   lc.source_url      AS sourceUrl,
+                   ( COALESCE(CASE WHEN lc.embedding IS NULL THEN 0
+                                   ELSE 1 - (lc.embedding <=> CAST(:queryVector AS vector))
+                               END, 0) * :vectorWeight
+                    + ts_rank(lc.content_tsv, to_tsquery('simple', :keywordQuery), 1) * :keywordWeight
+                    + similarity(COALESCE(lc.holding, ''), :vectorQuery) * :trigramWeight) AS score
+              FROM legal_cases lc
+             WHERE ( COALESCE(CARDINALITY(CAST(:categoryIds AS text[])), 0) = 0
+                     OR lc.category_ids && CAST(:categoryIds AS text[]) )
+               AND ( lc.content_tsv @@ plainto_tsquery('simple', :vectorQuery)
+                  OR lc.content_tsv @@ to_tsquery('simple', :keywordQuery)
+                  OR COALESCE(lc.holding, '') %% :vectorQuery
+                  OR lc.embedding IS NOT NULL )
+             ORDER BY score DESC
+             LIMIT :topK
+            """, nativeQuery = true)
+    List<LegalCaseRow> search3WayCases(@Param("queryVector") String queryVector,
+                                       @Param("vectorQuery") String vectorQuery,
+                                       @Param("keywordQuery") String keywordQuery,
+                                       @Param("categoryIds") String[] categoryIds,
+                                       @Param("vectorWeight") double vectorWeight,
+                                       @Param("keywordWeight") double keywordWeight,
+                                       @Param("trigramWeight") double trigramWeight,
+                                       @Param("topK") int topK);
+
+    /**
+     * 3-way 하이브리드 검색 (case_type 필터 포함, 예: 민사/가사).
+     * {@code :caseTypes} 가 null/empty 이면 호출부에서 필터 없는 버전을 써야 한다.
+     */
+    @Query(value = """
+            SELECT lc.id              AS id,
+                   lc.case_no         AS caseNo,
+                   lc.court           AS court,
+                   lc.case_name       AS caseName,
+                   to_char(lc.decision_date, 'YYYY-MM-DD') AS decisionDate,
+                   lc.case_type       AS caseType,
+                   lc.headnote        AS headnote,
+                   lc.holding         AS holding,
+                   lc.source_url      AS sourceUrl,
+                   ( COALESCE(CASE WHEN lc.embedding IS NULL THEN 0
+                                   ELSE 1 - (lc.embedding <=> CAST(:queryVector AS vector))
+                               END, 0) * :vectorWeight
+                    + ts_rank(lc.content_tsv, to_tsquery('simple', :keywordQuery), 1) * :keywordWeight
+                    + similarity(COALESCE(lc.holding, ''), :vectorQuery) * :trigramWeight) AS score
+              FROM legal_cases lc
+             WHERE lc.case_type IN (:caseTypes)
+               AND ( COALESCE(CARDINALITY(CAST(:categoryIds AS text[])), 0) = 0
+                     OR lc.category_ids && CAST(:categoryIds AS text[]) )
+               AND ( lc.content_tsv @@ plainto_tsquery('simple', :vectorQuery)
+                  OR lc.content_tsv @@ to_tsquery('simple', :keywordQuery)
+                  OR COALESCE(lc.holding, '') %% :vectorQuery
+                  OR lc.embedding IS NOT NULL )
+             ORDER BY score DESC
+             LIMIT :topK
+            """, nativeQuery = true)
+    List<LegalCaseRow> search3WayCasesByTypes(@Param("queryVector") String queryVector,
+                                              @Param("vectorQuery") String vectorQuery,
+                                              @Param("keywordQuery") String keywordQuery,
+                                              @Param("categoryIds") String[] categoryIds,
+                                              @Param("caseTypes") java.util.Collection<String> caseTypes,
+                                              @Param("vectorWeight") double vectorWeight,
+                                              @Param("keywordWeight") double keywordWeight,
+                                              @Param("trigramWeight") double trigramWeight,
+                                              @Param("topK") int topK);
+
+    /**
+     * Spring Data JPA 네이티브 쿼리용 projection 인터페이스.
+     * 서비스 레이어에서 Precedent record 로 변환해 반환한다.
+     */
+    interface LegalCaseRow {
+        Long getId();
+        String getCaseNo();
+        String getCourt();
+        String getCaseName();
+        String getDecisionDate();
+        String getCaseType();
+        String getHeadnote();
+        String getHolding();
+        String getSourceUrl();
+        Double getScore();
+    }
 }

--- a/src/main/java/org/example/shield/ai/dto/LegalChunk.java
+++ b/src/main/java/org/example/shield/ai/dto/LegalChunk.java
@@ -3,6 +3,10 @@ package org.example.shield.ai.dto;
 /**
  * 법률 조문 청크 데이터.
  * Layer 2 벡터 검색 결과로 반환되는 개별 법률 조문 단위.
+ *
+ * <p>Phase C-5 (Issue #42) 부터 {@link RetrievedDocument} sealed interface 를 구현하여
+ * 판례({@link Precedent}) 와 함께 RAG 컨텍스트 빌더에서 다루어진다.
+ * 기존 필드 시그니처는 그대로 유지되어 하위 호환성에 영향이 없다.</p>
  */
 public record LegalChunk(
         String lawName,
@@ -12,5 +16,10 @@ public record LegalChunk(
         String effectiveDate,
         String sourceUrl,
         double score
-) {
+) implements RetrievedDocument {
+
+    @Override
+    public String kind() {
+        return "law";
+    }
 }

--- a/src/main/java/org/example/shield/ai/dto/MixedRetrievalResult.java
+++ b/src/main/java/org/example/shield/ai/dto/MixedRetrievalResult.java
@@ -1,0 +1,37 @@
+package org.example.shield.ai.dto;
+
+import java.util.List;
+
+/**
+ * 법령 + 판례 병합 검색 결과. Phase C-5 (Issue #42).
+ *
+ * <p>법령 검색과 판례 검색을 각각 top-K 뽑은 뒤 {@code score DESC} 기준으로 병합하여
+ * 상위 {@code limit} 개를 {@link #merged()} 에 담는다. 원본 리스트({@link #laws()} /
+ * {@link #cases()}) 도 함께 제공하여 디버깅·로깅·섹션별 프롬프트 구성에 활용 가능.</p>
+ *
+ * <p>{@code scripts/eval_rag.py} 의 UNION ALL 경로와 동일한 방식이지만, JDBC 매핑 단순화를
+ * 위해 두 번의 쿼리를 날리고 메모리에서 병합한다. 두 쿼리 모두 인덱스를 잘 타므로 (HNSW +
+ * GIN) 오버헤드는 무시할 만큼 작다.</p>
+ *
+ * @param laws   법령 조문 검색 결과 (score 내림차순)
+ * @param cases  판례 검색 결과 (score 내림차순)
+ * @param merged 두 리스트를 score 기준으로 합친 뒤 상위 {@code limit} 만 자른 결과
+ */
+public record MixedRetrievalResult(
+        List<LegalChunk> laws,
+        List<Precedent> cases,
+        List<RetrievedDocument> merged
+) {
+
+    public static MixedRetrievalResult empty() {
+        return new MixedRetrievalResult(List.of(), List.of(), List.of());
+    }
+
+    public boolean isEmpty() {
+        return merged == null || merged.isEmpty();
+    }
+
+    public int size() {
+        return merged == null ? 0 : merged.size();
+    }
+}

--- a/src/main/java/org/example/shield/ai/dto/Precedent.java
+++ b/src/main/java/org/example/shield/ai/dto/Precedent.java
@@ -1,0 +1,40 @@
+package org.example.shield.ai.dto;
+
+/**
+ * 판례(대법원·하급심) 검색 결과 DTO.
+ *
+ * <p>Phase C-5 (Issue #42) — {@code legal_cases} 하이브리드 검색이 반환하는 단위.
+ * {@link LegalChunk} 가 법령 조문을 담는 것과 대비된다. 두 타입은 {@link RetrievedDocument}
+ * sealed interface 로 묶여 RAG 컨텍스트 빌더가 함께 다룬다.</p>
+ *
+ * <p>필드:
+ * <ul>
+ *   <li>{@code caseNo} — 사건번호 (예: "2025다213466")</li>
+ *   <li>{@code court} — 법원 (예: "대법원")</li>
+ *   <li>{@code caseName} — 사건명 (없을 수 있음)</li>
+ *   <li>{@code decisionDate} — 선고일자 (YYYY-MM-DD)</li>
+ *   <li>{@code caseType} — 민사/형사/가사/행정/특허</li>
+ *   <li>{@code headnote} — 판시사항 (쟁점·요점)</li>
+ *   <li>{@code holding} — 판결요지 (법리 결론)</li>
+ *   <li>{@code sourceUrl} — 출처 URL (법제처 등)</li>
+ *   <li>{@code score} — 하이브리드 점수 (높을수록 관련성 ↑)</li>
+ * </ul>
+ * </p>
+ */
+public record Precedent(
+        String caseNo,
+        String court,
+        String caseName,
+        String decisionDate,
+        String caseType,
+        String headnote,
+        String holding,
+        String sourceUrl,
+        double score
+) implements RetrievedDocument {
+
+    @Override
+    public String kind() {
+        return "case";
+    }
+}

--- a/src/main/java/org/example/shield/ai/dto/RetrievedDocument.java
+++ b/src/main/java/org/example/shield/ai/dto/RetrievedDocument.java
@@ -1,0 +1,26 @@
+package org.example.shield.ai.dto;
+
+/**
+ * RAG 검색 결과의 공통 인터페이스. Phase C-5 (Issue #42) 도입.
+ *
+ * <p>법령 조문({@link LegalChunk}) 과 판례({@link Precedent}) 를 함께 다루기 위한 sealed 타입.
+ * {@link LegalChunk} 는 기존 코드 호환을 위해 유지하면서 이 인터페이스를 추가로 구현한다.</p>
+ *
+ * <p>{@code kind()} 는 프롬프트 직렬화와 로깅에서 두 타입을 분기하는 용도로 사용된다.
+ * <ul>
+ *   <li>{@code "law"} — 법령 조문 ({@link LegalChunk})</li>
+ *   <li>{@code "case"} — 판례 ({@link Precedent})</li>
+ * </ul>
+ * </p>
+ *
+ * <p>Java sealed 타입 문법으로 컴파일러가 두 구현체 외 확장을 차단한다.</p>
+ */
+public sealed interface RetrievedDocument
+        permits LegalChunk, Precedent {
+
+    /** 문서 유형 식별자. 프롬프트 섹션 분기·로깅에 사용. */
+    String kind();
+
+    /** 하이브리드 검색 점수 (법령·판례 모두 동일 가중치 스키마로 계산되므로 비교 가능). */
+    double score();
+}

--- a/src/main/java/org/example/shield/ai/infrastructure/PgLegalRetrievalService.java
+++ b/src/main/java/org/example/shield/ai/infrastructure/PgLegalRetrievalService.java
@@ -7,14 +7,21 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.shield.ai.application.LegalRetrievalService;
 import org.example.shield.ai.application.QueryEmbeddingService;
 import org.example.shield.ai.config.CohereApiConfig;
+import org.example.shield.ai.domain.LegalCaseJpaRepository;
+import org.example.shield.ai.domain.LegalCaseJpaRepository.LegalCaseRow;
 import org.example.shield.ai.domain.LegalChunkJpaRepository;
 import org.example.shield.ai.domain.LegalChunkJpaRepository.LegalChunkRow;
 import org.example.shield.ai.dto.LegalChunk;
+import org.example.shield.ai.dto.MixedRetrievalResult;
+import org.example.shield.ai.dto.Precedent;
+import org.example.shield.ai.dto.RetrievedDocument;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -58,6 +65,7 @@ public class PgLegalRetrievalService implements LegalRetrievalService {
     private static final String EMPTY_QUERY_SENTINEL = "__shield_never_match__";
 
     private final LegalChunkJpaRepository legalChunkJpaRepository;
+    private final LegalCaseJpaRepository legalCaseJpaRepository;
     private final QueryEmbeddingService queryEmbeddingService;
     private final RagMetrics ragMetrics;
     private final double vectorWeight;
@@ -73,6 +81,7 @@ public class PgLegalRetrievalService implements LegalRetrievalService {
 
     public PgLegalRetrievalService(
             LegalChunkJpaRepository legalChunkJpaRepository,
+            LegalCaseJpaRepository legalCaseJpaRepository,
             QueryEmbeddingService queryEmbeddingService,
             CohereApiConfig cohereConfig,
             RagMetrics ragMetrics,
@@ -81,6 +90,7 @@ public class PgLegalRetrievalService implements LegalRetrievalService {
             @Value("${rag.retrieval.weights.trigram:0.2}") double trigramWeight,
             @Value("${rag.retrieval.hnsw.ef-search:40}") int hnswEfSearch) {
         this.legalChunkJpaRepository = legalChunkJpaRepository;
+        this.legalCaseJpaRepository = legalCaseJpaRepository;
         this.queryEmbeddingService = queryEmbeddingService;
         this.ragMetrics = ragMetrics;
         this.vectorWeight = vectorWeight;
@@ -108,6 +118,114 @@ public class PgLegalRetrievalService implements LegalRetrievalService {
             ragMetrics.stopRetrieveFailure(sample);
             throw e;
         }
+    }
+
+    /**
+     * 법령 + 판례 병합 하이브리드 검색 (C-5, Issue #42).
+     *
+     * <p>{@code legal_chunks} 와 {@code legal_cases} 에 각각 3-way 하이브리드를 돌리고
+     * {@code score DESC} 로 병합한 뒤 상위 {@code topK} 만 잘라 반환한다.
+     * 쿼리 임베딩은 한 번만 생성하여 두 SQL 에 재사용한다 — Cohere API 호출이 RAG 레이턴시의
+     * 대부분을 차지하므로 1회 재사용이 중요.</p>
+     *
+     * <p>{@code lawIds} 는 판례에는 적용되지 않는다 — 판례는 law_id 컬럼이 없고
+     * case_type 으로 분류되기 때문. 판례 필터가 필요하면 caseType 기반 별도 메서드로 확장.</p>
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public MixedRetrievalResult retrieveMixed(String vectorQuery,
+                                              List<String> bm25Keywords,
+                                              List<String> categoryIds,
+                                              List<String> lawIds,
+                                              int topK) {
+        Timer.Sample sample = ragMetrics.startRetrieve();
+        try {
+            MixedRetrievalResult result = doRetrieveMixed(vectorQuery, bm25Keywords, categoryIds, lawIds, topK);
+            ragMetrics.stopRetrieveSuccess(sample, result.size());
+            return result;
+        } catch (RuntimeException e) {
+            ragMetrics.stopRetrieveFailure(sample);
+            throw e;
+        }
+    }
+
+    private MixedRetrievalResult doRetrieveMixed(String vectorQuery,
+                                                 List<String> bm25Keywords,
+                                                 List<String> categoryIds,
+                                                 List<String> lawIds,
+                                                 int topK) {
+        String safeVectorQuery = (vectorQuery == null || vectorQuery.isBlank())
+                ? ""
+                : vectorQuery.trim();
+        String keywordQuery = buildKeywordTsQuery(bm25Keywords, safeVectorQuery);
+        int safeTopK = Math.max(1, topK);
+
+        if (safeVectorQuery.isEmpty() && keywordQuery.isEmpty()) {
+            log.debug("RAG mixed 검색 스킵 — vectorQuery/bm25Keywords 모두 비어 있음");
+            return MixedRetrievalResult.empty();
+        }
+
+        String vq = safeVectorQuery.isEmpty() ? EMPTY_QUERY_SENTINEL : safeVectorQuery;
+        String kq = keywordQuery.isEmpty() ? EMPTY_QUERY_SENTINEL : keywordQuery;
+
+        // 쿼리 임베딩 1회 생성 → 법령/판례 SQL 에서 재사용
+        String queryVectorLiteral = buildQueryVectorLiteral(safeVectorQuery);
+        String[] categoryFilter = normalizeCategoryFilter(categoryIds);
+
+        applyHnswEfSearch();
+
+        // 법령 검색 (기존 경로 동일)
+        List<LegalChunkRow> lawRows;
+        if (lawIds == null || lawIds.isEmpty()) {
+            lawRows = legalChunkJpaRepository.search3Way(
+                    queryVectorLiteral, vq, kq, categoryFilter,
+                    vectorWeight, keywordWeight, trigramWeight, safeTopK);
+        } else {
+            lawRows = legalChunkJpaRepository.search3WayByLaws(
+                    queryVectorLiteral, vq, kq, categoryFilter, lawIds,
+                    vectorWeight, keywordWeight, trigramWeight, safeTopK);
+        }
+        List<LegalChunk> laws = lawRows.stream()
+                .map(r -> new LegalChunk(
+                        nz(r.getLawName()),
+                        nz(r.getArticleNo()),
+                        nz(r.getArticleTitle()),
+                        nz(r.getContent()),
+                        nz(r.getEffectiveDate()),
+                        nz(r.getSourceUrl()),
+                        r.getScore() == null ? 0.0 : r.getScore()))
+                .toList();
+
+        // 판례 검색 (C-5 신규 경로)
+        List<LegalCaseRow> caseRows = legalCaseJpaRepository.search3WayCases(
+                queryVectorLiteral, vq, kq, categoryFilter,
+                vectorWeight, keywordWeight, trigramWeight, safeTopK);
+        List<Precedent> cases = caseRows.stream()
+                .map(r -> new Precedent(
+                        nz(r.getCaseNo()),
+                        nz(r.getCourt()),
+                        nz(r.getCaseName()),
+                        nz(r.getDecisionDate()),
+                        nz(r.getCaseType()),
+                        nz(r.getHeadnote()),
+                        nz(r.getHolding()),
+                        nz(r.getSourceUrl()),
+                        r.getScore() == null ? 0.0 : r.getScore()))
+                .toList();
+
+        // score DESC 병합 후 상위 topK cut
+        List<RetrievedDocument> combined = new ArrayList<>(laws.size() + cases.size());
+        combined.addAll(laws);
+        combined.addAll(cases);
+        List<RetrievedDocument> merged = combined.stream()
+                .sorted(Comparator.comparingDouble(RetrievedDocument::score).reversed())
+                .limit(safeTopK)
+                .toList();
+
+        log.debug("RAG mixed 검색 완료 — vq='{}', kq='{}', laws={}, cases={}, merged={}",
+                vq, kq, laws.size(), cases.size(), merged.size());
+
+        return new MixedRetrievalResult(laws, cases, merged);
     }
 
     private List<LegalChunk> doRetrieve(String vectorQuery,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -127,10 +127,11 @@ rag:
   retrieval:
     stub: ${RAG_STUB:false}
     # C-5 (Issue #42): 법령 + 판례 병합 검색 사용 여부.
-    #   false(기본) : legal_chunks 만 검색 (Phase C-4 동작 호환)
-    #   true           : legal_chunks + legal_cases 3-way 하이브리드 병합 후 score DESC merge
-    # Phase C-4 벤치마크에서 MRR +0.246 / nDCG@5 +0.250 검증. 판례 인제스트 완료 후 true 로 전환.
-    include-cases: ${RAG_INCLUDE_CASES:false}
+    #   false          : legal_chunks 만 검색 (Phase C-4 동작 호환)
+    #   true(기본)  : legal_chunks + legal_cases 3-way 하이브리드 병합 후 score DESC merge
+    # Phase C-4 벤치마크에서 MRR +0.246 / nDCG@5 +0.250 검증.
+    # 판례 183건 인제스트 완료로 true 기본 적용. 이상 발생 시 RAG_INCLUDE_CASES=false 로 즉시 롤백.
+    include-cases: ${RAG_INCLUDE_CASES:true}
     # 3-way 하이브리드 점수 가중치 (Phase B-4 재설계)
     # 경로:
     #  - vector:  Cohere embed-v4.0 임베딩 ↔ pgvector cosine similarity (0~1)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -126,6 +126,11 @@ cohere:
 rag:
   retrieval:
     stub: ${RAG_STUB:false}
+    # C-5 (Issue #42): 법령 + 판례 병합 검색 사용 여부.
+    #   false(기본) : legal_chunks 만 검색 (Phase C-4 동작 호환)
+    #   true           : legal_chunks + legal_cases 3-way 하이브리드 병합 후 score DESC merge
+    # Phase C-4 벤치마크에서 MRR +0.246 / nDCG@5 +0.250 검증. 판례 인제스트 완료 후 true 로 전환.
+    include-cases: ${RAG_INCLUDE_CASES:false}
     # 3-way 하이브리드 점수 가중치 (Phase B-4 재설계)
     # 경로:
     #  - vector:  Cohere embed-v4.0 임베딩 ↔ pgvector cosine similarity (0~1)

--- a/src/test/java/org/example/shield/ai/application/RagContextBuilderTest.java
+++ b/src/test/java/org/example/shield/ai/application/RagContextBuilderTest.java
@@ -1,6 +1,9 @@
 package org.example.shield.ai.application;
 
 import org.example.shield.ai.dto.LegalChunk;
+import org.example.shield.ai.dto.MixedRetrievalResult;
+import org.example.shield.ai.dto.Precedent;
+import org.example.shield.ai.dto.RetrievedDocument;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -77,5 +80,80 @@ class RagContextBuilderTest {
         String result = builder.build(List.of(chunk), "이혼 절차");
 
         assertThat(result).doesNotContain("출처:");
+    }
+
+    // ------------------------------------------------------------------------
+    // C-5 (Issue #42) — MixedRetrievalResult 오버로드 테스트
+    // ------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Mixed 법령+판례 — 두 섹션(참고 법령/참고 판례) 모두 포함")
+    void build_mixed_bothSectionsPresent() {
+        LegalChunk law = new LegalChunk("민법", "제618조", "임대차",
+                "임대차는 당사자 일방이 상대방에게...",
+                "2024-01-01", "urlL", 0.9);
+        Precedent prec = new Precedent(
+                "2025다213466", "대법원", "임대차보증금 반환 청구",
+                "2025-03-15", "민사",
+                "임대차 종료 후 보증금 반환 의무",
+                "임대인은 임대차 종료 시 지체 없이 보증금을 반환해야 한다",
+                "urlC", 0.8);
+        MixedRetrievalResult mixed = new MixedRetrievalResult(
+                List.of(law), List.of(prec), List.<RetrievedDocument>of(law, prec));
+
+        String result = builder.build(mixed, "임대차 보증금 반환");
+
+        assertThat(result).contains("## 참고 법령");
+        assertThat(result).contains("## 참고 판례");
+        assertThat(result).contains("분류: 임대차 보증금 반환");
+        assertThat(result).contains("[1] 민법 제618조");
+        assertThat(result).contains("[대법원 2025다213466 · 2025-03-15]");
+        assertThat(result).contains("임대차보증금 반환 청구"); // caseName
+        assertThat(result).contains("판시사항:");
+        assertThat(result).contains("판결요지:");
+        assertThat(result).contains("유형: 민사");
+        // 섹션 순서: 법령이 판례보다 앞에 나와야 함
+        int lawIdx = result.indexOf("## 참고 법령");
+        int caseIdx = result.indexOf("## 참고 판례");
+        assertThat(lawIdx).isLessThan(caseIdx);
+    }
+
+    @Test
+    @DisplayName("Mixed 판례만 있는 경우 — 법령 섹션 생략")
+    void build_mixed_onlyCases_omitsLawsSection() {
+        Precedent prec = new Precedent(
+                "2024다999", "대법원", "",
+                "2024-06-01", "형사",
+                "판시사항", "판결요지",
+                "", 0.7);
+        MixedRetrievalResult mixed = new MixedRetrievalResult(
+                List.of(), List.of(prec), List.<RetrievedDocument>of(prec));
+
+        String result = builder.build(mixed, "형사 젭점");
+
+        assertThat(result).doesNotContain("## 참고 법령");
+        assertThat(result).contains("## 참고 판례");
+        assertThat(result).contains("[대법원 2024다999 · 2024-06-01]");
+    }
+
+    @Test
+    @DisplayName("Mixed 법령만 있는 경우 — 판례 섹션 생략")
+    void build_mixed_onlyLaws_omitsCasesSection() {
+        LegalChunk law = new LegalChunk("민법", "제750조", "불법행위",
+                "...", "2024-01-01", "", 0.9);
+        MixedRetrievalResult mixed = new MixedRetrievalResult(
+                List.of(law), List.of(), List.<RetrievedDocument>of(law));
+
+        String result = builder.build(mixed, "손해배상");
+
+        assertThat(result).contains("## 참고 법령");
+        assertThat(result).doesNotContain("## 참고 판례");
+    }
+
+    @Test
+    @DisplayName("Mixed 빈 결과 — 빈 문자열 반환")
+    void build_mixed_empty_returnsEmpty() {
+        assertThat(builder.build(MixedRetrievalResult.empty(), "요약")).isEmpty();
+        assertThat(builder.build((MixedRetrievalResult) null, "요약")).isEmpty();
     }
 }

--- a/src/test/java/org/example/shield/ai/application/RagContextBuilderTest.java
+++ b/src/test/java/org/example/shield/ai/application/RagContextBuilderTest.java
@@ -22,7 +22,7 @@ class RagContextBuilderTest {
     @Test
     @DisplayName("null chunks — 빈 문자열 반환")
     void build_nullChunks_returnsEmpty() {
-        String result = builder.build(null, "테스트 요약");
+        String result = builder.build((List<LegalChunk>) null, "테스트 요약");
         assertThat(result).isEmpty();
     }
 

--- a/src/test/java/org/example/shield/ai/infrastructure/PgLegalRetrievalServiceTest.java
+++ b/src/test/java/org/example/shield/ai/infrastructure/PgLegalRetrievalServiceTest.java
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.example.shield.ai.application.LegalRetrievalService;
 import org.example.shield.ai.application.QueryEmbeddingService;
 import org.example.shield.ai.config.CohereApiConfig;
+import org.example.shield.ai.domain.LegalCaseJpaRepository;
 import org.example.shield.ai.domain.LegalChunkJpaRepository;
 import org.example.shield.ai.domain.LegalChunkJpaRepository.LegalChunkRow;
 import org.example.shield.ai.dto.LegalChunk;
@@ -26,6 +27,7 @@ import static org.mockito.Mockito.*;
 class PgLegalRetrievalServiceTest {
 
     private LegalChunkJpaRepository repository;
+    private LegalCaseJpaRepository caseRepository;
     private QueryEmbeddingService queryEmbeddingService;
     private CohereApiConfig cohereConfig;
     private SimpleMeterRegistry meterRegistry;
@@ -35,13 +37,14 @@ class PgLegalRetrievalServiceTest {
     @BeforeEach
     void setUp() {
         repository = mock(LegalChunkJpaRepository.class);
+        caseRepository = mock(LegalCaseJpaRepository.class);
         queryEmbeddingService = mock(QueryEmbeddingService.class);
         cohereConfig = mock(CohereApiConfig.class);
         meterRegistry = new SimpleMeterRegistry();
         ragMetrics = new RagMetrics(meterRegistry);
         when(cohereConfig.getEmbedModel()).thenReturn("embed-v4.0");
         when(cohereConfig.getEmbedDimension()).thenReturn(1024);
-        service = new PgLegalRetrievalService(repository, queryEmbeddingService, cohereConfig,
+        service = new PgLegalRetrievalService(repository, caseRepository, queryEmbeddingService, cohereConfig,
                 ragMetrics, 0.5, 0.3, 0.2, 40);
     }
 

--- a/src/test/java/org/example/shield/ai/infrastructure/PgLegalRetrievalServiceTest.java
+++ b/src/test/java/org/example/shield/ai/infrastructure/PgLegalRetrievalServiceTest.java
@@ -7,7 +7,9 @@ import org.example.shield.ai.config.CohereApiConfig;
 import org.example.shield.ai.domain.LegalCaseJpaRepository;
 import org.example.shield.ai.domain.LegalChunkJpaRepository;
 import org.example.shield.ai.domain.LegalChunkJpaRepository.LegalChunkRow;
+import org.example.shield.ai.domain.LegalCaseJpaRepository.LegalCaseRow;
 import org.example.shield.ai.dto.LegalChunk;
+import org.example.shield.ai.dto.MixedRetrievalResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -190,9 +192,126 @@ class PgLegalRetrievalServiceTest {
                 anyDouble(), anyDouble(), anyDouble(), eq(3));
     }
 
+    @Test
+    @DisplayName("retrieveMixed — 법령/판례 병합 후 score DESC 로 merge 및 topK cut")
+    void retrieveMixed_mergesByScoreAndLimitsTopK() {
+        // given: 법령 2건 (score 0.9, 0.5), 판례 2건 (score 0.8, 0.3)
+        when(queryEmbeddingService.embedQuery(anyString()))
+                .thenReturn(new float[1024]);
+        when(repository.search3Way(
+                anyString(), anyString(), anyString(), nullable(String[].class),
+                anyDouble(), anyDouble(), anyDouble(), anyInt()))
+                .thenReturn(List.of(
+                        row("민법", "제303조", "전세권", "조문A", "2024-01-01", "urlA", 0.9),
+                        row("민법", "제618조", "임대차", "조문B", "2024-01-01", "urlB", 0.5)));
+        when(caseRepository.search3WayCases(
+                anyString(), anyString(), anyString(), nullable(String[].class),
+                anyDouble(), anyDouble(), anyDouble(), anyInt()))
+                .thenReturn(List.of(
+                        caseRow("2025다213466", "대법원", "사건뉡1", "2025-03-15", "민사", "판시사항1", "판결요지1", "urlC1", 0.8),
+                        caseRow("2024다111",       "대법원", "사건뉡2", "2024-05-10", "민사", "판시사항2", "판결요지2", "urlC2", 0.3)));
+
+        // when: topK=3
+        MixedRetrievalResult result = service.retrieveMixed(
+                "전세", List.of("전세"), null, null, 3);
+
+        // then
+        assertThat(result.laws()).hasSize(2);
+        assertThat(result.cases()).hasSize(2);
+        assertThat(result.merged()).hasSize(3);
+        // score 내림차순: 0.9 (법령A) → 0.8 (판례1) → 0.5 (법령B). 0.3 은 cut 됨.
+        assertThat(result.merged().get(0).score()).isEqualTo(0.9);
+        assertThat(result.merged().get(1).score()).isEqualTo(0.8);
+        assertThat(result.merged().get(2).score()).isEqualTo(0.5);
+        assertThat(result.merged().get(0).kind()).isEqualTo("law");
+        assertThat(result.merged().get(1).kind()).isEqualTo("case");
+        assertThat(result.merged().get(2).kind()).isEqualTo("law");
+    }
+
+    @Test
+    @DisplayName("retrieveMixed — 쿼리 임베딩은 1회만 생성해 법령·판례 SQL 에 재사용")
+    void retrieveMixed_reusesSingleEmbedding() {
+        when(queryEmbeddingService.embedQuery(anyString())).thenReturn(new float[1024]);
+        when(repository.search3Way(
+                anyString(), anyString(), anyString(), nullable(String[].class),
+                anyDouble(), anyDouble(), anyDouble(), anyInt())).thenReturn(List.of());
+        when(caseRepository.search3WayCases(
+                anyString(), anyString(), anyString(), nullable(String[].class),
+                anyDouble(), anyDouble(), anyDouble(), anyInt())).thenReturn(List.of());
+
+        service.retrieveMixed("질문", List.of("키워드"), null, null, 5);
+
+        // Cohere 호출은 정확히 1회
+        verify(queryEmbeddingService, times(1)).embedQuery(anyString());
+        verify(repository, times(1)).search3Way(
+                anyString(), anyString(), anyString(), nullable(String[].class),
+                anyDouble(), anyDouble(), anyDouble(), anyInt());
+        verify(caseRepository, times(1)).search3WayCases(
+                anyString(), anyString(), anyString(), nullable(String[].class),
+                anyDouble(), anyDouble(), anyDouble(), anyInt());
+    }
+
+    @Test
+    @DisplayName("retrieveMixed — vectorQuery/bm25Keywords 모두 비면 empty 반환 + repo 미호출")
+    void retrieveMixed_emptyInputs_returnsEmpty() {
+        MixedRetrievalResult result = service.retrieveMixed("", List.of(), null, null, 5);
+
+        assertThat(result.isEmpty()).isTrue();
+        assertThat(result.merged()).isEmpty();
+        assertThat(result.laws()).isEmpty();
+        assertThat(result.cases()).isEmpty();
+        verifyNoInteractions(repository);
+        verifyNoInteractions(caseRepository);
+        verifyNoInteractions(queryEmbeddingService);
+    }
+
+    @Test
+    @DisplayName("retrieveMixed — lawIds 가 주어지면 법령은 *ByLaws, 판례는 search3WayCases 로 분기")
+    void retrieveMixed_withLawIds_branchesCorrectly() {
+        when(queryEmbeddingService.embedQuery(anyString())).thenReturn(new float[1024]);
+        when(repository.search3WayByLaws(
+                anyString(), anyString(), anyString(), nullable(String[].class),
+                anyCollection(), anyDouble(), anyDouble(), anyDouble(), anyInt())).thenReturn(List.of());
+        when(caseRepository.search3WayCases(
+                anyString(), anyString(), anyString(), nullable(String[].class),
+                anyDouble(), anyDouble(), anyDouble(), anyInt())).thenReturn(List.of());
+
+        service.retrieveMixed("임대차", List.of("임대차"), null, List.of("law-civil"), 5);
+
+        verify(repository, never()).search3Way(
+                anyString(), anyString(), anyString(), nullable(String[].class),
+                anyDouble(), anyDouble(), anyDouble(), anyInt());
+        verify(repository).search3WayByLaws(
+                anyString(), anyString(), anyString(), nullable(String[].class),
+                argThat(c -> c.contains("law-civil")),
+                anyDouble(), anyDouble(), anyDouble(), anyInt());
+        // 판례는 lawIds 영향 없이 항상 search3WayCases 로 감
+        verify(caseRepository).search3WayCases(
+                anyString(), anyString(), anyString(), nullable(String[].class),
+                anyDouble(), anyDouble(), anyDouble(), anyInt());
+    }
+
     // ------------------------------------------------------------------------
     // helpers
     // ------------------------------------------------------------------------
+
+    private static LegalCaseRow caseRow(String caseNo, String court, String caseName,
+                                        String decisionDate, String caseType,
+                                        String headnote, String holding,
+                                        String sourceUrl, double score) {
+        return new LegalCaseRow() {
+            @Override public Long getId() { return 0L; }
+            @Override public String getCaseNo() { return caseNo; }
+            @Override public String getCourt() { return court; }
+            @Override public String getCaseName() { return caseName; }
+            @Override public String getDecisionDate() { return decisionDate; }
+            @Override public String getCaseType() { return caseType; }
+            @Override public String getHeadnote() { return headnote; }
+            @Override public String getHolding() { return holding; }
+            @Override public String getSourceUrl() { return sourceUrl; }
+            @Override public Double getScore() { return score; }
+        };
+    }
 
     private static LegalChunkRow row(String lawName, String articleNo, String articleTitle,
                                      String content, String effectiveDate, String sourceUrl,


### PR DESCRIPTION
## Summary
RAG 검색 경로에 legal_cases 를 병합해 법령 청크 + 판례를 동시에 참고하도록 한다.

- RetrievedDocument sealed interface (permits LegalChunk, Precedent) — score() 공통 인터페이스
- LegalCaseJpaRepository.search3WayCases 네이티브 쿼리 추가 (vector 0.5 / keyword 0.3 / trigram 0.2)
- MixedRetrievalResult DTO + LegalRetrievalService.retrieveMixed 도입, PgLegalRetrievalService 구현체에서 쿼리 임베딩 1회 생성 후 법령·판례 SQL 재사용
- RagContextBuilder.build(MixedRetrievalResult, String) 오버로드 — 참고 법령 / 참고 판례 섹션 분리, 판례 포맷 [법원 사건번호 · 선고일]
- rag.retrieval.include-cases 프로퍼티 토글 (기본 true), RagPipelineService 에서 분기
- 롤백: 환경변수 RAG_INCLUDE_CASES=false

## Test Plan
- PgLegalRetrievalServiceTest retrieveMixed 4건: 병합 score DESC + topK cut, 임베딩 1회 재사용, empty 입력, lawIds 분기
- RagContextBuilderTest mixed 4건: 양쪽 섹션 / 판례만 / 법령만 / empty
- 전체 회귀: 내 코드 0 회귀 (baseline 3건 — ShieldApplicationTests.contextLoads, ChecklistCoverageServiceTest 2건 — 은 develop 과 동일, #40 머지 후 Coverage 2건은 리팩터로 해소됨)

## Related
Closes #42