### PR TITLE
[FIX] ChatAiException 롤백 제외로 USER 메시지 유실 방지 (Issue #45 후속)

### DIFF
--- a/src/main/java/org/example/shield/consultation/application/MessageService.java
+++ b/src/main/java/org/example/shield/consultation/application/MessageService.java
@@ -45,7 +45,19 @@ public class MessageService {
     private final RagPipelineService ragPipelineService;
     private final OntologyService ontologyService;
 
-    @Transactional
+    /**
+     * 사용자 메시지 처리 및 AI 응답 생성.
+     *
+     * <p>{@code noRollbackFor = ChatAiException.class} (Issue #45 후속):
+     * AI 응답이 blank 로 내려와 {@link ChatAiException} 이 발생하더라도
+     * 사용자가 이미 저장한 USER 메시지와 감사 로깅용
+     * {@code lastResponseId} 는 커밋되어야 한다. 그렇지 않으면 AI 실패
+     * 시마다 사용자 입력이 유실되어 재현 가능한 데이터 손실이 발생한다.</p>
+     *
+     * <p>ChatAiException 이외의 런타임 예외는 기존 기본 동작(전체 롤백)
+     * 을 유지하므로 RAG/Cohere 호출 실패는 그대로 롤백된다.</p>
+     */
+    @Transactional(noRollbackFor = ChatAiException.class)
     public SendMessageResponse sendMessage(UUID consultationId, String content) {
         Consultation consultation = consultationReader.findById(consultationId);
 

--- a/src/test/java/org/example/shield/consultation/application/MessageServiceTest.java
+++ b/src/test/java/org/example/shield/consultation/application/MessageServiceTest.java
@@ -29,8 +29,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
@@ -251,5 +253,64 @@ class MessageServiceTest {
         assertThat(real.getAiDomains()).containsExactly("부동산 거래");
         assertThat(real.getAiSubDomains()).containsExactly("부동산 임대차");
         assertThat(real.getAiTags()).containsExactly("보증금 및 차임");
+    }
+
+    // ── Issue #45 후속 — @Transactional(noRollbackFor=ChatAiException) 회귀 테스트 ──
+
+    /**
+     * {@link MessageService#sendMessage} 는 반드시
+     * {@code @Transactional(noRollbackFor = ChatAiException.class)} 로
+     * 지정되어 있어야 한다. 이 어노테이션이 제거되거나 속성이 누락되면
+     * AI blank 응답 시 USER 메시지와 {@code lastResponseId} 까지 롤백되어
+     * Issue #45 가 재발한다 (사용자 입력 유실).
+     *
+     * <p>통합 테스트로 실제 트랜잭션 동작을 검증하는 것이 이상적이지만,
+     * 현재 테스트 슬라이스는 단위 레벨이므로 어노테이션 계약을
+     * 명시적으로 고정해 회귀를 방지한다.</p>
+     */
+    @Test
+    @DisplayName("sendMessage 는 @Transactional(noRollbackFor = ChatAiException.class) 계약을 유지해야 한다 (Issue #45 회귀)")
+    void sendMessage_transactionalContract_noRollbackForChatAiException() throws NoSuchMethodException {
+        Method method = MessageService.class.getDeclaredMethod("sendMessage", UUID.class, String.class);
+        Transactional annotation = method.getAnnotation(Transactional.class);
+
+        assertThat(annotation)
+                .as("sendMessage 에 @Transactional 이 지정되어 있어야 한다")
+                .isNotNull();
+        assertThat(annotation.noRollbackFor())
+                .as("noRollbackFor 에 ChatAiException 이 포함되어야 USER 메시지 유실이 방지된다")
+                .contains(ChatAiException.class);
+    }
+
+    /**
+     * Mockito 단위 테스트 레벨에서 "AI 실패 시에도 USER 메시지는
+     * 저장된 후 예외가 던져진다"는 순서 계약을 명시적으로 검증한다.
+     * (실제 커밋 여부는 통합 테스트 범위)
+     */
+    @Test
+    @DisplayName("nextQuestion blank 시에도 USER 메시지는 먼저 저장된 뒤 ChatAiException 이 발생한다")
+    void sendMessage_blankNextQuestion_userMessageSavedBeforeException() {
+        // given
+        Consultation real = Consultation.create(consultationId, null, null, null);
+        given(consultationReader.findById(consultationId)).willReturn(real);
+        given(ragPipelineService.execute(any(), anyString(), any())).willReturn("");
+
+        ChatParsedResponse parsed = new ChatParsedResponse();
+        parsed.setNextQuestion("   "); // blank
+        given(cohereService.chat(any(), anyString(), anyString(), any()))
+                .willReturn(new AiCallResult<>("resp-blank-regression", parsed, 100, 0, 250));
+        given(messageWriter.save(any(Message.class))).willAnswer(inv -> inv.getArgument(0));
+
+        // when / then
+        assertThatThrownBy(() -> messageService.sendMessage(consultationId, "사용자 입력"))
+                .isInstanceOf(ChatAiException.class);
+
+        // USER 메시지만 저장되어야 한다 (AI 메시지는 blank 차단으로 저장 X)
+        ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+        verify(messageWriter, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getContent()).isEqualTo("사용자 입력");
+
+        // lastResponseId 도 dirty state 로 남아 있어야 한다 (감사 로깅 목적)
+        assertThat(real.getLastResponseId()).isEqualTo("resp-blank-regression");
     }
 }


### PR DESCRIPTION
## 배경

[PR #47](https://github.com/capstoneSHIELD/SHIELD_BE/pull/47) 에서 Issue #45 를 해결하며 `MessageService.sendMessage` 안에 `ChatAiException` 을 던지는 blank AI 응답 차단 로직을 추가했다.

문제는 `sendMessage` 가 `@Transactional` 메서드라 Spring 기본 롤백 규칙(RuntimeException → rollback)에 따라 같은 트랜잭션에서 먼저 저장된 USER 메시지와 `consultation.updateLastResponseId(...)` 의 dirty state 까지 함께 롤백된다는 점이다.

### 영향
- AI 응답이 blank 로 내려올 때마다 사용자 입력이 DB 에서 유실됨
- 프론트는 500 을 받고 사용자는 "내가 보낸 메시지마저 사라졌다" 는 경험
- `lastResponseId` 도 같이 롤백되어 Cohere 호출 감사 로그가 누락됨 → 빈 응답 원인 분석 곤란
- Issue #45 가 해결하려 했던 '대화가 영구적으로 막히는 문제' 와는 다른 새로운 데이터 손실 경로

## 변경

### 1. \`@Transactional(noRollbackFor = ChatAiException.class)\`
\`\`\`java
@Transactional(noRollbackFor = ChatAiException.class)
public SendMessageResponse sendMessage(UUID consultationId, String content) { ... }
\`\`\`
- \`ChatAiException\` 발생 시 예외는 그대로 전파되지만 트랜잭션은 **커밋**
- 그 외 \`RuntimeException\` 은 기존 기본 동작(전체 롤백) 유지 → RAG/Cohere 네트워크 실패 등은 여전히 롤백

### 2. 회귀 테스트 2건 (\`MessageServiceTest\`)
1. **\`sendMessage_transactionalContract_noRollbackForChatAiException\`**  
   리플렉션으로 \`@Transactional.noRollbackFor\` 에 \`ChatAiException\` 포함 여부 검증. 어노테이션이 실수로 제거되거나 속성이 누락되는 회귀를 방지.
2. **\`sendMessage_blankNextQuestion_userMessageSavedBeforeException\`**  
   blank nextQuestion 케이스에서 USER 메시지가 먼저 저장되고 \`lastResponseId\` 가 dirty state 로 남아있음을 검증.

## 검증

- 변경 범위는 어노테이션 1개 속성 추가 + 테스트 2건
- \`MessageServiceTest\` 기존 테스트는 그대로 통과 (semantic 변화 없음)
- 단위 테스트로는 실제 커밋 여부까지 검증할 수 없으므로 어노테이션 계약을 고정하는 방식으로 회귀를 방지
- 추후 \`@SpringBootTest\` + 실제 DB 기반 통합 테스트로 \"blank 응답 발생 후 재조회 시 USER 메시지가 남아있음\" 을 검증하면 더 강력

## 대안 검토

| 전략 | 장점 | 단점 | 채택? |
|------|------|------|-------|
| \`noRollbackFor\` | 변경 최소, 감사 로그 보존 | AI 분류 dirty state 도 커밋 | ✅ |
| USER 저장을 \`REQUIRES_NEW\` | 가장 정석 | \`MessageWriter\` 리팩터 + propagation 복잡도 | ❌ (범위 초과) |
| blank 시 fallback 응답 | UX 최선 | \`ChatAiException\` 계약 변경 | 🔜 PR-D 에서 논의 |

## Refs
- Refs #45
- Follow-up: PR-B (\`CohereService\` 공통 메서드 추출), PR-C (Cohere 호출을 트랜잭션 밖으로), PR-D (fallback 메시지 전환)