### PR TITLE
[BUGFIX] 빈 CHATBOT 메시지 차단 + ChatAiException (Issue #45)

### DIFF
--- a/src/main/java/org/example/shield/ai/application/CohereService.java
+++ b/src/main/java/org/example/shield/ai/application/CohereService.java
@@ -135,13 +135,25 @@ public class CohereService {
         msgs.add(CohereChatRequest.Message.system(systemPrompt));
 
         // 2. 기존 대화 내역 (시간순) — 호출자가 전달한 리스트 사용
+        //    방어적 skip: 과거 DB 에 이미 저장된 빈 content 메시지가 섞여 있을 수 있음.
+        //    Cohere v2 Chat API 는 빈 content 를 400 으로 거부하므로 history 구성
+        //    시점에서 제외해야 한다. (Issue #45)
         for (Message msg : chatHistory) {
             if (msg.getRole() == MessageRole.USER) {
                 // TODO: 저장 시점에 sanitize된 텍스트를 별도 필드에 보관하면 중복 sanitize 제거 가능
-                msgs.add(CohereChatRequest.Message.user(
-                        sanitizeService.sanitizeUserText(msg.getContent())));
+                String sanitized = sanitizeService.sanitizeUserText(msg.getContent());
+                if (sanitized == null || sanitized.isBlank()) {
+                    log.warn("Skipping blank USER message in chat history: messageId={}", msg.getId());
+                    continue;
+                }
+                msgs.add(CohereChatRequest.Message.user(sanitized));
             } else if (msg.getRole() == MessageRole.CHATBOT) {
-                msgs.add(CohereChatRequest.Message.assistant(msg.getContent()));
+                String content = msg.getContent();
+                if (content == null || content.isBlank()) {
+                    log.warn("Skipping blank CHATBOT message in chat history: messageId={}", msg.getId());
+                    continue;
+                }
+                msgs.add(CohereChatRequest.Message.assistant(content));
             }
         }
 
@@ -163,13 +175,24 @@ public class CohereService {
         msgs.add(CohereChatRequest.Message.system(systemPrompt));
 
         // 2. 전체 대화 내역
+        //    방어적 skip: 빈 content 메시지는 Cohere v2 Chat API 가 400 으로 거부.
+        //    (Issue #45)
         List<Message> history = messageReader.findAllByConsultationId(consultation.getId());
         for (Message msg : history) {
             if (msg.getRole() == MessageRole.USER) {
-                msgs.add(CohereChatRequest.Message.user(
-                        sanitizeService.sanitizeUserText(msg.getContent())));
+                String sanitized = sanitizeService.sanitizeUserText(msg.getContent());
+                if (sanitized == null || sanitized.isBlank()) {
+                    log.warn("Skipping blank USER message in brief history: messageId={}", msg.getId());
+                    continue;
+                }
+                msgs.add(CohereChatRequest.Message.user(sanitized));
             } else if (msg.getRole() == MessageRole.CHATBOT) {
-                msgs.add(CohereChatRequest.Message.assistant(msg.getContent()));
+                String content = msg.getContent();
+                if (content == null || content.isBlank()) {
+                    log.warn("Skipping blank CHATBOT message in brief history: messageId={}", msg.getId());
+                    continue;
+                }
+                msgs.add(CohereChatRequest.Message.assistant(content));
             }
         }
 

--- a/src/main/java/org/example/shield/common/exception/ChatAiException.java
+++ b/src/main/java/org/example/shield/common/exception/ChatAiException.java
@@ -1,0 +1,27 @@
+package org.example.shield.common.exception;
+
+/**
+ * AI 채팅 응답 생성 실패 시 발생하는 예외.
+ *
+ * <p>Cohere Chat v2 호출 자체는 성공했으나 결과 파싱·후처리 단계에서
+ * nextQuestion 이 blank 로 내려오는 등 사용자에게 의미 있는 응답을
+ * 만들 수 없는 경우 또는 AI 호출 과정에서 복구 불가능한 오류가 난
+ * 경우에 사용한다.</p>
+ *
+ * <p>{@link GlobalExceptionHandler#handleBusinessException} 에서
+ * {@link BusinessException} 으로 잡혀 HTTP 500 으로 매핑된다.</p>
+ */
+public class ChatAiException extends BusinessException {
+
+    public ChatAiException() {
+        super(ErrorCode.CHAT_AI_FAILURE);
+    }
+
+    public ChatAiException(String detailMessage) {
+        super(ErrorCode.CHAT_AI_FAILURE, detailMessage);
+    }
+
+    public ChatAiException(String detailMessage, Throwable cause) {
+        super(ErrorCode.CHAT_AI_FAILURE, detailMessage, cause);
+    }
+}

--- a/src/main/java/org/example/shield/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/shield/common/exception/ErrorCode.java
@@ -59,7 +59,10 @@ public enum ErrorCode {
     // Document
     DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "서류를 찾을 수 없습니다"),
     DOCUMENT_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기가 10MB를 초과합니다"),
-    DOCUMENT_TYPE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다");
+    DOCUMENT_TYPE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다"),
+
+    // AI
+    CHAT_AI_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "AI 응답 생성에 실패했습니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/example/shield/consultation/application/MessageService.java
+++ b/src/main/java/org/example/shield/consultation/application/MessageService.java
@@ -9,6 +9,7 @@ import org.example.shield.ai.config.CohereApiConfig;
 import org.example.shield.ai.dto.ChatParsedResponse;
 import org.example.shield.ai.dto.AiCallResult;
 import org.example.shield.ai.infrastructure.SanitizeService;
+import org.example.shield.common.exception.ChatAiException;
 import org.example.shield.common.response.PageResponse;
 import org.example.shield.consultation.controller.dto.MessageResponse;
 import org.example.shield.consultation.controller.dto.SendMessageResponse;
@@ -79,6 +80,17 @@ public class MessageService {
         // 3. 응답 ID 저장 (감사 로깅용)
         consultation.updateLastResponseId(result.responseId());
 
+        // 3-1. AI 응답 blank 차단 (Issue #45)
+        //      — nextQuestion 이 비어있으면 사용자에게 의미 있는 응답을 만들 수 없고,
+        //        이 상태로 DB에 저장되면 이후 Cohere v2 Chat API 가 빈 assistant
+        //        content 를 400 으로 거부해 대화가 영구적으로 막힌다.
+        String nextQuestion = parsed.getNextQuestion();
+        if (nextQuestion == null || nextQuestion.isBlank()) {
+            log.error("AI chat response is blank: consultationId={}, responseId={}, tokensOut={}",
+                    consultationId, result.responseId(), result.tokensOutput());
+            throw new ChatAiException();
+        }
+
         // 4. AI 분류 결과 처리 (primaryFieldLocked 가드)
         if (hasAny(parsed.getAiDomains()) || hasAny(parsed.getAiSubDomains()) || hasAny(parsed.getAiTags())) {
             boolean updated = consultation.updateAiClassification(
@@ -92,7 +104,7 @@ public class MessageService {
         // 5. AI 메시지 저장
         Message aiMessage = Message.createAiMessage(
                 consultationId,
-                parsed.getNextQuestion(),
+                nextQuestion,
                 cohereApiConfig.getChatModel(),  // model name from config
                 result.tokensInput(),
                 result.tokensOutput(),

--- a/src/test/java/org/example/shield/consultation/application/MessageServiceTest.java
+++ b/src/test/java/org/example/shield/consultation/application/MessageServiceTest.java
@@ -1,0 +1,146 @@
+package org.example.shield.consultation.application;
+
+import org.example.shield.ai.application.ChecklistCoverageService;
+import org.example.shield.ai.application.CohereService;
+import org.example.shield.ai.application.RagPipelineService;
+import org.example.shield.ai.config.CohereApiConfig;
+import org.example.shield.ai.dto.AiCallResult;
+import org.example.shield.ai.dto.ChatParsedResponse;
+import org.example.shield.ai.infrastructure.SanitizeService;
+import org.example.shield.common.exception.ChatAiException;
+import org.example.shield.consultation.controller.dto.SendMessageResponse;
+import org.example.shield.consultation.domain.Consultation;
+import org.example.shield.consultation.domain.ConsultationReader;
+import org.example.shield.consultation.domain.ConsultationWriter;
+import org.example.shield.consultation.domain.Message;
+import org.example.shield.consultation.domain.MessageReader;
+import org.example.shield.consultation.domain.MessageWriter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * {@link MessageService} 단위 테스트 (Issue #45).
+ *
+ * <p>Cohere chat() 결과 {@code nextQuestion} 이 null/blank 인 경우
+ * 빈 CHATBOT 메시지를 DB 에 저장하지 않고 {@link ChatAiException} 으로
+ * 조기 실패하는지 검증한다. 정상 응답은 기존대로 저장된다.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MessageServiceTest {
+
+    @Mock private MessageReader messageReader;
+    @Mock private MessageWriter messageWriter;
+    @Mock private ConsultationReader consultationReader;
+    @Mock private ConsultationWriter consultationWriter;
+    @Mock private CohereService cohereService;
+    @Mock private CohereApiConfig cohereApiConfig;
+    @Mock private SanitizeService sanitizeService;
+    @Mock private ChecklistCoverageService checklistCoverageService;
+    @Mock private RagPipelineService ragPipelineService;
+    @Mock private Consultation consultation;
+
+    @InjectMocks
+    private MessageService messageService;
+
+    private UUID consultationId;
+
+    @BeforeEach
+    void setUp() {
+        consultationId = UUID.randomUUID();
+
+        given(consultationReader.findById(consultationId)).willReturn(consultation);
+        given(consultation.getFirstDomain()).willReturn(null);                 // RAG skip
+        given(sanitizeService.sanitizeUserText(anyString())).willReturn("clean");
+        given(messageReader.findAllByConsultationId(consultationId)).willReturn(Collections.emptyList());
+        given(cohereApiConfig.getChatModel()).willReturn("command-a-03-2025");
+    }
+
+    @Test
+    @DisplayName("nextQuestion 이 blank 이면 ChatAiException 을 던지고 AI 메시지를 저장하지 않는다")
+    void sendMessage_blankNextQuestion_throwsChatAiException() {
+        // given
+        ChatParsedResponse parsed = new ChatParsedResponse();
+        parsed.setNextQuestion("   ");   // whitespace-only
+        AiCallResult<ChatParsedResponse> result = new AiCallResult<>(
+                "resp-blank-1", parsed, 100, 0, 250);
+        given(cohereService.chat(any(), anyString(), anyString(), any())).willReturn(result);
+
+        // when / then
+        assertThatThrownBy(() -> messageService.sendMessage(consultationId, "사용자 입력"))
+                .isInstanceOf(ChatAiException.class);
+
+        // USER 메시지는 이미 저장된 상태라 verify 는 정확히 1회 (AI 메시지는 저장 X)
+        verify(messageWriter, times(1)).save(any(Message.class));
+        verify(consultationWriter, never()).save(any(Consultation.class));
+    }
+
+    @Test
+    @DisplayName("nextQuestion 이 null 이면 ChatAiException 을 던진다")
+    void sendMessage_nullNextQuestion_throwsChatAiException() {
+        // given
+        ChatParsedResponse parsed = new ChatParsedResponse();
+        parsed.setNextQuestion(null);
+        AiCallResult<ChatParsedResponse> result = new AiCallResult<>(
+                "resp-null-1", parsed, 100, 0, 250);
+        given(cohereService.chat(any(), anyString(), anyString(), any())).willReturn(result);
+
+        // when / then
+        assertThatThrownBy(() -> messageService.sendMessage(consultationId, "사용자 입력"))
+                .isInstanceOf(ChatAiException.class);
+
+        verify(messageWriter, times(1)).save(any(Message.class));
+        verify(consultationWriter, never()).save(any(Consultation.class));
+    }
+
+    @Test
+    @DisplayName("정상 nextQuestion 이면 AI 메시지를 저장하고 응답을 반환한다")
+    void sendMessage_validNextQuestion_savesAiMessage() {
+        // given
+        ChatParsedResponse parsed = new ChatParsedResponse();
+        parsed.setNextQuestion("추가로 어떤 피해를 입으셨나요?");
+        parsed.setAiDomains(List.of());
+        parsed.setAiSubDomains(List.of());
+        parsed.setAiTags(List.of());
+        AiCallResult<ChatParsedResponse> result = new AiCallResult<>(
+                "resp-ok-1", parsed, 100, 42, 250);
+        given(cohereService.chat(any(), anyString(), anyString(), any())).willReturn(result);
+
+        // AI 메시지 저장 반환값 stub (mock Message 로 최소 동작만 보장)
+        Message savedAi = Message.createAiMessage(
+                consultationId, parsed.getNextQuestion(),
+                "command-a-03-2025", 100, 42, 250);
+        given(messageWriter.save(any(Message.class))).willReturn(savedAi);
+
+        // when
+        SendMessageResponse response = messageService.sendMessage(consultationId, "사용자 입력");
+
+        // then
+        assertThat(response).isNotNull();
+        // USER + AI 합 2회 저장
+        verify(messageWriter, times(2)).save(any(Message.class));
+        // Consultation 상태 업데이트 경로 도달 확인
+        verify(consultation).updateLastResponseId("resp-ok-1");
+        verify(consultationWriter, times(1)).save(consultation);
+    }
+}


### PR DESCRIPTION
## 배경

`Issue #45` — 상담 대화에서 Cohere Chat v2 호출 결과의 `nextQuestion` 이 공백/빈 문자열로 내려올 때, 빈 CHATBOT 메시지가 그대로 DB 에 저장돼 이후 대화가 영구적으로 막히는 문제.

- Cohere v2 Chat API 는 빈 `content` 의 assistant 메시지를 400 으로 거부
- 해당 상담의 모든 후속 대화/의뢰서 생성이 불가능해짐
- 사용자에게도 의미 없는 빈 챗봇 응답이 노출

## 변경사항

### 1. 예외 체계
- `ErrorCode.CHAT_AI_FAILURE` (HTTP 500, "AI 응답 생성에 실패했습니다") 추가
- `ChatAiException extends BusinessException` 신설
  - 기본 / detailMessage / detailMessage+cause 3종 생성자
  - `GlobalExceptionHandler.handleBusinessException` 가 이미 `BusinessException` 처리 → HTTP 500 자동 매핑

### 2. 예방 — 저장 경로 차단
`MessageService.sendMessage`:
- 응답 ID 저장 직후, AI 분류 처리 전에 `nextQuestion` null/blank 검증
- 비어있으면 `log.error(consultationId, responseId, tokensOut)` 후 `ChatAiException` throw
- 기존 AI 메시지 저장 시 지역변수 `nextQuestion` 재사용

### 3. 방어 — 기존 데이터 보호
`CohereService.buildChatMessages` / `buildBriefMessages`:
- DB 조회한 대화 내역 루프에서 USER/CHATBOT 모두 null/blank skip + warn 로그
- 과거 이미 저장된 빈 메시지가 있을 수 있어 history 구성 시점에서 제외

### 4. 테스트
`MessageServiceTest` (Mockito + JUnit5 + AssertJ + BDD):
- `sendMessage_blankNextQuestion_throwsChatAiException` — whitespace-only → ChatAiException, AI 메시지 저장 X
- `sendMessage_nullNextQuestion_throwsChatAiException` — null → ChatAiException
- `sendMessage_validNextQuestion_savesAiMessage` — 정상 → USER+AI 2회 저장, updateLastResponseId 호출

## 검증

- `./gradlew compileJava` / `compileTestJava` 성공
- MessageServiceTest 3건 전부 통과
- 전체 테스트 136건 중 1건 실패 — `ShieldApplicationTests.contextLoads()` (이전부터 있던 env 의존 baseline 실패, 회귀 X)

## Closes

Closes #45
