### PR TITLE
[REFACTOR] Cohere 호출을 트랜잭션 밖으로 분리 + Micrometer 메트릭 (Issue #45 후속)

### DIFF
--- a/src/main/java/org/example/shield/consultation/application/AiFinalizePayload.java
+++ b/src/main/java/org/example/shield/consultation/application/AiFinalizePayload.java
@@ -1,0 +1,41 @@
+package org.example.shield.consultation.application;
+
+import java.util.List;
+
+/**
+ * {@link ChatTransactionalBoundary#finalizeAiResponse} 에 전달할 AI 응답 처리
+ * 결과 페이로드.
+ *
+ * <p>{@link MessageService} 가 Cohere 호출 후 트랜잭션 밖에서 준비하고,
+ * 최종 DB 반영 시 boundary 에 넘긴다. 분류 값은 온톨로지 필터링이 끝난
+ * 유효 값만 담아야 한다 (boundary 는 더 이상 검증하지 않음).</p>
+ *
+ * @param responseId    Cohere 응답 ID (감사 로깅)
+ * @param nextQuestion  다음 질문 (blank 검증 완료된 값)
+ * @param model         사용 모델명
+ * @param tokensInput   입력 토큰 수
+ * @param tokensOutput  출력 토큰 수
+ * @param latencyMs     Cohere 호출 지연(ms)
+ * @param aiDomains     온톨로지 검증 완료된 L1 (nullable)
+ * @param aiSubDomains  온톨로지 검증 완료된 L2 (nullable)
+ * @param aiTags        온톨로지 검증 완료된 L3 (nullable)
+ */
+public record AiFinalizePayload(
+        String responseId,
+        String nextQuestion,
+        String model,
+        Integer tokensInput,
+        Integer tokensOutput,
+        Integer latencyMs,
+        List<String> aiDomains,
+        List<String> aiSubDomains,
+        List<String> aiTags
+) {
+    public boolean hasAnyClassification() {
+        return isNonEmpty(aiDomains) || isNonEmpty(aiSubDomains) || isNonEmpty(aiTags);
+    }
+
+    private static boolean isNonEmpty(List<String> list) {
+        return list != null && !list.isEmpty();
+    }
+}

--- a/src/main/java/org/example/shield/consultation/application/ChatMetrics.java
+++ b/src/main/java/org/example/shield/consultation/application/ChatMetrics.java
@@ -1,0 +1,78 @@
+package org.example.shield.consultation.application;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Phase 1 Chat 파이프라인 전용 Micrometer 메트릭 센서.
+ *
+ * <p>계측 대상:</p>
+ * <ul>
+ *   <li>{@code shield.chat.cohere.call} — Cohere Chat v2 호출 지연
+ *       (timer, tag: {@code outcome=success|failure|blank})</li>
+ *   <li>{@code shield.chat.blank_response} — blank {@code nextQuestion} 발생 카운터
+ *       (counter, tag: {@code stage=chat})</li>
+ *   <li>{@code shield.chat.send_message} — sendMessage 전체 파이프라인 지연
+ *       (timer, tag: {@code outcome=success|blank|pii|error})</li>
+ * </ul>
+ *
+ * <p>메트릭 네이밍은 기존 {@code shield.rag.*} 컨벤션({@code RagMetrics})과
+ * 일관성을 맞춘다. {@code /actuator/prometheus} 에 자동 노출되며,
+ * 공통 {@code application} 태그는 {@code spring.application.name} 으로 부여된다.</p>
+ *
+ * <p>중앙화 이유는 {@code RagMetrics} 와 동일 — 호출 지점마다 Counter 를
+ * 찾지 않도록 API 를 단순화하고, 테스트에서 {@code SimpleMeterRegistry} 로
+ * 대체하기 쉽게 한다.</p>
+ */
+@Component
+public class ChatMetrics {
+
+    public static final String METRIC_COHERE_CALL = "shield.chat.cohere.call";
+    public static final String METRIC_BLANK_RESPONSE = "shield.chat.blank_response";
+    public static final String METRIC_SEND_MESSAGE = "shield.chat.send_message";
+
+    private final MeterRegistry registry;
+
+    public ChatMetrics(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    // === Cohere chat() 호출 ===
+
+    public Timer.Sample startCohereCall() {
+        return Timer.start(registry);
+    }
+
+    public void stopCohereCallSuccess(Timer.Sample sample) {
+        sample.stop(registry.timer(METRIC_COHERE_CALL, Tags.of("outcome", "success")));
+    }
+
+    public void stopCohereCallBlank(Timer.Sample sample) {
+        sample.stop(registry.timer(METRIC_COHERE_CALL, Tags.of("outcome", "blank")));
+    }
+
+    public void stopCohereCallFailure(Timer.Sample sample) {
+        sample.stop(registry.timer(METRIC_COHERE_CALL, Tags.of("outcome", "failure")));
+    }
+
+    // === Blank response counter ===
+
+    public void incrementBlankResponse() {
+        Counter.builder(METRIC_BLANK_RESPONSE)
+                .tag("stage", "chat")
+                .register(registry)
+                .increment();
+    }
+
+    // === sendMessage 전체 파이프라인 ===
+
+    public void recordSendMessage(long startNanos, String outcome) {
+        registry.timer(METRIC_SEND_MESSAGE, Tags.of("outcome", outcome))
+                .record(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
+    }
+}

--- a/src/main/java/org/example/shield/consultation/application/ChatTransactionalBoundary.java
+++ b/src/main/java/org/example/shield/consultation/application/ChatTransactionalBoundary.java
@@ -1,0 +1,111 @@
+package org.example.shield.consultation.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.shield.consultation.domain.Consultation;
+import org.example.shield.consultation.domain.ConsultationReader;
+import org.example.shield.consultation.domain.ConsultationWriter;
+import org.example.shield.consultation.domain.Message;
+import org.example.shield.consultation.domain.MessageWriter;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * Chat 파이프라인의 DB 트랜잭션 경계를 모아둔 컴포넌트.
+ *
+ * <p>Cohere Chat v2 호출은 외부 HTTP 요청이라 {@code sendMessage} 와 같은
+ * 단일 트랜잭션 안에서 수행되면 DB 커넥션을 수초~수십초 점유할 수 있다.
+ * 이 클래스는 짧은 DB-only 트랜잭션만 담당해 커넥션 보유 시간을 최소화한다.</p>
+ *
+ * <p>Spring 프록시 특성상 같은 클래스의 self-invocation 은 {@code @Transactional}
+ * 을 태우지 못하므로, 트랜잭션 단위를 별도 bean 으로 분리했다. {@link MessageService}
+ * 는 이 클래스를 주입받아 각 단계를 호출한다.</p>
+ *
+ * <p>트랜잭션 단위:</p>
+ * <ul>
+ *   <li>{@link #saveUserMessage(UUID, String)} — USER 메시지 영속화 (독립 커밋)</li>
+ *   <li>{@link #finalizeAiResponse(UUID, AiFinalizePayload)} — AI 응답 이후
+ *       consultation 상태 업데이트 + AI 메시지 영속화 (독립 커밋)</li>
+ * </ul>
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ChatTransactionalBoundary {
+
+    private final MessageWriter messageWriter;
+    private final ConsultationWriter consultationWriter;
+    private final ConsultationReader consultationReader;
+
+    /**
+     * USER 메시지를 독립 트랜잭션으로 저장한다.
+     *
+     * <p>후속 Cohere 호출이 실패하거나 blank 응답을 반환하더라도
+     * 사용자 입력은 절대 유실되지 않는다 (Issue #45 후속 — PR-A 의 noRollbackFor
+     * 보다 한 단계 더 강력한 격리).</p>
+     */
+    @Transactional
+    public Message saveUserMessage(UUID consultationId, String content) {
+        Message userMessage = Message.createUserMessage(consultationId, content);
+        return messageWriter.save(userMessage);
+    }
+
+    /**
+     * PII 감지 시 AI 채널로 안내 메시지만 저장하는 독립 트랜잭션 경로.
+     */
+    @Transactional
+    public Message savePiiAiMessage(UUID consultationId, String message) {
+        Message piiMessage = Message.createAiMessage(
+                consultationId, message, null, null, null, null);
+        return messageWriter.save(piiMessage);
+    }
+
+    /**
+     * Cohere 호출 성공 후 DB 에 반영할 상태 변경을 하나의 트랜잭션으로 커밋한다.
+     *
+     * <p>Consultation 은 준영속(detached) 상태이므로 reader 로 재조회하고
+     * payload 로 받은 값을 반영한 뒤 writer 로 저장한다. AI 메시지는
+     * 별도로 영속화한다.</p>
+     *
+     * @param consultationId 대상 상담 ID
+     * @param payload        AI 응답 처리 결과 (분류·메시지·메타)
+     * @return 저장된 AI {@link Message}
+     */
+    @Transactional
+    public Message finalizeAiResponse(UUID consultationId, AiFinalizePayload payload) {
+        Consultation consultation = consultationReader.findById(consultationId);
+
+        // 1. lastResponseId (감사 로깅)
+        consultation.updateLastResponseId(payload.responseId());
+
+        // 2. AI 분류 결과 반영 (이미 온톨로지 필터링 완료된 값)
+        if (payload.hasAnyClassification()) {
+            boolean updated = consultation.updateAiClassification(
+                    payload.aiDomains(), payload.aiSubDomains(), payload.aiTags());
+            if (!updated) {
+                log.warn("LLM attempted to override locked classification: consultationId={}, aiDomains={}",
+                        consultationId, payload.aiDomains());
+            }
+        }
+
+        // 3. AI 메시지 영속화
+        Message aiMessage = Message.createAiMessage(
+                consultationId,
+                payload.nextQuestion(),
+                payload.model(),
+                payload.tokensInput(),
+                payload.tokensOutput(),
+                payload.latencyMs()
+        );
+        Message savedAi = messageWriter.save(aiMessage);
+
+        // 4. 상담 마지막 메시지 + updatedAt 갱신
+        consultation.updateLastMessage(savedAi.getContent(), savedAi.getCreatedAt());
+        consultation.touch();
+        consultationWriter.save(consultation);
+
+        return savedAi;
+    }
+}

--- a/src/main/java/org/example/shield/consultation/application/MessageService.java
+++ b/src/main/java/org/example/shield/consultation/application/MessageService.java
@@ -1,5 +1,6 @@
 package org.example.shield.consultation.application;
 
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.shield.ai.application.ChecklistCoverageService;
@@ -7,8 +8,8 @@ import org.example.shield.ai.application.CohereService;
 import org.example.shield.ai.application.OntologyService;
 import org.example.shield.ai.application.RagPipelineService;
 import org.example.shield.ai.config.CohereApiConfig;
-import org.example.shield.ai.dto.ChatParsedResponse;
 import org.example.shield.ai.dto.AiCallResult;
+import org.example.shield.ai.dto.ChatParsedResponse;
 import org.example.shield.ai.infrastructure.SanitizeService;
 import org.example.shield.common.exception.ChatAiException;
 import org.example.shield.common.response.PageResponse;
@@ -16,10 +17,8 @@ import org.example.shield.consultation.controller.dto.MessageResponse;
 import org.example.shield.consultation.controller.dto.SendMessageResponse;
 import org.example.shield.consultation.domain.Consultation;
 import org.example.shield.consultation.domain.ConsultationReader;
-import org.example.shield.consultation.domain.ConsultationWriter;
 import org.example.shield.consultation.domain.Message;
 import org.example.shield.consultation.domain.MessageReader;
-import org.example.shield.consultation.domain.MessageWriter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -28,139 +27,184 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * 상담 메시지 처리 조율자.
+ *
+ * <p>이 서비스는 <b>non-transactional</b> 이다 ({@code readOnly=true} 도 부여하지
+ * 않는다). Cohere Chat v2 호출은 외부 HTTP 요청이라 DB 트랜잭션 안에서 수행
+ * 되면 커넥션을 수초~수십초 점유할 수 있으므로, DB 작업은
+ * {@link ChatTransactionalBoundary} 의 짧은 트랜잭션으로 분리했다.</p>
+ *
+ * <p>실행 흐름:</p>
+ * <ol>
+ *   <li>사용자 입력 sanitize (순수 로직, 예외 시 PII 안내 메시지 저장 후 early return)</li>
+ *   <li>USER 메시지 저장 — {@link ChatTransactionalBoundary#saveUserMessage} (독립 tx)</li>
+ *   <li>대화 내역 조회 (tx 밖의 read-only)</li>
+ *   <li>RAG + Cohere chat() 호출 — <b>트랜잭션 밖</b></li>
+ *   <li>blank 응답 차단 — {@link ChatAiException} (Issue #45)</li>
+ *   <li>AI 분류 결과 온톨로지 필터링 (순수 로직)</li>
+ *   <li>AI 응답 최종 반영 — {@link ChatTransactionalBoundary#finalizeAiResponse} (독립 tx)</li>
+ *   <li>allCompleted 커버리지 게이트 (외부 검사, tx 불필요)</li>
+ * </ol>
+ *
+ * <p>USER 메시지 저장이 독립 트랜잭션이기 때문에 이후 Cohere 실패·blank 응답·
+ * 네트워크 에러 등 어떤 예외가 발생해도 사용자 입력은 절대 유실되지 않는다.
+ * PR-A 의 {@code noRollbackFor} 접근보다 한 단계 더 강한 격리다.</p>
+ */
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 @Slf4j
 public class MessageService {
 
     private final MessageReader messageReader;
-    private final MessageWriter messageWriter;
     private final ConsultationReader consultationReader;
-    private final ConsultationWriter consultationWriter;
     private final CohereService cohereService;
     private final CohereApiConfig cohereApiConfig;
     private final SanitizeService sanitizeService;
     private final ChecklistCoverageService checklistCoverageService;
     private final RagPipelineService ragPipelineService;
     private final OntologyService ontologyService;
+    private final ChatTransactionalBoundary chatTxBoundary;
+    private final ChatMetrics chatMetrics;
 
-    @Transactional
     public SendMessageResponse sendMessage(UUID consultationId, String content) {
-        Consultation consultation = consultationReader.findById(consultationId);
-
-        // 0. 사용자 입력 sanitization (P0-III)
-        String sanitizedText;
+        long pipelineStart = System.nanoTime();
         try {
-            sanitizedText = sanitizeService.sanitizeUserText(content);
-        } catch (SanitizeService.PiiDetectedException e) {
-            Message piiMessage = Message.createAiMessage(
-                    consultationId, e.getMessage(), null, null, null, null);
-            Message savedPii = messageWriter.save(piiMessage);
-            return SendMessageResponse.from(savedPii, false);
-        }
+            Consultation consultation = consultationReader.findById(consultationId);
 
-        // 1. USER 메시지 저장 (원문 보존)
-        Message userMessage = Message.createUserMessage(consultationId, content);
-        messageWriter.save(userMessage);
-
-        // 대화 내역 1회 조회 — RAG와 chat() 양쪽에서 공유 (중복 DB 쿼리 방지)
-        List<Message> chatHistory = messageReader.findAllByConsultationId(consultationId);
-
-        // [RAG] 도메인 정보가 있을 때만 실행
-        String ragContext = "";
-        String domainForRag = consultation.getFirstDomain();
-        if (domainForRag != null) {
-            ragContext = ragPipelineService.execute(chatHistory, domainForRag, consultationId);
-        }
-
-        // 2. Cohere API 호출 (Phase 1 대화 — RAG 컨텍스트 포함, 조회된 chatHistory 재사용)
-        AiCallResult<ChatParsedResponse> result = cohereService.chat(
-                consultation, sanitizedText, ragContext, chatHistory);
-        ChatParsedResponse parsed = result.data();
-
-        // 3. 응답 ID 저장 (감사 로깅용)
-        consultation.updateLastResponseId(result.responseId());
-
-        // 3-1. AI 응답 blank 차단 (Issue #45)
-        //      — nextQuestion 이 비어있으면 사용자에게 의미 있는 응답을 만들 수 없고,
-        //        이 상태로 DB에 저장되면 이후 Cohere v2 Chat API 가 빈 assistant
-        //        content 를 400 으로 거부해 대화가 영구적으로 막힌다.
-        String nextQuestion = parsed.getNextQuestion();
-        if (nextQuestion == null || nextQuestion.isBlank()) {
-            log.error("AI chat response is blank: consultationId={}, responseId={}, tokensOut={}",
-                    consultationId, result.responseId(), result.tokensOutput());
-            throw new ChatAiException();
-        }
-
-        // 4. AI 분류 결과 처리 (per-level lock + 온톨로지 환각 필터, Issue #48)
-        boolean hasAnyAi = hasAny(parsed.getAiDomains())
-                || hasAny(parsed.getAiSubDomains())
-                || hasAny(parsed.getAiTags());
-        if (hasAnyAi) {
-            // L2 검증: 부모 = userDomains 의 첫 값 (있을 때만)
-            List<String> validSubs = filterValidChildren(
-                    parsed.getAiSubDomains(),
-                    firstOrNull(consultation.getUserDomains()),
-                    consultationId,
-                    "L2");
-
-            // L3 검증: 부모 = userSubDomains 가 있으면 그것, 없으면 방금 검증된 validSubs 첫 값
-            List<String> l2Ref = hasAny(consultation.getUserSubDomains())
-                    ? consultation.getUserSubDomains()
-                    : validSubs;
-            List<String> validTags = filterValidChildren(
-                    parsed.getAiTags(),
-                    firstOrNull(l2Ref),
-                    consultationId,
-                    "L3");
-
-            boolean updated = consultation.updateAiClassification(
-                    parsed.getAiDomains(), validSubs, validTags);
-            if (!updated) {
-                log.warn("LLM attempted to override locked classification: consultationId={}, aiDomains={}",
-                        consultationId, parsed.getAiDomains());
+            // 0. 사용자 입력 sanitization (P0-III)
+            String sanitizedText;
+            try {
+                sanitizedText = sanitizeService.sanitizeUserText(content);
+            } catch (SanitizeService.PiiDetectedException e) {
+                Message savedPii = chatTxBoundary.savePiiAiMessage(consultationId, e.getMessage());
+                chatMetrics.recordSendMessage(pipelineStart, "pii");
+                return SendMessageResponse.from(savedPii, false);
             }
-        }
 
-        // 5. AI 메시지 저장
-        Message aiMessage = Message.createAiMessage(
-                consultationId,
-                nextQuestion,
-                cohereApiConfig.getChatModel(),  // model name from config
-                result.tokensInput(),
-                result.tokensOutput(),
-                result.latencyMs()
-        );
-        Message savedAi = messageWriter.save(aiMessage);
+            // 1. USER 메시지 저장 (독립 트랜잭션 — 후속 실패와 무관하게 보존)
+            chatTxBoundary.saveUserMessage(consultationId, content);
 
-        // 6. allCompleted AND gate (P0-II, Issue #40 3레벨 커버리지)
-        boolean effectiveAllCompleted = false;
-        if (parsed.isAllCompleted()) {
-            String l1 = consultation.getFirstDomain();
-            String l2 = consultation.getFirstSubDomain();
-            String l3 = consultation.getFirstTag();
+            // 대화 내역 1회 조회 — RAG와 chat() 양쪽에서 공유 (중복 DB 쿼리 방지)
+            List<Message> chatHistory = messageReader.findAllByConsultationId(consultationId);
 
-            double coverageRatio = checklistCoverageService.compute(
-                    consultationId, l1, l2, l3);
-            effectiveAllCompleted = checklistCoverageService.isEffectivelyCompleted(
-                    true, coverageRatio);
-
-            if (!effectiveAllCompleted) {
-                log.warn("LLM reported allCompleted=true but coverage={} < {}: consultationId={}, L1={}, L2={}, L3={}",
-                        coverageRatio, checklistCoverageService.getThreshold(), consultationId,
-                        l1, l2, l3);
+            // 2. [RAG] 도메인 정보가 있을 때만 실행 — 트랜잭션 밖
+            String ragContext = "";
+            String domainForRag = consultation.getFirstDomain();
+            if (domainForRag != null) {
+                ragContext = ragPipelineService.execute(chatHistory, domainForRag, consultationId);
             }
+
+            // 3. Cohere Chat v2 호출 — 트랜잭션 밖 + Micrometer 타이밍
+            AiCallResult<ChatParsedResponse> result = callCohereMeasured(
+                    consultation, sanitizedText, ragContext, chatHistory);
+            ChatParsedResponse parsed = result.data();
+
+            // 4. AI 응답 blank 차단 (Issue #45)
+            String nextQuestion = parsed.getNextQuestion();
+            if (nextQuestion == null || nextQuestion.isBlank()) {
+                log.error("AI chat response is blank: consultationId={}, responseId={}, tokensOut={}",
+                        consultationId, result.responseId(), result.tokensOutput());
+                chatMetrics.incrementBlankResponse();
+                chatMetrics.recordSendMessage(pipelineStart, "blank");
+                throw new ChatAiException();
+            }
+
+            // 5. AI 분류 결과 온톨로지 필터링 (순수 로직)
+            List<String> validSubs = null;
+            List<String> validTags = null;
+            boolean hasAnyAi = hasAny(parsed.getAiDomains())
+                    || hasAny(parsed.getAiSubDomains())
+                    || hasAny(parsed.getAiTags());
+            if (hasAnyAi) {
+                validSubs = filterValidChildren(
+                        parsed.getAiSubDomains(),
+                        firstOrNull(consultation.getUserDomains()),
+                        consultationId,
+                        "L2");
+                List<String> l2Ref = hasAny(consultation.getUserSubDomains())
+                        ? consultation.getUserSubDomains()
+                        : validSubs;
+                validTags = filterValidChildren(
+                        parsed.getAiTags(),
+                        firstOrNull(l2Ref),
+                        consultationId,
+                        "L3");
+            }
+
+            // 6. AI 응답 최종 반영 (독립 트랜잭션)
+            AiFinalizePayload payload = new AiFinalizePayload(
+                    result.responseId(),
+                    nextQuestion,
+                    cohereApiConfig.getChatModel(),
+                    result.tokensInput(),
+                    result.tokensOutput(),
+                    result.latencyMs(),
+                    hasAnyAi ? parsed.getAiDomains() : null,
+                    validSubs,
+                    validTags
+            );
+            Message savedAi = chatTxBoundary.finalizeAiResponse(consultationId, payload);
+
+            // 7. allCompleted AND gate (P0-II, Issue #40 3레벨 커버리지) — 트랜잭션 밖
+            boolean effectiveAllCompleted = evaluateAllCompletedGate(consultationId, consultation, parsed);
+
+            chatMetrics.recordSendMessage(pipelineStart, "success");
+            return SendMessageResponse.from(savedAi, effectiveAllCompleted);
+        } catch (ChatAiException e) {
+            throw e; // already metered
+        } catch (RuntimeException e) {
+            chatMetrics.recordSendMessage(pipelineStart, "error");
+            throw e;
         }
-
-        // 7. 상담 마지막 메시지 + updatedAt 갱신
-        consultation.updateLastMessage(savedAi.getContent(), savedAi.getCreatedAt());
-        consultation.touch();
-        consultationWriter.save(consultation);
-
-        return SendMessageResponse.from(savedAi, effectiveAllCompleted);
     }
 
+    /**
+     * Cohere chat() 호출을 Micrometer timer 로 감싼다.
+     * outcome 태그: success / blank / failure.
+     */
+    private AiCallResult<ChatParsedResponse> callCohereMeasured(
+            Consultation consultation, String sanitizedText, String ragContext, List<Message> chatHistory) {
+        Timer.Sample sample = chatMetrics.startCohereCall();
+        try {
+            AiCallResult<ChatParsedResponse> result = cohereService.chat(
+                    consultation, sanitizedText, ragContext, chatHistory);
+            String nq = result.data() == null ? null : result.data().getNextQuestion();
+            if (nq == null || nq.isBlank()) {
+                chatMetrics.stopCohereCallBlank(sample);
+            } else {
+                chatMetrics.stopCohereCallSuccess(sample);
+            }
+            return result;
+        } catch (RuntimeException e) {
+            chatMetrics.stopCohereCallFailure(sample);
+            throw e;
+        }
+    }
+
+    /**
+     * allCompleted 커버리지 AND 게이트 — DB read-only 계산만 수행.
+     * {@link ChecklistCoverageService} 자체가 필요 시 readOnly 트랜잭션을 연다.
+     */
+    private boolean evaluateAllCompletedGate(UUID consultationId, Consultation consultation,
+                                              ChatParsedResponse parsed) {
+        if (!parsed.isAllCompleted()) return false;
+
+        String l1 = consultation.getFirstDomain();
+        String l2 = consultation.getFirstSubDomain();
+        String l3 = consultation.getFirstTag();
+
+        double coverageRatio = checklistCoverageService.compute(consultationId, l1, l2, l3);
+        boolean effective = checklistCoverageService.isEffectivelyCompleted(true, coverageRatio);
+
+        if (!effective) {
+            log.warn("LLM reported allCompleted=true but coverage={} < {}: consultationId={}, L1={}, L2={}, L3={}",
+                    coverageRatio, checklistCoverageService.getThreshold(), consultationId, l1, l2, l3);
+        }
+        return effective;
+    }
+
+    @Transactional(readOnly = true)
     public PageResponse<MessageResponse> getMessages(UUID consultationId, Pageable pageable) {
         consultationReader.findById(consultationId);
 

--- a/src/main/java/org/example/shield/consultation/application/MessageService.java
+++ b/src/main/java/org/example/shield/consultation/application/MessageService.java
@@ -146,6 +146,11 @@ public class MessageService {
             );
             Message savedAi = chatTxBoundary.finalizeAiResponse(consultationId, payload);
 
+            // DB에 반영된 AI 분류 결과를 로컬 객체에도 동기화하여 후속 커버리지 계산에 사용
+            if (payload.hasAnyClassification()) {
+                consultation.updateAiClassification(payload.aiDomains(), payload.aiSubDomains(), payload.aiTags());
+            }
+
             // 7. allCompleted AND gate (P0-II, Issue #40 3레벨 커버리지) — 트랜잭션 밖
             boolean effectiveAllCompleted = evaluateAllCompletedGate(consultationId, consultation, parsed);
 

--- a/src/test/java/org/example/shield/consultation/application/ChatTransactionalBoundaryTest.java
+++ b/src/test/java/org/example/shield/consultation/application/ChatTransactionalBoundaryTest.java
@@ -1,0 +1,135 @@
+package org.example.shield.consultation.application;
+
+import org.example.shield.consultation.domain.Consultation;
+import org.example.shield.consultation.domain.ConsultationReader;
+import org.example.shield.consultation.domain.ConsultationWriter;
+import org.example.shield.consultation.domain.Message;
+import org.example.shield.consultation.domain.MessageWriter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * {@link ChatTransactionalBoundary} 단위 테스트.
+ *
+ * <p>boundary 는 DB 작업만 담당하는 얇은 컴포넌트이므로 주로 검증할 것은:</p>
+ * <ol>
+ *   <li>각 메서드가 {@code @Transactional} 어노테이션을 유지하는지 (트랜잭션 분리 보장)</li>
+ *   <li>AiFinalizePayload 값이 Consultation / Message 에 올바르게 반영되는지</li>
+ * </ol>
+ */
+@ExtendWith(MockitoExtension.class)
+class ChatTransactionalBoundaryTest {
+
+    @Mock private MessageWriter messageWriter;
+    @Mock private ConsultationWriter consultationWriter;
+    @Mock private ConsultationReader consultationReader;
+    @Mock private Consultation consultation;
+
+    @InjectMocks
+    private ChatTransactionalBoundary boundary;
+
+    private UUID consultationId;
+
+    @BeforeEach
+    void setUp() {
+        consultationId = UUID.randomUUID();
+    }
+
+    // ── 트랜잭션 계약 고정 ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("saveUserMessage / savePiiAiMessage / finalizeAiResponse 는 @Transactional 이어야 한다")
+    void methods_haveTransactionalAnnotation() throws NoSuchMethodException {
+        for (String name : new String[]{"saveUserMessage", "savePiiAiMessage", "finalizeAiResponse"}) {
+            Method m = findMethod(name);
+            Transactional tx = m.getAnnotation(Transactional.class);
+            assertThat(tx)
+                    .as("%s 는 @Transactional 이 유지되어야 트랜잭션 분리 효과가 보장된다", name)
+                    .isNotNull();
+            assertThat(tx.readOnly())
+                    .as("%s 는 write 트랜잭션이어야 한다", name)
+                    .isFalse();
+        }
+    }
+
+    private Method findMethod(String name) {
+        return java.util.Arrays.stream(ChatTransactionalBoundary.class.getDeclaredMethods())
+                .filter(m -> m.getName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(name + " 메서드가 존재해야 한다"));
+    }
+
+    // ── saveUserMessage ──────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("saveUserMessage → Message.createUserMessage 로 USER 메시지 1건 저장")
+    void saveUserMessage_savesUserRoleMessage() {
+        given(messageWriter.save(any(Message.class))).willAnswer(inv -> inv.getArgument(0));
+
+        Message saved = boundary.saveUserMessage(consultationId, "사용자 입력");
+
+        ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+        verify(messageWriter, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getContent()).isEqualTo("사용자 입력");
+        assertThat(saved).isNotNull();
+    }
+
+    // ── finalizeAiResponse ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("finalizeAiResponse → lastResponseId 업데이트 + 분류 반영 + AI 메시지 저장 + consultation save")
+    void finalizeAiResponse_fullFlow() {
+        given(consultationReader.findById(consultationId)).willReturn(consultation);
+        given(consultation.updateAiClassification(any(), any(), any())).willReturn(true);
+        given(messageWriter.save(any(Message.class))).willAnswer(inv -> inv.getArgument(0));
+
+        AiFinalizePayload payload = new AiFinalizePayload(
+                "resp-ok", "다음 질문입니다.", "command-a-03-2025",
+                100, 42, 250,
+                List.of("부동산 거래"), List.of("부동산 임대차"), List.of("보증금 및 차임")
+        );
+
+        Message savedAi = boundary.finalizeAiResponse(consultationId, payload);
+
+        verify(consultation).updateLastResponseId("resp-ok");
+        verify(consultation).updateAiClassification(
+                List.of("부동산 거래"), List.of("부동산 임대차"), List.of("보증금 및 차임"));
+        verify(consultation).touch();
+        verify(consultationWriter, times(1)).save(consultation);
+        verify(messageWriter, times(1)).save(any(Message.class));
+        assertThat(savedAi.getContent()).isEqualTo("다음 질문입니다.");
+    }
+
+    @Test
+    @DisplayName("finalizeAiResponse — 분류 payload 가 모두 null 이면 updateAiClassification 미호출")
+    void finalizeAiResponse_noClassification_skipsUpdate() {
+        given(consultationReader.findById(consultationId)).willReturn(consultation);
+        given(messageWriter.save(any(Message.class))).willAnswer(inv -> inv.getArgument(0));
+
+        AiFinalizePayload payload = new AiFinalizePayload(
+                "resp-noai", "질문", "model-x", 10, 5, 100,
+                null, null, null);
+
+        boundary.finalizeAiResponse(consultationId, payload);
+
+        verify(consultation).updateLastResponseId("resp-noai");
+        verify(consultation, times(0)).updateAiClassification(any(), any(), any());
+    }
+}

--- a/src/test/java/org/example/shield/consultation/application/MessageServiceTest.java
+++ b/src/test/java/org/example/shield/consultation/application/MessageServiceTest.java
@@ -1,6 +1,8 @@
 package org.example.shield.consultation.application;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.example.shield.ai.application.ChecklistCoverageService;
 import org.example.shield.ai.application.CohereService;
 import org.example.shield.ai.application.OntologyService;
@@ -13,10 +15,8 @@ import org.example.shield.common.exception.ChatAiException;
 import org.example.shield.consultation.controller.dto.SendMessageResponse;
 import org.example.shield.consultation.domain.Consultation;
 import org.example.shield.consultation.domain.ConsultationReader;
-import org.example.shield.consultation.domain.ConsultationWriter;
 import org.example.shield.consultation.domain.Message;
 import org.example.shield.consultation.domain.MessageReader;
-import org.example.shield.consultation.domain.MessageWriter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,32 +40,38 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
- * {@link MessageService} 단위 테스트 (Issue #45).
+ * {@link MessageService} 단위 테스트.
  *
- * <p>Cohere chat() 결과 {@code nextQuestion} 이 null/blank 인 경우
- * 빈 CHATBOT 메시지를 DB 에 저장하지 않고 {@link ChatAiException} 으로
- * 조기 실패하는지 검증한다. 정상 응답은 기존대로 저장된다.</p>
+ * <p>PR-C 에서 DB 트랜잭션 경계가 {@link ChatTransactionalBoundary} 로 분리되어
+ * MessageService 자체는 non-transactional 조율자 역할만 한다. 따라서 이 테스트는
+ * boundary 를 mock 으로 두고 조율 흐름만 검증한다 (실제 트랜잭션 동작은 통합
+ * 테스트 범위).</p>
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class MessageServiceTest {
 
     @Mock private MessageReader messageReader;
-    @Mock private MessageWriter messageWriter;
     @Mock private ConsultationReader consultationReader;
-    @Mock private ConsultationWriter consultationWriter;
     @Mock private CohereService cohereService;
     @Mock private CohereApiConfig cohereApiConfig;
     @Mock private SanitizeService sanitizeService;
     @Mock private ChecklistCoverageService checklistCoverageService;
     @Mock private RagPipelineService ragPipelineService;
     @Mock private Consultation consultation;
+    @Mock private ChatTransactionalBoundary chatTxBoundary;
+
+    // 실제 MeterRegistry — 카운터 증감까지 검증한다.
+    private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    @Spy
+    private ChatMetrics chatMetrics = new ChatMetrics(meterRegistry);
 
     // 실제 온톨로지 JSON 을 로드한 real OntologyService 주입 — 환각 필터 동작을 end-to-end 로 검증.
     @Spy
@@ -81,7 +87,6 @@ class MessageServiceTest {
                 json = new String(in.readAllBytes(), StandardCharsets.UTF_8);
             }
             OntologyService svc = new OntologyService(json, new ObjectMapper());
-            // loadOntology 는 package-private(@PostConstruct) — 다른 패키지에서는 reflection 으로 호출
             var m = OntologyService.class.getDeclaredMethod("loadOntology");
             m.setAccessible(true);
             m.invoke(svc);
@@ -98,141 +103,147 @@ class MessageServiceTest {
         consultationId = UUID.randomUUID();
 
         given(consultationReader.findById(consultationId)).willReturn(consultation);
-        given(consultation.getFirstDomain()).willReturn(null);                 // RAG skip
+        given(consultation.getFirstDomain()).willReturn(null); // RAG skip
         given(sanitizeService.sanitizeUserText(anyString())).willReturn("clean");
         given(messageReader.findAllByConsultationId(consultationId)).willReturn(Collections.emptyList());
         given(cohereApiConfig.getChatModel()).willReturn("command-a-03-2025");
+        // boundary 의 finalize 는 기본적으로 저장된 Message 를 리턴하도록 느슨하게 stub
+        given(chatTxBoundary.finalizeAiResponse(eq(consultationId), any(AiFinalizePayload.class)))
+                .willAnswer(inv -> {
+                    AiFinalizePayload p = inv.getArgument(1);
+                    return Message.createAiMessage(consultationId, p.nextQuestion(),
+                            p.model(), p.tokensInput(), p.tokensOutput(), p.latencyMs());
+                });
     }
 
-    @Test
-    @DisplayName("nextQuestion 이 blank 이면 ChatAiException 을 던지고 AI 메시지를 저장하지 않는다")
-    void sendMessage_blankNextQuestion_throwsChatAiException() {
-        // given
-        ChatParsedResponse parsed = new ChatParsedResponse();
-        parsed.setNextQuestion("   ");   // whitespace-only
-        AiCallResult<ChatParsedResponse> result = new AiCallResult<>(
-                "resp-blank-1", parsed, 100, 0, 250);
-        given(cohereService.chat(any(), anyString(), anyString(), any())).willReturn(result);
+    // ── Issue #45 — blank 응답 차단 ──────────────────────────────────────
 
-        // when / then
+    @Test
+    @DisplayName("nextQuestion blank → ChatAiException + USER 메시지는 boundary 로 저장됨 + blank_response 카운터 증가")
+    void sendMessage_blankNextQuestion_throwsChatAiException() {
+        ChatParsedResponse parsed = new ChatParsedResponse();
+        parsed.setNextQuestion("   ");
+        given(cohereService.chat(any(), anyString(), anyString(), any()))
+                .willReturn(new AiCallResult<>("resp-blank-1", parsed, 100, 0, 250));
+
         assertThatThrownBy(() -> messageService.sendMessage(consultationId, "사용자 입력"))
                 .isInstanceOf(ChatAiException.class);
 
-        // USER 메시지는 이미 저장된 상태라 verify 는 정확히 1회 (AI 메시지는 저장 X)
-        verify(messageWriter, times(1)).save(any(Message.class));
-        verify(consultationWriter, never()).save(any(Consultation.class));
+        // USER 는 먼저 저장되어야 한다 (독립 tx)
+        verify(chatTxBoundary, times(1)).saveUserMessage(consultationId, "사용자 입력");
+        // AI 응답 finalize 는 호출되지 않는다
+        verify(chatTxBoundary, never()).finalizeAiResponse(any(), any());
+
+        // 메트릭 — blank 카운터 1건, send_message timer outcome=blank
+        assertThat(meterRegistry.counter(ChatMetrics.METRIC_BLANK_RESPONSE, "stage", "chat").count())
+                .isEqualTo(1.0);
+        assertThat(meterRegistry.timer(ChatMetrics.METRIC_SEND_MESSAGE, "outcome", "blank").count())
+                .isEqualTo(1L);
+        assertThat(meterRegistry.timer(ChatMetrics.METRIC_COHERE_CALL, "outcome", "blank").count())
+                .isEqualTo(1L);
     }
 
     @Test
-    @DisplayName("nextQuestion 이 null 이면 ChatAiException 을 던진다")
+    @DisplayName("nextQuestion null → ChatAiException")
     void sendMessage_nullNextQuestion_throwsChatAiException() {
-        // given
         ChatParsedResponse parsed = new ChatParsedResponse();
         parsed.setNextQuestion(null);
-        AiCallResult<ChatParsedResponse> result = new AiCallResult<>(
-                "resp-null-1", parsed, 100, 0, 250);
-        given(cohereService.chat(any(), anyString(), anyString(), any())).willReturn(result);
+        given(cohereService.chat(any(), anyString(), anyString(), any()))
+                .willReturn(new AiCallResult<>("resp-null-1", parsed, 100, 0, 250));
 
-        // when / then
         assertThatThrownBy(() -> messageService.sendMessage(consultationId, "사용자 입력"))
                 .isInstanceOf(ChatAiException.class);
-
-        verify(messageWriter, times(1)).save(any(Message.class));
-        verify(consultationWriter, never()).save(any(Consultation.class));
+        verify(chatTxBoundary, times(1)).saveUserMessage(consultationId, "사용자 입력");
+        verify(chatTxBoundary, never()).finalizeAiResponse(any(), any());
     }
 
     @Test
-    @DisplayName("정상 nextQuestion 이면 AI 메시지를 저장하고 응답을 반환한다")
+    @DisplayName("정상 nextQuestion → finalizeAiResponse 에 payload 전달 + success 메트릭")
     void sendMessage_validNextQuestion_savesAiMessage() {
-        // given
         ChatParsedResponse parsed = new ChatParsedResponse();
         parsed.setNextQuestion("추가로 어떤 피해를 입으셨나요?");
         parsed.setAiDomains(List.of());
         parsed.setAiSubDomains(List.of());
         parsed.setAiTags(List.of());
-        AiCallResult<ChatParsedResponse> result = new AiCallResult<>(
-                "resp-ok-1", parsed, 100, 42, 250);
-        given(cohereService.chat(any(), anyString(), anyString(), any())).willReturn(result);
+        given(cohereService.chat(any(), anyString(), anyString(), any()))
+                .willReturn(new AiCallResult<>("resp-ok-1", parsed, 100, 42, 250));
 
-        // AI 메시지 저장 반환값 stub (mock Message 로 최소 동작만 보장)
-        Message savedAi = Message.createAiMessage(
-                consultationId, parsed.getNextQuestion(),
-                "command-a-03-2025", 100, 42, 250);
-        given(messageWriter.save(any(Message.class))).willReturn(savedAi);
-
-        // when
         SendMessageResponse response = messageService.sendMessage(consultationId, "사용자 입력");
 
-        // then
         assertThat(response).isNotNull();
-        // USER + AI 합 2회 저장
-        verify(messageWriter, times(2)).save(any(Message.class));
-        // Consultation 상태 업데이트 경로 도달 확인
-        verify(consultation).updateLastResponseId("resp-ok-1");
-        verify(consultationWriter, times(1)).save(consultation);
+
+        ArgumentCaptor<AiFinalizePayload> captor = ArgumentCaptor.forClass(AiFinalizePayload.class);
+        verify(chatTxBoundary, times(1)).saveUserMessage(consultationId, "사용자 입력");
+        verify(chatTxBoundary, times(1)).finalizeAiResponse(eq(consultationId), captor.capture());
+
+        AiFinalizePayload p = captor.getValue();
+        assertThat(p.responseId()).isEqualTo("resp-ok-1");
+        assertThat(p.nextQuestion()).isEqualTo("추가로 어떤 피해를 입으셨나요?");
+        assertThat(p.model()).isEqualTo("command-a-03-2025");
+        assertThat(p.tokensInput()).isEqualTo(100);
+        assertThat(p.tokensOutput()).isEqualTo(42);
+        assertThat(p.latencyMs()).isEqualTo(250);
+        assertThat(p.hasAnyClassification()).isFalse();
+
+        // 메트릭
+        assertThat(meterRegistry.timer(ChatMetrics.METRIC_SEND_MESSAGE, "outcome", "success").count())
+                .isEqualTo(1L);
+        assertThat(meterRegistry.timer(ChatMetrics.METRIC_COHERE_CALL, "outcome", "success").count())
+                .isEqualTo(1L);
     }
 
-    // =====================================================================
-    // Issue #48 온톨로지 환각 필터 통합 검증 (real OntologyService)
-    // =====================================================================
+    // ── Cohere 실패 시 메트릭 / tx 분리 검증 ──────────────────────────────
 
     @Test
-    @DisplayName("L1=부동산 거래, AI 가 잘못된 L2=재산분할(이혼 도메인) 반환 → 필터링되어 null 저장")
-    void sendMessage_환각L2필터링() {
-        // given — 실제 Consultation 으로 교체 (update 검증)
-        Consultation real = Consultation.create(consultationId,
-                List.of("부동산 거래"), null, null);
-        given(consultationReader.findById(consultationId)).willReturn(real);
-        given(ragPipelineService.execute(any(), anyString(), any())).willReturn("");
-
-        ChatParsedResponse parsed = new ChatParsedResponse();
-        parsed.setNextQuestion("어떤 유형의 부동산 거래인가요?");
-        parsed.setAiDomains(List.of("부동산 거래"));
-        // 환각: 재산분할 은 이혼·위자료·재산분할 트리 소속 → 부동산 거래 의 직계 자식 아님
-        parsed.setAiSubDomains(List.of("재산분할"));
-        parsed.setAiTags(List.of());
-        AiCallResult<ChatParsedResponse> result = new AiCallResult<>(
-                "resp-hallu-1", parsed, 100, 42, 250);
-        given(cohereService.chat(any(), anyString(), anyString(), any())).willReturn(result);
-        given(messageWriter.save(any(Message.class))).willAnswer(inv -> inv.getArgument(0));
-
-        // when
-        messageService.sendMessage(consultationId, "사용자 입력");
-
-        // then — L1 은 user 고정, AI 의 L2 는 온톨로지 위반으로 제거되어 null 저장
-        assertThat(real.getUserDomains()).containsExactly("부동산 거래");
-        assertThat(real.getAiDomains()).isNull();        // user 가 있으므로 ai 미반영
-        assertThat(real.getAiSubDomains()).isNull();     // 환각 제거 → 유효 0개 → null
-        assertThat(real.getAiTags()).isNull();
-    }
-
-    @Test
-    @DisplayName("L1=부동산 거래, AI L2=[부동산 임대차(정상),재산분할(환각)] → 정상만 남음")
-    void sendMessage_환각L2부분필터링() {
-        Consultation real = Consultation.create(consultationId,
-                List.of("부동산 거래"), null, null);
-        given(consultationReader.findById(consultationId)).willReturn(real);
-        given(ragPipelineService.execute(any(), anyString(), any())).willReturn("");
-
-        ChatParsedResponse parsed = new ChatParsedResponse();
-        parsed.setNextQuestion("임대차 관련 상세식 알려주세요.");
-        parsed.setAiDomains(List.of("부동산 거래"));
-        parsed.setAiSubDomains(List.of("부동산 임대차", "재산분할")); // 1개만 정상
-        parsed.setAiTags(List.of("보증금 및 차임"));                    // 부동산 임대차 자식 → 정상
+    @DisplayName("Cohere 호출 예외 → USER 메시지는 저장된 상태로 남고, cohere.call failure 메트릭 기록")
+    void sendMessage_cohereFailure_userPreservedAndMetered() {
         given(cohereService.chat(any(), anyString(), anyString(), any()))
-                .willReturn(new AiCallResult<>("resp-hallu-2", parsed, 100, 42, 250));
-        given(messageWriter.save(any(Message.class))).willAnswer(inv -> inv.getArgument(0));
+                .willThrow(new RuntimeException("Cohere 500"));
+
+        assertThatThrownBy(() -> messageService.sendMessage(consultationId, "사용자 입력"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Cohere 500");
+
+        // USER 는 별도 tx 로 이미 커밋되었으므로 boundary 호출은 1회 수행
+        verify(chatTxBoundary, times(1)).saveUserMessage(consultationId, "사용자 입력");
+        verify(chatTxBoundary, never()).finalizeAiResponse(any(), any());
+
+        assertThat(meterRegistry.timer(ChatMetrics.METRIC_COHERE_CALL, "outcome", "failure").count())
+                .isEqualTo(1L);
+        assertThat(meterRegistry.timer(ChatMetrics.METRIC_SEND_MESSAGE, "outcome", "error").count())
+                .isEqualTo(1L);
+    }
+
+    // ── 온톨로지 환각 필터 (AI 분류) — 순수 로직 ──────────────────────────
+
+    @Test
+    @DisplayName("L1=부동산 거래, AI L2=[부동산 임대차(정상),재산분할(환각)] → 정상만 payload 에 실린다")
+    void sendMessage_filtersHallucinatedSubDomains() {
+        Consultation real = Consultation.create(consultationId,
+                List.of("부동산 거래"), null, null);
+        given(consultationReader.findById(consultationId)).willReturn(real);
+        given(ragPipelineService.execute(any(), anyString(), any())).willReturn("");
+
+        ChatParsedResponse parsed = new ChatParsedResponse();
+        parsed.setNextQuestion("임대차 보증금 조건을 알려주세요.");
+        parsed.setAiDomains(List.of("부동산 거래"));
+        parsed.setAiSubDomains(List.of("부동산 임대차", "재산분할")); // 1개 환각
+        parsed.setAiTags(List.of("보증금 및 차임"));
+        given(cohereService.chat(any(), anyString(), anyString(), any()))
+                .willReturn(new AiCallResult<>("resp-hallu", parsed, 100, 42, 250));
 
         messageService.sendMessage(consultationId, "사용자 입력");
 
-        // 정상 L2 1개만 남고, L3 도 정상 부모(부동산 임대차) 중 유효하므로 저장
-        assertThat(real.getAiSubDomains()).containsExactly("부동산 임대차");
-        assertThat(real.getAiTags()).containsExactly("보증금 및 차임");
+        ArgumentCaptor<AiFinalizePayload> captor = ArgumentCaptor.forClass(AiFinalizePayload.class);
+        verify(chatTxBoundary).finalizeAiResponse(eq(consultationId), captor.capture());
+        AiFinalizePayload p = captor.getValue();
+        assertThat(p.aiSubDomains()).containsExactly("부동산 임대차");
+        assertThat(p.aiTags()).containsExactly("보증금 및 차임");
     }
 
     @Test
-    @DisplayName("부모(userDomains)가 없으면 검증 skip — AI 가 반환한 L2 그대로 저장")
-    void sendMessage_부모없으면검증skip() {
+    @DisplayName("부모(userDomains)가 없으면 환각 필터 skip — AI L2/L3 가 그대로 payload 에 실린다")
+    void sendMessage_noParent_skipsValidation() {
         Consultation real = Consultation.create(consultationId, null, null, null);
         given(consultationReader.findById(consultationId)).willReturn(real);
 
@@ -243,13 +254,37 @@ class MessageServiceTest {
         parsed.setAiTags(List.of("보증금 및 차임"));
         given(cohereService.chat(any(), anyString(), anyString(), any()))
                 .willReturn(new AiCallResult<>("resp-noparent", parsed, 100, 42, 250));
-        given(messageWriter.save(any(Message.class))).willAnswer(inv -> inv.getArgument(0));
 
         messageService.sendMessage(consultationId, "사용자 입력");
 
-        // user 가 없으므로 AI 값이 그대로 반영 (부모가 null 이면 검증 skip)
-        assertThat(real.getAiDomains()).containsExactly("부동산 거래");
-        assertThat(real.getAiSubDomains()).containsExactly("부동산 임대차");
-        assertThat(real.getAiTags()).containsExactly("보증금 및 차임");
+        ArgumentCaptor<AiFinalizePayload> captor = ArgumentCaptor.forClass(AiFinalizePayload.class);
+        verify(chatTxBoundary).finalizeAiResponse(eq(consultationId), captor.capture());
+        AiFinalizePayload p = captor.getValue();
+        assertThat(p.aiDomains()).containsExactly("부동산 거래");
+        assertThat(p.aiSubDomains()).containsExactly("부동산 임대차");
+        assertThat(p.aiTags()).containsExactly("보증금 및 차임");
+    }
+
+    // ── PII 안내 응답 — early return 경로 ──────────────────────────────────
+
+    @Test
+    @DisplayName("PII 감지 → boundary.savePiiAiMessage 로 안내 메시지 저장, Cohere 호출 없음")
+    void sendMessage_piiDetected_earlyReturn() {
+        given(sanitizeService.sanitizeUserText(anyString()))
+                .willThrow(new SanitizeService.PiiDetectedException("주민등록번호가 감지되었습니다."));
+        given(chatTxBoundary.savePiiAiMessage(eq(consultationId), anyString()))
+                .willReturn(Message.createAiMessage(consultationId, "주민등록번호가 감지되었습니다.",
+                        null, null, null, null));
+
+        SendMessageResponse response = messageService.sendMessage(consultationId, "주민번호 1234");
+
+        assertThat(response).isNotNull();
+        verify(chatTxBoundary, times(1)).savePiiAiMessage(eq(consultationId), anyString());
+        verify(chatTxBoundary, never()).saveUserMessage(any(), any());
+        verify(chatTxBoundary, never()).finalizeAiResponse(any(), any());
+        verify(cohereService, never()).chat(any(), any(), any(), any());
+
+        assertThat(meterRegistry.timer(ChatMetrics.METRIC_SEND_MESSAGE, "outcome", "pii").count())
+                .isEqualTo(1L);
     }
 }


### PR DESCRIPTION
## 배경

\`MessageService.sendMessage\` 는 \`@Transactional\` 로 감싸진 채 내부에서 외부 HTTP 요청인 Cohere Chat v2 호출을 수행했다.

### 문제
- **DB 커넥션 점유**: Cohere 응답이 올 때까지 수초~수십초 커넥션을 잡고 있음 → 풀 고갈 리스크
- **트랜잭션 타임아웃 증가**: Cohere 지연이 길어지면 전체 sendMessage 트랜잭션이 타임아웃될 확률 상승
- **관측성 부재**: Cohere 지연/실패/blank 응답 비율을 볼 수 있는 메트릭이 없어 Issue #45 같은 증상을 사후 진단에만 의존

## 변경

### 1. 트랜잭션 경계 분리

\`\`\`
[before]  sendMessage { tx { USER 저장 · RAG · Cohere · AI 저장 · consultation save } }
                                       └─ 외부 HTTP 가 tx 안에서 동작

[after]   sendMessage {                                     (non-tx)
            boundary.saveUserMessage()   { tx { USER 저장 } }
            ragPipeline.execute()                            (tx 밖)
            cohereService.chat()                             (tx 밖, 측정됨)
            boundary.finalizeAiResponse(payload) { tx { consultation 업데이트 + AI 저장 } }
            checklistCoverage.compute()                       (tx 밖)
          }
\`\`\`

#### 신규 컴포넌트
- **\`ChatTransactionalBoundary\`**: DB 작업 전담
  - \`saveUserMessage\` — USER 메시지 저장 (독립 tx)
  - \`savePiiAiMessage\` — PII 안내 메시지 저장 (독립 tx)
  - \`finalizeAiResponse\` — lastResponseId + 분류 + AI 메시지 + consultation save 를 **하나의 짧은 tx** 로 커밋
- **\`AiFinalizePayload\`** (record): MessageService 가 tx 밖에서 준비한 AI 응답 처리 결과를 boundary 에 전달

#### 효과
- Cohere 호출은 어떤 tx 에도 속하지 않음 → DB 커넥션 점유 0
- USER 메시지는 Cohere 호출 전에 **독립 tx 로 커밋** → [PR-A](https://github.com/capstoneSHIELD/SHIELD_BE/pull/51) 의 \`noRollbackFor\` 보다 한 단계 강한 격리 (Cohere 타임아웃·네트워크 에러·blank 응답 어떤 경우에도 사용자 입력 유실 불가)
- AI 응답 이후 DB 업데이트는 짧은 tx 로만 묶여 커넥션 보유 시간 최소

### 2. Micrometer 메트릭 (\`ChatMetrics\`)

\`RagMetrics\` 컨벤션 준수:

| 메트릭 | 타입 | 태그 | 용도 |
|--------|------|------|------|
| \`shield.chat.cohere.call\` | Timer | \`outcome={success,blank,failure}\` | Cohere 호출 지연 + 결과 분포 |
| \`shield.chat.blank_response\` | Counter | \`stage=chat\` | **blank nextQuestion 발생 횟수 — Issue #45 재발 감지 알럿 기반** |
| \`shield.chat.send_message\` | Timer | \`outcome={success,blank,pii,error}\` | 전체 파이프라인 지연 + outcome 분포 |

모두 \`/actuator/prometheus\` 에 자동 노출.

## 테스트

- **\`MessageServiceTest\` 전면 재작성 (7건)**
  - blank / null nextQuestion → \`ChatAiException\` + 메트릭 카운팅
  - 정상 응답 → \`AiFinalizePayload\` 필드 전달 검증 + success 메트릭
  - Cohere 예외 → USER 메시지 저장은 유지 + failure 메트릭
  - L2 환각 필터링 (온톨로지)
  - 부모 부재 시 환각 필터 skip
  - PII 감지 → \`savePiiAiMessage\` 경로, Cohere 미호출
- **\`ChatTransactionalBoundaryTest\` 신규 (4건)**
  - 3개 메서드 모두 \`@Transactional\` 유지 (계약 고정)
  - \`saveUserMessage\` 가 USER role 로 저장
  - \`finalizeAiResponse\` 전체 흐름 (lastResponseId / 분류 / AI 메시지 / consultation save)
  - 분류가 모두 null 이면 \`updateAiClassification\` 미호출

## 호환성

- **public API 시그니처 동일** (\`sendMessage\`, \`getMessages\`)
- **외부 행동 변화 없음**: blank 차단 / PII 안내 / AI 메시지 저장 모두 그대로
- \`MessageService\` 에서 \`@Transactional\` 이 사라졌지만 DB 작업은 모두 boundary 로 이동했으므로 영속성 계약은 유지

## PR 의존성

- [PR #51 (PR-A)](https://github.com/capstoneSHIELD/SHIELD_BE/pull/51): 이 PR 이 merge 되면 PR-A 의 \`noRollbackFor\` 는 자연스럽게 대체됨 (sendMessage 자체가 non-tx 가 되므로 더 이상 필요 없음). **순서: PR-A → PR-B → PR-C 권장**
- [PR #52 (PR-B)](https://github.com/capstoneSHIELD/SHIELD_BE/pull/52): 독립적이나 conflict 가능성 있음 (CohereService 는 이 PR 에서 건드리지 않으므로 영향 없음)

## Refs
- Refs #45
- Follow-up: PR-D (blank 응답을 예외 대신 fallback 메시지로 전환 여부 논의)