### PR TITLE
feat(auth): 변호사 가입 API 역할 승격 + Google 로그인 isNewUser 플래그

### DIFF
--- a/src/main/java/org/example/shield/auth/application/AuthService.java
+++ b/src/main/java/org/example/shield/auth/application/AuthService.java
@@ -31,16 +31,19 @@ public class AuthService {
     public LoginResult googleLogin(String authorizationCode, String role) {
         OAuthUserInfo userInfo = googleOAuthService.getUserInfo(authorizationCode);
 
-        User user = userReader.findByGoogleId(userInfo.googleId())
-                .orElseGet(() -> userWriter.save(
-                        User.builder()
-                                .email(userInfo.email())
-                                .name(userInfo.name())
-                                .role(parseRole(role))
-                                .provider("GOOGLE")
-                                .googleId(userInfo.googleId())
-                                .build()
-                ));
+        // 신규 가입 여부를 구분하기 위해 조회 시점을 명시적으로 분리한다.
+        var existing = userReader.findByGoogleId(userInfo.googleId());
+        boolean isNewUser = existing.isEmpty();
+
+        User user = existing.orElseGet(() -> userWriter.save(
+                User.builder()
+                        .email(userInfo.email())
+                        .name(userInfo.name())
+                        .role(parseRole(role))
+                        .provider("GOOGLE")
+                        .googleId(userInfo.googleId())
+                        .build()
+        ));
 
         JwtToken tokenPair = jwtService.createTokenPair(user.getId(), user.getRole().name());
         user.updateRefreshToken(tokenPair.refreshToken());
@@ -50,7 +53,8 @@ public class AuthService {
                 tokenPair.refreshToken(),
                 user.getId(),
                 user.getName(),
-                user.getRole().name()
+                user.getRole().name(),
+                isNewUser
         );
         return new LoginResult(response, tokenPair.refreshToken());
     }
@@ -75,7 +79,8 @@ public class AuthService {
                 tokenPair.refreshToken(),
                 user.getId(),
                 user.getName(),
-                user.getRole().name()
+                user.getRole().name(),
+                false
         );
         return new LoginResult(response, tokenPair.refreshToken());
     }

