### PR TITLE
[REFACTOR] CohereService history 순회 공통화 — appendHistory 메서드 추출 (Issue #45 후속)

### DIFF
--- a/src/main/java/org/example/shield/ai/application/CohereService.java
+++ b/src/main/java/org/example/shield/ai/application/CohereService.java
@@ -142,27 +142,7 @@ public class CohereService {
         msgs.add(CohereChatRequest.Message.system(systemPrompt));
 
         // 2. 기존 대화 내역 (시간순) — 호출자가 전달한 리스트 사용
-        //    방어적 skip: 과거 DB 에 이미 저장된 빈 content 메시지가 섞여 있을 수 있음.
-        //    Cohere v2 Chat API 는 빈 content 를 400 으로 거부하므로 history 구성
-        //    시점에서 제외해야 한다. (Issue #45)
-        for (Message msg : chatHistory) {
-            if (msg.getRole() == MessageRole.USER) {
-                // TODO: 저장 시점에 sanitize된 텍스트를 별도 필드에 보관하면 중복 sanitize 제거 가능
-                String sanitized = sanitizeService.sanitizeUserText(msg.getContent());
-                if (sanitized == null || sanitized.isBlank()) {
-                    log.warn("Skipping blank USER message in chat history: messageId={}", msg.getId());
-                    continue;
-                }
-                msgs.add(CohereChatRequest.Message.user(sanitized));
-            } else if (msg.getRole() == MessageRole.CHATBOT) {
-                String content = msg.getContent();
-                if (content == null || content.isBlank()) {
-                    log.warn("Skipping blank CHATBOT message in chat history: messageId={}", msg.getId());
-                    continue;
-                }
-                msgs.add(CohereChatRequest.Message.assistant(content));
-            }
-        }
+        appendHistory(msgs, chatHistory, "chat");
 
         // 3. 새 사용자 메시지 (이미 sanitize됨)
         msgs.add(CohereChatRequest.Message.user(latestSanitizedUserText));
@@ -182,28 +162,48 @@ public class CohereService {
         msgs.add(CohereChatRequest.Message.system(systemPrompt));
 
         // 2. 전체 대화 내역
-        //    방어적 skip: 빈 content 메시지는 Cohere v2 Chat API 가 400 으로 거부.
-        //    (Issue #45)
         List<Message> history = messageReader.findAllByConsultationId(consultation.getId());
+        appendHistory(msgs, history, "brief");
+
+        return truncateMessages(msgs, config.getMaxHistoryMessages());
+    }
+
+    /**
+     * DB 대화 내역을 Cohere messages 배열로 변환 — buildChatMessages /
+     * buildBriefMessages 공통 로직.
+     *
+     * <p>방어적 skip 정책 (Issue #45):</p>
+     * <ul>
+     *   <li>USER/CHATBOT 무관하게 원본 content 가 null/blank 이면 skip → sanitize 호출 자체를 회피해 불필요한 PII 스캔 비용 제거</li>
+     *   <li>USER 의 경우 sanitize 결과가 blank 로 수축하는 경우도 skip (예: 전체가 마스킹 대상)</li>
+     *   <li>Cohere v2 Chat API 가 빈 content 를 400 으로 거부하므로 history 구성 시점에서 배제해야 한다</li>
+     * </ul>
+     *
+     * <p>{@code context} 는 로그 구분용 (\"chat\" / \"brief\" / \"search\" 등) —
+     * 한 곳에서 메트릭/알럿을 달기 쉽게 태깅한다.</p>
+     */
+    private void appendHistory(
+            List<CohereChatRequest.Message> msgs, List<Message> history, String context) {
         for (Message msg : history) {
+            String raw = msg.getContent();
+            if (raw == null || raw.isBlank()) {
+                log.warn("Skipping blank {} message in {} history: messageId={}",
+                        msg.getRole(), context, msg.getId());
+                continue;
+            }
             if (msg.getRole() == MessageRole.USER) {
-                String sanitized = sanitizeService.sanitizeUserText(msg.getContent());
+                // TODO: 저장 시점에 sanitize된 텍스트를 별도 필드에 보관하면 중복 sanitize 제거 가능
+                String sanitized = sanitizeService.sanitizeUserText(raw);
                 if (sanitized == null || sanitized.isBlank()) {
-                    log.warn("Skipping blank USER message in brief history: messageId={}", msg.getId());
+                    log.warn("Skipping post-sanitize blank USER message in {} history: messageId={}",
+                            context, msg.getId());
                     continue;
                 }
                 msgs.add(CohereChatRequest.Message.user(sanitized));
             } else if (msg.getRole() == MessageRole.CHATBOT) {
-                String content = msg.getContent();
-                if (content == null || content.isBlank()) {
-                    log.warn("Skipping blank CHATBOT message in brief history: messageId={}", msg.getId());
-                    continue;
-                }
-                msgs.add(CohereChatRequest.Message.assistant(content));
+                msgs.add(CohereChatRequest.Message.assistant(raw));
             }
         }
-
-        return truncateMessages(msgs, config.getMaxHistoryMessages());
     }
 
     /**

--- a/src/test/java/org/example/shield/ai/application/CohereServiceHistoryAppendTest.java
+++ b/src/test/java/org/example/shield/ai/application/CohereServiceHistoryAppendTest.java
@@ -1,0 +1,171 @@
+package org.example.shield.ai.application;
+
+import org.example.shield.ai.dto.CohereChatRequest;
+import org.example.shield.ai.infrastructure.SanitizeService;
+import org.example.shield.common.enums.MessageRole;
+import org.example.shield.consultation.domain.Message;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link CohereService#appendHistory} 공통 메서드 단위 테스트.
+ *
+ * <p>PR-B 리팩터링에서 {@code buildChatMessages} / {@code buildBriefMessages}
+ * 의 대화 내역 순회 로직을 {@code appendHistory} 로 추출했다. 이 테스트는 그
+ * 공통 경로의 방어적 skip 계약(Issue #45)을 고정한다:</p>
+ * <ul>
+ *   <li>원본 content 가 null/blank 이면 role 과 무관하게 skip</li>
+ *   <li>USER 의 경우 sanitize 결과가 blank 로 수축해도 skip</li>
+ *   <li>정상 content 는 USER 는 sanitize 후, CHATBOT 은 원본 그대로 추가</li>
+ * </ul>
+ *
+ * <p>리플렉션으로 private 메서드를 직접 호출해 {@code aiClient}/{@code promptService}
+ * 같은 불필요한 협력자 없이 순수 로직만 검증한다.</p>
+ */
+class CohereServiceHistoryAppendTest {
+
+    private SanitizeService sanitizeService;
+    private CohereService service;
+    private Method appendHistory;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        sanitizeService = mock(SanitizeService.class);
+        when(sanitizeService.sanitizeUserText(anyString()))
+                .thenAnswer(inv -> inv.getArgument(0)); // 기본은 원문 유지
+
+        service = createServiceWithSanitize(sanitizeService);
+        appendHistory = CohereService.class.getDeclaredMethod(
+                "appendHistory", List.class, List.class, String.class);
+        appendHistory.setAccessible(true);
+    }
+
+    @Test
+    @DisplayName("appendHistory — 정상 USER/CHATBOT 메시지는 순서대로 변환되어 추가된다")
+    void appendHistory_valid_addsInOrder() throws Exception {
+        List<Message> history = List.of(
+                messageWithId(MessageRole.USER, "사용자 질문 1"),
+                messageWithId(MessageRole.CHATBOT, "챗봇 응답 1"),
+                messageWithId(MessageRole.USER, "사용자 질문 2")
+        );
+        List<CohereChatRequest.Message> msgs = new ArrayList<>();
+
+        appendHistory.invoke(service, msgs, history, "chat");
+
+        assertThat(msgs).hasSize(3);
+        assertThat(msgs.get(0).getRole()).isEqualTo("user");
+        assertThat(msgs.get(0).getContent()).isEqualTo("사용자 질문 1");
+        assertThat(msgs.get(1).getRole()).isEqualTo("assistant");
+        assertThat(msgs.get(1).getContent()).isEqualTo("챗봇 응답 1");
+        assertThat(msgs.get(2).getRole()).isEqualTo("user");
+    }
+
+    @Test
+    @DisplayName("appendHistory — null/blank content 메시지는 role 무관하게 skip")
+    void appendHistory_blankRawContent_skipped() throws Exception {
+        List<Message> history = List.of(
+                messageWithId(MessageRole.USER, "정상 질문"),
+                messageWithId(MessageRole.CHATBOT, ""),        // blank CHATBOT → skip
+                messageWithId(MessageRole.USER, "   "),        // whitespace USER → skip
+                messageWithId(MessageRole.CHATBOT, null),      // null CHATBOT → skip
+                messageWithId(MessageRole.CHATBOT, "정상 응답")
+        );
+        List<CohereChatRequest.Message> msgs = new ArrayList<>();
+
+        appendHistory.invoke(service, msgs, history, "chat");
+
+        assertThat(msgs).hasSize(2);
+        assertThat(msgs.get(0).getContent()).isEqualTo("정상 질문");
+        assertThat(msgs.get(1).getContent()).isEqualTo("정상 응답");
+    }
+
+    @Test
+    @DisplayName("appendHistory — USER 원본이 blank 면 sanitizeService 를 아예 호출하지 않는다 (비용 회피)")
+    void appendHistory_blankUser_doesNotCallSanitize() throws Exception {
+        SanitizeService strictSanitize = mock(SanitizeService.class);
+        // sanitize 가 호출되면 예외로 실패시켜 호출 여부를 감지
+        when(strictSanitize.sanitizeUserText(anyString()))
+                .thenThrow(new AssertionError("sanitizeUserText 는 blank 원본에 대해 호출되면 안 된다"));
+
+        CohereService strictService = createServiceWithSanitize(strictSanitize);
+        List<Message> history = List.of(
+                messageWithId(MessageRole.USER, ""),
+                messageWithId(MessageRole.USER, "   ")
+        );
+        List<CohereChatRequest.Message> msgs = new ArrayList<>();
+
+        appendHistory.invoke(strictService, msgs, history, "brief");
+
+        assertThat(msgs).isEmpty();
+    }
+
+    @Test
+    @DisplayName("appendHistory — sanitize 결과가 blank 로 수축하는 USER 메시지는 skip")
+    void appendHistory_sanitizeShrinksToBlank_skipped() throws Exception {
+        when(sanitizeService.sanitizeUserText("[[PII]]")).thenReturn("   ");
+
+        List<Message> history = List.of(
+                messageWithId(MessageRole.USER, "[[PII]]"),
+                messageWithId(MessageRole.USER, "정상 질문")
+        );
+        List<CohereChatRequest.Message> msgs = new ArrayList<>();
+
+        appendHistory.invoke(service, msgs, history, "chat");
+
+        assertThat(msgs).hasSize(1);
+        assertThat(msgs.get(0).getContent()).isEqualTo("정상 질문");
+    }
+
+    @Test
+    @DisplayName("appendHistory — 빈 history 면 아무 것도 추가하지 않는다")
+    void appendHistory_emptyHistory_noop() throws Exception {
+        List<CohereChatRequest.Message> msgs = new ArrayList<>();
+        appendHistory.invoke(service, msgs, List.<Message>of(), "chat");
+        assertThat(msgs).isEmpty();
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    /** Message 는 @GeneratedValue 로 id 가 null 이므로, 로그에 쓰일 id 를 리플렉션으로 주입. */
+    private Message messageWithId(MessageRole role, String content) throws Exception {
+        Message msg;
+        if (role == MessageRole.USER) {
+            msg = Message.createUserMessage(UUID.randomUUID(), content);
+        } else {
+            msg = Message.createAiMessage(UUID.randomUUID(), content, null, null, null, null);
+        }
+        Field idField = Message.class.getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(msg, UUID.randomUUID());
+        return msg;
+    }
+
+    /**
+     * CohereService 의 모든 의존성에 null 을 넣되 sanitizeService 만 실제 mock 을
+     * 주입한다. appendHistory 는 sanitizeService 만 사용하므로 이것으로 충분.
+     */
+    private CohereService createServiceWithSanitize(SanitizeService sanitize) throws Exception {
+        Constructor<?> constructor = CohereService.class.getDeclaredConstructors()[0];
+        constructor.setAccessible(true);
+        Object[] args = new Object[constructor.getParameterCount()];
+        CohereService s = (CohereService) constructor.newInstance(args);
+
+        Field f = CohereService.class.getDeclaredField("sanitizeService");
+        f.setAccessible(true);
+        f.set(s, sanitize);
+        return s;
+    }
+}


### PR DESCRIPTION
## 배경

[PR #47](https://github.com/capstoneSHIELD/SHIELD_BE/pull/47) 에서 Issue #45 를 해결하며 `buildChatMessages` / `buildBriefMessages` 양쪽에 거의 동일한 대화 내역 순회 루프와 방어적 skip 로직이 추가됐다. 이로 인해:

- 로그 메시지·sanitize 호출 순서·null/blank 체크 분기가 두 벌로 중복
- 향후 skip 정책 변경(메트릭 추가, sanitize 필드 분리 등)이 두 곳을 동시에 수정하게 만듦
- USER 메시지는 **원본 blank 체크 전에 `sanitizeService.sanitizeUserText()`를 먼저 호출** → blank 원본도 PII 스캔 비용을 치르고 있음

## 변경

### 1. \`appendHistory(msgs, history, context)\` private 메서드 신설

\`\`\`java
private void appendHistory(
        List<CohereChatRequest.Message> msgs, List<Message> history, String context) {
    for (Message msg : history) {
        String raw = msg.getContent();
        if (raw == null || raw.isBlank()) {
            log.warn(\"Skipping blank {} message in {} history: messageId={}\",
                    msg.getRole(), context, msg.getId());
            continue;
        }
        if (msg.getRole() == MessageRole.USER) {
            String sanitized = sanitizeService.sanitizeUserText(raw);
            if (sanitized == null || sanitized.isBlank()) { ... skip ... }
            msgs.add(CohereChatRequest.Message.user(sanitized));
        } else if (msg.getRole() == MessageRole.CHATBOT) {
            msgs.add(CohereChatRequest.Message.assistant(raw));
        }
    }
}
\`\`\`

### 2. 호출부 정리
- \`buildChatMessages\` → \`appendHistory(msgs, chatHistory, \"chat\")\`
- \`buildBriefMessages\` → \`appendHistory(msgs, history, \"brief\")\`
- 중복 ~30 라인 제거

### 3. 동작 차이 (의도적 개선)
- **USER 원본이 blank 이면 sanitize 를 건너뛰고 즉시 skip**  
  - 이전: blank 원본도 sanitize 호출 후 빈 결과 체크  
  - 이후: PII 스캔 비용 제거, 결과는 동일(skip)
- **\`context\` 파라미터로 로그 구분 (\"chat\" / \"brief\")**  
  - 향후 Micrometer 카운터/알럿에 태그로 바로 연결 가능

## 테스트

\`CohereServiceHistoryAppendTest\` 5건 추가:

| 케이스 | 검증 |
|--------|------|
| 정상 USER/CHATBOT | 순서 보존, role/content 올바른 변환 |
| null/blank content | role 무관하게 skip |
| blank 원본일 때 sanitize 미호출 | throw stub 으로 호출 여부 감지 |
| sanitize 결과가 blank 로 수축하는 USER | skip |
| 빈 history | no-op |

기존 \`CohereServiceTruncationTest\` 는 \`truncateMessages\` 만 테스트하므로 영향 없음.

## Refs
- Refs #45
- Depends on [PR #51 (PR-A)](https://github.com/capstoneSHIELD/SHIELD_BE/pull/51): 독립 PR 이지만 PR-A 먼저 merge 권장 (\`develop\` 최신 상태 유지)
- Follow-up: PR-C (Cohere 호출을 트랜잭션 밖으로 + Micrometer 메트릭)