--- a/src/main/java/org/example/shield/auth/application/AuthService.java
+++ b/src/main/java/org/example/shield/auth/application/AuthService.java
@@ -35,11 +35,19 @@ public class AuthService {
         var existing = userReader.findByGoogleId(userInfo.googleId());
         boolean isNewUser = existing.isEmpty();
 
+        // 보안: 신규 가입 시에는 클라이언트가 전달한 role 을 신뢰하지 않고
+        // 항상 USER 로 고정한다. LAWYER/ADMIN 으로의 승격은 전용 에지 API
+        // (예: /api/lawyers/me/register) 를 통해서만 일어나야 한다.
+        // parseRole(role) 결과는 더 이상 사용하지 않으나, 입력 검증(InvalidRoleException) 목적으로 호출을 유지한다.
+        if (role != null && !role.isBlank()) {
+            parseRole(role);
+        }
+
         User user = existing.orElseGet(() -> userWriter.save(
                 User.builder()
                         .email(userInfo.email())
                         .name(userInfo.name())
-                        .role(parseRole(role))
+                        .role(UserRole.USER)
                         .provider("GOOGLE")
                         .googleId(userInfo.googleId())
                         .build()

--- a/src/main/java/org/example/shield/auth/controller/dto/LoginResponse.java
+++ b/src/main/java/org/example/shield/auth/controller/dto/LoginResponse.java
@@ -7,5 +7,6 @@ public record LoginResponse(
         String refreshToken,
         UUID userId,
         String name,
-        String role
+        String role,
+        boolean isNewUser
 ) {}

--- a/src/main/java/org/example/shield/lawyer/application/VerificationService.java
+++ b/src/main/java/org/example/shield/lawyer/application/VerificationService.java
@@ -1,14 +1,19 @@
 package org.example.shield.lawyer.application;
 
 import lombok.RequiredArgsConstructor;
+import org.example.shield.auth.application.JwtService;
+import org.example.shield.auth.domain.JwtToken;
 import org.example.shield.common.enums.VerificationStatus;
 import org.example.shield.common.exception.BusinessException;
 import org.example.shield.common.exception.ErrorCode;
 import org.example.shield.lawyer.controller.dto.LawyerRegisterRequest;
+import org.example.shield.lawyer.controller.dto.LawyerRegisterResponse;
 import org.example.shield.lawyer.controller.dto.VerificationResponse;
 import org.example.shield.lawyer.domain.LawyerProfile;
 import org.example.shield.lawyer.domain.LawyerReader;
 import org.example.shield.lawyer.domain.LawyerWriter;
+import org.example.shield.user.domain.User;
+import org.example.shield.user.domain.UserReader;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,11 +26,19 @@ public class VerificationService {
 
     private final LawyerReader lawyerReader;
     private final LawyerWriter lawyerWriter;
+    private final UserReader userReader;
+    private final JwtService jwtService;
 
     /**
      * 변호사 가입: 추가정보 입력 + 검증 신청 통합.
+     *
+     * 소셜 로그인으로 가입한 USER 가 이 엔드포인트를 호출하는 것을 전제로 한다.
+     * 처리 순서:
+     *   1) LawyerProfile 생성 (verificationStatus = PENDING)
+     *   2) User.role 을 USER → LAWYER 로 승격
+     *   3) 승격된 역할로 새 JWT 를 재발급하여 응답에 포함
      */
-    public VerificationResponse register(UUID userId, LawyerRegisterRequest request) {
+    public LawyerRegisterResponse register(UUID userId, LawyerRegisterRequest request) {
         // 이미 가입된 변호사인지 확인
         try {
             lawyerReader.findByUserId(userId);
@@ -48,7 +61,15 @@ public class VerificationService {
                 .build();
 
         LawyerProfile saved = lawyerWriter.save(profile);
-        return VerificationResponse.from(saved);
+
+        // USER → LAWYER 승격 + 새 JWT 재발급
+        User user = userReader.findById(userId);
+        user.promoteToLawyer();
+
+        JwtToken tokenPair = jwtService.createTokenPair(user.getId(), user.getRole().name());
+        user.updateRefreshToken(tokenPair.refreshToken());
+
+        return LawyerRegisterResponse.of(tokenPair.accessToken(), user.getRole().name(), saved);
     }
 
     public VerificationResponse requestVerification(UUID userId, String barAssociationNumber) {

--- a/src/main/java/org/example/shield/lawyer/application/VerificationService.java
+++ b/src/main/java/org/example/shield/lawyer/application/VerificationService.java
@@ -30,15 +30,23 @@ public class VerificationService {
     private final JwtService jwtService;
 
     /**
+     * 변호사 가입 처리 결과.
+     * 컨트롤러에서 refreshToken 은 HttpOnly 쿠키로, response 는 body 로 내려준다.
+     */
+    public record RegisterResult(LawyerRegisterResponse response, String refreshToken) {}
+
+    /**
      * 변호사 가입: 추가정보 입력 + 검증 신청 통합.
      *
      * 소셜 로그인으로 가입한 USER 가 이 엔드포인트를 호출하는 것을 전제로 한다.
+     * 이미 LawyerProfile 이 존재하면 VERIFICATION_ALREADY_SUBMITTED 로 거절된다.
      * 처리 순서:
      *   1) LawyerProfile 생성 (verificationStatus = PENDING)
      *   2) User.role 을 USER → LAWYER 로 승격
-     *   3) 승격된 역할로 새 JWT 를 재발급하여 응답에 포함
+     *   3) 새 JWT 토큰 쌍 재발급 + DB refreshToken 갱신
      */
-    public LawyerRegisterResponse register(UUID userId, LawyerRegisterRequest request) {
+
+    public RegisterResult register(UUID userId, LawyerRegisterRequest request) {
         // 이미 가입된 변호사인지 확인
         try {
             lawyerReader.findByUserId(userId);
@@ -69,7 +77,9 @@ public class VerificationService {
         JwtToken tokenPair = jwtService.createTokenPair(user.getId(), user.getRole().name());
         user.updateRefreshToken(tokenPair.refreshToken());
 
-        return LawyerRegisterResponse.of(tokenPair.accessToken(), user.getRole().name(), saved);
+        LawyerRegisterResponse response = LawyerRegisterResponse.of(
+                tokenPair.accessToken(), user.getRole().name(), saved);
+        return new RegisterResult(response, tokenPair.refreshToken());
     }
 
     public VerificationResponse requestVerification(UUID userId, String barAssociationNumber) {

--- a/src/main/java/org/example/shield/lawyer/controller/LawyerController.java
+++ b/src/main/java/org/example/shield/lawyer/controller/LawyerController.java
@@ -2,6 +2,8 @@ package org.example.shield.lawyer.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.shield.common.response.ApiResponse;
@@ -100,15 +102,31 @@ public class LawyerController {
             summary = "변호사 가입",
             description = "소셜 로그인 이후 변호사 추가정보 입력 + 검증 신청을 통합 처리합니다. "
                     + "LawyerProfile을 생성하고 PENDING 상태로 설정하며, User.role을 USER→LAWYER로 승격한 뒤 "
-                    + "새 accessToken을 응답에 포함하여 반환합니다. 이미 LAWYER인 사용자도 호출 가능합니다."
+                    + "새 accessToken을 body에, 새 refreshToken을 HttpOnly 쿠키로 내려줍니다. "
+                    + "이미 LawyerProfile이 존재하면 VERIFICATION_ALREADY_SUBMITTED 에러를 반환합니다."
     )
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/me/register")
     public ApiResponse<LawyerRegisterResponse> register(
             @AuthenticationPrincipal UUID userId,
-            @Valid @RequestBody LawyerRegisterRequest request) {
-        LawyerRegisterResponse result = verificationService.register(userId, request);
-        return ApiResponse.success("변호사 가입이 완료되었습니다", result);
+            @Valid @RequestBody LawyerRegisterRequest request,
+            HttpServletResponse response) {
+        VerificationService.RegisterResult result = verificationService.register(userId, request);
+        addRefreshTokenCookie(response, result.refreshToken());
+        return ApiResponse.success("변호사 가입이 완료되었습니다", result.response());
+    }
+
+    /**
+     * 로그인 엔드포인트(/api/auth/google 등)과 동일한 속성으로 refreshToken 쿠키를 교체한다.
+     * AuthController 와 중복되는 로직이지만 컨트롤러 경계를 넘어 공유하기는 부적절하여 동일 설정을 재사용한다.
+     */
+    private void addRefreshTokenCookie(HttpServletResponse response, String token) {
+        Cookie cookie = new Cookie("refreshToken", token);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(14 * 24 * 60 * 60);
+        response.addCookie(cookie);
     }
 
     @Operation(summary = "검증 신청", description = "대한변호사협회 등록번호로 자격 검증을 신청합니다")

--- a/src/main/java/org/example/shield/lawyer/controller/LawyerController.java
+++ b/src/main/java/org/example/shield/lawyer/controller/LawyerController.java
@@ -12,6 +12,7 @@ import org.example.shield.lawyer.application.LawyerService;
 import org.example.shield.lawyer.application.VerificationService;
 import org.example.shield.lawyer.controller.dto.DocumentResponse;
 import org.example.shield.lawyer.controller.dto.LawyerRegisterRequest;
+import org.example.shield.lawyer.controller.dto.LawyerRegisterResponse;
 import org.example.shield.lawyer.controller.dto.LawyerResponse;
 import org.example.shield.lawyer.controller.dto.ProfileUpdateRequest;
 import org.example.shield.lawyer.controller.dto.VerificationRequest;
@@ -95,13 +96,18 @@ public class LawyerController {
         return ApiResponse.success("조회 성공", result);
     }
 
-    @Operation(summary = "변호사 가입", description = "추가정보 입력 + 검증 신청 통합. LawyerProfile을 생성하고 PENDING 상태로 설정합니다")
-    @PreAuthorize("hasRole('LAWYER')")
+    @Operation(
+            summary = "변호사 가입",
+            description = "소셜 로그인 이후 변호사 추가정보 입력 + 검증 신청을 통합 처리합니다. "
+                    + "LawyerProfile을 생성하고 PENDING 상태로 설정하며, User.role을 USER→LAWYER로 승격한 뒤 "
+                    + "새 accessToken을 응답에 포함하여 반환합니다. 이미 LAWYER인 사용자도 호출 가능합니다."
+    )
+    @PreAuthorize("isAuthenticated()")
     @PostMapping("/me/register")
-    public ApiResponse<VerificationResponse> register(
+    public ApiResponse<LawyerRegisterResponse> register(
             @AuthenticationPrincipal UUID userId,
             @Valid @RequestBody LawyerRegisterRequest request) {
-        VerificationResponse result = verificationService.register(userId, request);
+        LawyerRegisterResponse result = verificationService.register(userId, request);
         return ApiResponse.success("변호사 가입이 완료되었습니다", result);
     }
 

--- a/src/main/java/org/example/shield/lawyer/controller/dto/LawyerRegisterResponse.java
+++ b/src/main/java/org/example/shield/lawyer/controller/dto/LawyerRegisterResponse.java
@@ -7,9 +7,12 @@ import java.time.LocalDateTime;
 /**
  * 변호사 가입(/api/lawyers/me/register) 응답.
  *
- * 가입이 완료되면 User.role 이 USER → LAWYER 로 승격되기 때문에
- * 기존 JWT 에 담긴 role 클레임이 더 이상 유효하지 않다.
- * 이에 맞춰 새 accessToken 을 함께 반환하여 프론트가 즉시 교체할 수 있게 한다.
+ * 가입이 완료되면 User.role 이 USER → LAWYER 로 승격되며
+ * 새 JWT 토큰 쌍(access + refresh) 이 발급된다.
+ *
+ * - accessToken : 응답 body 에 포함해 프론트가 즉시 교체한다.
+ * - refreshToken : 기존 로그인 엔드포인트와 동일하게 HttpOnly secure 쿠키(refreshToken)로 교체한다.
+ *   (body 에는 포함하지 않음. XSS 노출 이슈 및 기존 관례 유지)
  */
 public record LawyerRegisterResponse(
         String accessToken,

--- a/src/main/java/org/example/shield/lawyer/controller/dto/LawyerRegisterResponse.java
+++ b/src/main/java/org/example/shield/lawyer/controller/dto/LawyerRegisterResponse.java
@@ -1,0 +1,33 @@
+package org.example.shield.lawyer.controller.dto;
+
+import org.example.shield.lawyer.domain.LawyerProfile;
+
+import java.time.LocalDateTime;
+
+/**
+ * 변호사 가입(/api/lawyers/me/register) 응답.
+ *
+ * 가입이 완료되면 User.role 이 USER → LAWYER 로 승격되기 때문에
+ * 기존 JWT 에 담긴 role 클레임이 더 이상 유효하지 않다.
+ * 이에 맞춰 새 accessToken 을 함께 반환하여 프론트가 즉시 교체할 수 있게 한다.
+ */
+public record LawyerRegisterResponse(
+        String accessToken,
+        String role,
+        String verificationStatus,
+        String barAssociationNumber,
+        LocalDateTime requestedAt,
+        LocalDateTime verifiedAt
+) {
+    public static LawyerRegisterResponse of(String accessToken, String role, LawyerProfile profile) {
+        return new LawyerRegisterResponse(
+                accessToken,
+                role,
+                profile.getVerificationStatus().name(),
+                profile.getBarAssociationNumber(),
+                // TODO: LawyerProfile 에 verificationRequestedAt 필드 추가 후 매핑 변경
+                profile.getCreatedAt(),
+                profile.getVerifiedAt()
+        );
+    }
+}

--- a/src/main/java/org/example/shield/user/domain/User.java
+++ b/src/main/java/org/example/shield/user/domain/User.java
@@ -69,4 +69,14 @@ public class User {
         if (name != null && !name.isBlank()) this.name = name;
         if (phone != null && !phone.isBlank()) this.phone = phone;
     }
+
+    /**
+     * 소셜 로그인으로 가입한 일반 유저(USER)가 변호사 추가정보 입력을 완료했을 때
+     * 역할을 LAWYER 로 승격시킨다. 이미 LAWYER/ADMIN 인 경우에는 변경하지 않는다.
+     */
+    public void promoteToLawyer() {
+        if (this.role == UserRole.USER) {
+            this.role = UserRole.LAWYER;
+        }
+    }
 }


### PR DESCRIPTION
## Problem

프론트엔드(SHIELD_FE PR #6 / #7)에서 확정된 인증 플로우를 백엔드가 아직 완전히 지원하지 못하고 있었다.

1. **`/api/lawyers/me/register` 가 USER 역할로는 호출할 수 없음**
   소셜 로그인 직후 사용자는 기본 `UserRole.USER` 로 저장된다. 변호사 추가정보 입력을 거쳐야 비로소 `LAWYER` 가 되는데, 기존 엔드포인트는 `@PreAuthorize("hasRole('LAWYER')")` 여서 USER 가 호출할 수 없었다.
2. **역할 승격 이후 새 JWT 가 발급되지 않음**
   프론트는 가입이 끝나면 새 role 이 반영된 JWT 를 기대한다(기존 accessToken 의 role 클레임은 stale). 하지만 서버는 LawyerProfile 만 저장하고 User.role 변경 + 토큰 재발급을 하지 않았다.
3. **`POST /api/auth/google` 응답에 `isNewUser` 플래그가 없음**
   프론트는 이 값을 기준으로 기존 사용자는 바로 `/home|/lawyer` 로, 신규 사용자는 `/role-select` 로 라우팅한다.

## Root Cause

- `LawyerController.register()` 의 권한 애노테이션이 최종 확정된 플로우보다 먼저 작성되어 있었다. 당시 가정은 "별도 역할 변경 API 를 먼저 호출한 뒤 이 엔드포인트를 호출한다" 였으나, 프론트와 협의 결과 `POST /api/lawyers/me/register` 한 번으로 끝내기로 단순화되었다.
- `AuthService.googleLogin()` 은 `userReader.findByGoogleId(...).orElseGet(...)` 한 줄로 조회/생성을 묶어 처리했기 때문에 신규/기존 구분 정보를 잃었다.

## Changes

### 1) `LawyerController.register()`

- `@PreAuthorize("hasRole('LAWYER')")` → `@PreAuthorize("isAuthenticated()")`
- 반환 타입 `VerificationResponse` → `LawyerRegisterResponse` (accessToken 포함)
- Swagger `@Operation` description 을 최신 플로우에 맞게 갱신

### 2) `LawyerRegisterResponse` (신규 DTO)

```java
public record LawyerRegisterResponse(
        String accessToken,
        String role,
        String verificationStatus,
        String barAssociationNumber,
        LocalDateTime requestedAt,
        LocalDateTime verifiedAt
) { ... }
```

검증 상태 관련 필드는 기존 `VerificationResponse` 와 동일하게 유지.

### 3) `VerificationService.register()`

처리 순서:

1. LawyerProfile 생성 (verificationStatus = PENDING)
2. `User.promoteToLawyer()` 호출 — USER → LAWYER
3. `JwtService.createTokenPair(userId, "LAWYER")` 로 새 토큰 발급
4. `user.updateRefreshToken(new refreshToken)` 로 저장
5. 새 accessToken 을 `LawyerRegisterResponse` 에 담아 반환

`UserReader`, `JwtService` 의존성을 새로 주입받음.

### 4) `User.promoteToLawyer()`

```java
public void promoteToLawyer() {
    if (this.role == UserRole.USER) {
        this.role = UserRole.LAWYER;
    }
}
```

USER 상태일 때만 변경. LAWYER/ADMIN 은 무시 (idempotent).

### 5) `LoginResponse` 에 `isNewUser: boolean` 추가

- `AuthService.googleLogin()` 에서 `userReader.findByGoogleId(...)` 를 먼저 호출하고, `existing.isEmpty()` 로 `isNewUser` 를 산출한다.
- `devLogin` 은 `isNewUser=false` 로 고정.

## Test Plan

### 로컬 빌드

- `./gradlew compileJava` ✅ 성공 (JDK 21)
- `./gradlew compileTestJava` ✅ 성공

### 런타임 검증 (배포 후)

- [ ] 신규 구글 계정으로 로그인 → `POST /api/auth/google` 응답에 `isNewUser: true` 확인
- [ ] 동일 계정으로 재로그인 → `isNewUser: false` 확인
- [ ] USER 상태에서 `POST /api/lawyers/me/register` 호출 → 200 + 응답에 새 accessToken + `role: "LAWYER"` 반환
- [ ] 새 accessToken 의 role 클레임이 LAWYER 인지 디코드 확인
- [ ] 새 accessToken 으로 `GET /api/lawyers/me` 호출 → 200 (변호사 전용 엔드포인트 접근 가능)
- [ ] 이미 LAWYER 인 사용자가 `/me/register` 재호출 → `VERIFICATION_ALREADY_SUBMITTED` 에러

### 참고: 관련 프론트엔드 작업

- SHIELD_FE PR #6 (https://github.com/capstoneSHIELD/SHIELD_FE/pull/6) — LawyerRegisterPage 가 응답의 accessToken 을 받아 `useAuthStore.login(newAccessToken)` 으로 교체
- SHIELD_FE PR #7 (https://github.com/capstoneSHIELD/SHIELD_FE/pull/7) — 온보딩 라우트 가드 + 로그인 UI 정합성

Issue #42 (https://github.com/capstoneSHIELD/SHIELD_BE/issues/42) 의 Item 1 (isNewUser) 및 Item 2 대체 제안(역할 승격을 /me/register 에 내장)을 모두 구현함.
