### PR TITLE
[FEAT] 변호사 매칭 임베딩 + Consultation 3-tier 분류 기반 쿼리 (Issue #50)

### DIFF
--- a/src/main/java/org/example/shield/admin/application/AdminService.java
+++ b/src/main/java/org/example/shield/admin/application/AdminService.java
@@ -18,6 +18,7 @@ import org.example.shield.common.enums.VerificationStatus;
 import org.example.shield.common.exception.BusinessException;
 import org.example.shield.common.exception.ErrorCode;
 import org.example.shield.common.response.PageResponse;
+import org.example.shield.lawyer.application.LawyerEmbeddingService;
 import org.example.shield.lawyer.domain.LawyerProfile;
 import org.example.shield.lawyer.domain.LawyerReader;
 import org.example.shield.lawyer.domain.LawyerWriter;
@@ -52,6 +53,7 @@ public class AdminService {
     private final VerificationLogReader verificationLogReader;
     private final VerificationLogRepository verificationLogRepository;
     private final VerificationCheckReader verificationCheckReader;
+    private final LawyerEmbeddingService lawyerEmbeddingService;
 
     public DashboardStatsResponse getDashboardStats() {
         log.info("대시보드 통계 조회");
@@ -196,6 +198,15 @@ public class AdminService {
 
         lawyer.updateVerificationStatus(newStatus);
         lawyerWriter.save(lawyer);
+
+        // VERIFIED 로 전환된 경우 매칭용 임베딩을 업서트 (Issue #50)
+        if (newStatus == VerificationStatus.VERIFIED) {
+            try {
+                lawyerEmbeddingService.upsertEmbedding(lawyer);
+            } catch (Exception ex) {
+                log.warn("변호사 임베딩 생성 실패 (승인은 성공) lawyerId={} error={}", lawyerId, ex.getMessage());
+            }
+        }
 
         VerificationLog log = VerificationLog.create(lawyerId, adminId, previousStatus, newStatus.name(), reason);
         verificationLogWriter.save(log);

--- a/src/main/java/org/example/shield/brief/application/LawyerMatchingService.java
+++ b/src/main/java/org/example/shield/brief/application/LawyerMatchingService.java
@@ -9,6 +9,8 @@ import org.example.shield.brief.controller.dto.MatchingResponse;
 import org.example.shield.brief.domain.Brief;
 import org.example.shield.brief.domain.BriefReader;
 import org.example.shield.brief.exception.BriefNotFoundException;
+import org.example.shield.consultation.domain.Consultation;
+import org.example.shield.consultation.domain.ConsultationReader;
 import org.example.shield.common.enums.VerificationStatus;
 import org.example.shield.common.response.PageResponse;
 import org.example.shield.lawyer.application.LawyerEmbeddingTextBuilder;
@@ -49,6 +51,7 @@ import java.util.stream.Collectors;
 public class LawyerMatchingService {
 
     private final BriefReader briefReader;
+    private final ConsultationReader consultationReader;
     private final LawyerReader lawyerReader;
     private final UserReader userReader;
     private final LawyerEmbeddingRepository lawyerEmbeddingRepository;
@@ -62,18 +65,34 @@ public class LawyerMatchingService {
             throw new BriefNotFoundException(briefId);
         }
 
+        // 상담의 대/중/소분류를 우선 사용 (user > ai 폴백).
+        Consultation consultation = consultationReader.findById(brief.getConsultationId());
+        List<String> domains = consultation.getEffectiveDomains();
+        List<String> subDomains = consultation.getEffectiveSubDomains();
+        List<String> tags = consultation.getEffectiveTags();
+
+        // 상담에 대분류 없으면 Brief.legalField 로 폴백.
+        if (domains.isEmpty() && brief.getLegalField() != null) {
+            domains = List.of(brief.getLegalField());
+        }
+
+        // matchedKeywords 집계용: 소분류 + Brief.keywords 합집합.
         List<String> briefKeywords = brief.getKeywords() != null ? brief.getKeywords() : Collections.emptyList();
+        List<String> matchKeywords = new ArrayList<>(tags);
+        for (String kw : briefKeywords) {
+            if (kw != null && !matchKeywords.contains(kw)) matchKeywords.add(kw);
+        }
 
         // 1) 쿼리 텍스트 조립 → 임베딩
         String queryText = embeddingTextBuilder.build(
-                brief.getLegalField() != null ? List.of(brief.getLegalField()) : List.of(),
-                List.of(),
-                briefKeywords,
+                domains,
+                subDomains,
+                tags,
                 brief.getContent());
 
         float[] queryVec = tryEmbedQuery(queryText);
         if (queryVec != null && queryVec.length > 0) {
-            Page<MatchingResponse> vectorPage = searchByVector(queryVec, briefKeywords, pageable);
+            Page<MatchingResponse> vectorPage = searchByVector(queryVec, matchKeywords, pageable);
             if (vectorPage != null) {
                 return PageResponse.from(vectorPage);
             }
@@ -81,7 +100,7 @@ public class LawyerMatchingService {
 
         // 2) degrade: 기존 키워드 매칭 fallback
         log.warn("벡터 매칭 실패 → 키워드 fallback briefId={}", briefId);
-        return fallbackKeywordMatching(briefKeywords, pageable);
+        return fallbackKeywordMatching(matchKeywords, pageable);
     }
 
     private float[] tryEmbedQuery(String queryText) {

--- a/src/main/java/org/example/shield/brief/application/LawyerMatchingService.java
+++ b/src/main/java/org/example/shield/brief/application/LawyerMatchingService.java
@@ -78,10 +78,11 @@ public class LawyerMatchingService {
 
         // matchedKeywords 집계용: 소분류 + Brief.keywords 합집합.
         List<String> briefKeywords = brief.getKeywords() != null ? brief.getKeywords() : Collections.emptyList();
-        List<String> matchKeywords = new ArrayList<>(tags);
+        java.util.Set<String> keywordSet = new java.util.LinkedHashSet<>(tags);
         for (String kw : briefKeywords) {
-            if (kw != null && !matchKeywords.contains(kw)) matchKeywords.add(kw);
+            if (kw != null) keywordSet.add(kw);
         }
+        List<String> matchKeywords = new java.util.ArrayList<>(keywordSet);
 
         // 1) 쿼리 텍스트 조립 → 임베딩
         String queryText = embeddingTextBuilder.build(

--- a/src/main/java/org/example/shield/brief/application/LawyerMatchingService.java
+++ b/src/main/java/org/example/shield/brief/application/LawyerMatchingService.java
@@ -1,17 +1,25 @@
 package org.example.shield.brief.application;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.shield.ai.application.QueryEmbeddingService;
 import org.example.shield.brief.controller.dto.MatchingResponse;
 import org.example.shield.brief.domain.Brief;
 import org.example.shield.brief.domain.BriefReader;
 import org.example.shield.brief.exception.BriefNotFoundException;
 import org.example.shield.common.enums.VerificationStatus;
 import org.example.shield.common.response.PageResponse;
+import org.example.shield.lawyer.application.LawyerEmbeddingTextBuilder;
 import org.example.shield.lawyer.domain.LawyerProfile;
 import org.example.shield.lawyer.domain.LawyerReader;
+import org.example.shield.lawyer.infrastructure.LawyerEmbeddingRepository;
+import org.example.shield.lawyer.infrastructure.LawyerMatchProjection;
 import org.example.shield.user.domain.User;
 import org.example.shield.user.domain.UserReader;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,11 +27,22 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+/**
+ * 변호사 매칭 서비스 (Issue #50 리팩터).
+ *
+ * <p>Brief 의 {@code legalField}, {@code keywords}, {@code content} 를
+ * {@link LawyerEmbeddingTextBuilder} 로 문서 측과 동일한 템플릿에 조립해 쿼리 벡터를 생성하고,
+ * {@link LawyerEmbeddingRepository#findTopBySimilarity} 로 코사인 유사도 상위 변호사를 페이지네이션 반환한다.</p>
+ *
+ * <p>쿼리 임베딩 호출 실패 시 기존 키워드 매칭 fallback 으로 degrade.</p>
+ */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -32,9 +51,11 @@ public class LawyerMatchingService {
     private final BriefReader briefReader;
     private final LawyerReader lawyerReader;
     private final UserReader userReader;
+    private final LawyerEmbeddingRepository lawyerEmbeddingRepository;
+    private final LawyerEmbeddingTextBuilder embeddingTextBuilder;
+    private final QueryEmbeddingService queryEmbeddingService;
+    private final ObjectMapper objectMapper;
 
-    // TODO: AI 서버 연동 시 벡터DB 유사도 검색으로 교체
-    // 현재는 VERIFIED 변호사를 경력순으로 반환하는 목 매칭
     public PageResponse<MatchingResponse> findMatching(UUID briefId, UUID userId, Pageable pageable) {
         Brief brief = briefReader.findById(briefId);
         if (!brief.getUserId().equals(userId)) {
@@ -43,22 +64,106 @@ public class LawyerMatchingService {
 
         List<String> briefKeywords = brief.getKeywords() != null ? brief.getKeywords() : Collections.emptyList();
 
+        // 1) 쿼리 텍스트 조립 → 임베딩
+        String queryText = embeddingTextBuilder.build(
+                brief.getLegalField() != null ? List.of(brief.getLegalField()) : List.of(),
+                List.of(),
+                briefKeywords,
+                brief.getContent());
+
+        float[] queryVec = tryEmbedQuery(queryText);
+        if (queryVec != null && queryVec.length > 0) {
+            Page<MatchingResponse> vectorPage = searchByVector(queryVec, briefKeywords, pageable);
+            if (vectorPage != null) {
+                return PageResponse.from(vectorPage);
+            }
+        }
+
+        // 2) degrade: 기존 키워드 매칭 fallback
+        log.warn("벡터 매칭 실패 → 키워드 fallback briefId={}", briefId);
+        return fallbackKeywordMatching(briefKeywords, pageable);
+    }
+
+    private float[] tryEmbedQuery(String queryText) {
+        if (queryText == null || queryText.isBlank()) {
+            return null;
+        }
+        try {
+            return queryEmbeddingService.embedQuery(queryText);
+        } catch (Exception e) {
+            log.warn("쿼리 임베딩 실패, fallback 전환 error={}", e.getMessage());
+            return null;
+        }
+    }
+
+    private Page<MatchingResponse> searchByVector(float[] queryVec,
+                                                   List<String> briefKeywords,
+                                                   Pageable pageable) {
+        try {
+            String vecLiteral = floatArrayToPgVector(queryVec);
+            int limit = pageable.getPageSize();
+            int offset = (int) pageable.getOffset();
+
+            List<LawyerMatchProjection> rows = lawyerEmbeddingRepository.findTopBySimilarity(
+                    vecLiteral, limit, offset);
+            long total = lawyerEmbeddingRepository.countVerifiedWithEmbedding();
+
+            List<UUID> userIds = rows.stream().map(LawyerMatchProjection::getUserId).toList();
+            Map<UUID, User> userMap = userReader.findAllByIds(userIds).stream()
+                    .collect(Collectors.toMap(User::getId, Function.identity()));
+
+            List<MatchingResponse> responses = rows.stream()
+                    .map(row -> toResponse(row, userMap, briefKeywords))
+                    .toList();
+
+            return new PageImpl<>(responses, pageable, total);
+        } catch (Exception e) {
+            log.warn("벡터 검색 실패 error={}", e.getMessage());
+            return null;
+        }
+    }
+
+    private MatchingResponse toResponse(LawyerMatchProjection row,
+                                        Map<UUID, User> userMap,
+                                        List<String> briefKeywords) {
+        User user = userMap.get(row.getUserId());
+        List<String> domains = parseJsonArray(row.getDomains());
+        List<String> subDomains = parseJsonArray(row.getSubDomains());
+        List<String> tags = parseJsonArray(row.getTags());
+        List<String> matched = findMatchedKeywords(briefKeywords, tags);
+
+        double score = row.getSimilarity() != null ? row.getSimilarity() : 0.0;
+
+        return new MatchingResponse(
+                row.getUserId(),
+                user != null ? user.getName() : "알 수 없음",
+                user != null ? user.getProfileImageUrl() : null,
+                domains,
+                subDomains,
+                row.getExperienceYears(),
+                tags,
+                matched,
+                row.getBio(),
+                row.getRegion(),
+                score
+        );
+    }
+
+    private PageResponse<MatchingResponse> fallbackKeywordMatching(List<String> briefKeywords,
+                                                                   Pageable pageable) {
         Page<LawyerProfile> lawyers = lawyerReader.findAllByVerificationStatus(
                 VerificationStatus.VERIFIED, pageable);
 
-        // 변호사 userId 일괄 조회 (이름 가져오기용)
         List<UUID> userIds = lawyers.getContent().stream()
                 .map(LawyerProfile::getUserId).toList();
         Map<UUID, User> userMap = userReader.findAllByIds(userIds).stream()
                 .collect(Collectors.toMap(User::getId, Function.identity()));
 
-        Page<MatchingResponse> responsePage = lawyers.map(lawyer -> {
+        Page<MatchingResponse> page = lawyers.map(lawyer -> {
             User user = userMap.get(lawyer.getUserId());
             List<String> matched = findMatchedKeywords(briefKeywords, lawyer.getTags());
-            // TODO: AI 매칭 점수로 교체 — 현재는 키워드 일치 비율 기반 간이 스코어
             double score = briefKeywords.isEmpty() ? 0.0
                     : (double) matched.size() / briefKeywords.size();
-
             return new MatchingResponse(
                     lawyer.getUserId(),
                     user != null ? user.getName() : "알 수 없음",
@@ -73,8 +178,7 @@ public class LawyerMatchingService {
                     score
             );
         });
-
-        return PageResponse.from(responsePage);
+        return PageResponse.from(page);
     }
 
     private List<String> findMatchedKeywords(List<String> briefKeywords, List<String> lawyerTags) {
@@ -82,5 +186,30 @@ public class LawyerMatchingService {
         List<String> matched = new ArrayList<>(briefKeywords);
         matched.retainAll(lawyerTags);
         return matched;
+    }
+
+    private List<String> parseJsonArray(String json) {
+        if (json == null || json.isBlank()) return Collections.emptyList();
+        try {
+            return objectMapper.readValue(json, new TypeReference<List<String>>() {});
+        } catch (Exception e) {
+            log.debug("jsonb 파싱 실패 raw={} error={}", json, e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * {@code float[]} 를 pgvector 리터럴 {@code "[0.123456,...]"} 로 변환.
+     * {@code PgLegalRetrievalService.floatArrayToPgVector} 와 동일 포맷.
+     */
+    static String floatArrayToPgVector(float[] vec) {
+        StringBuilder sb = new StringBuilder(vec.length * 10 + 2);
+        sb.append('[');
+        for (int i = 0; i < vec.length; i++) {
+            if (i > 0) sb.append(',');
+            sb.append(String.format(Locale.ROOT, "%.6f", vec[i]));
+        }
+        sb.append(']');
+        return sb.toString();
     }
 }

--- a/src/main/java/org/example/shield/brief/application/LawyerMatchingService.java
+++ b/src/main/java/org/example/shield/brief/application/LawyerMatchingService.java
@@ -227,7 +227,7 @@ public class LawyerMatchingService {
         sb.append('[');
         for (int i = 0; i < vec.length; i++) {
             if (i > 0) sb.append(',');
-            sb.append(String.format(Locale.ROOT, "%.6f", vec[i]));
+            sb.append(vec[i]);
         }
         sb.append(']');
         return sb.toString();

--- a/src/main/java/org/example/shield/consultation/domain/Consultation.java
+++ b/src/main/java/org/example/shield/consultation/domain/Consultation.java
@@ -164,6 +164,33 @@ public class Consultation extends BaseEntity {
         return null;
     }
 
+    /**
+     * 매칭용 전체 대분류 리스트: userDomains 우선, 없으면 aiDomains.
+     */
+    public List<String> getEffectiveDomains() {
+        if (isNonEmpty(userDomains)) return userDomains;
+        if (isNonEmpty(aiDomains)) return aiDomains;
+        return List.of();
+    }
+
+    /**
+     * 매칭용 전체 중분류 리스트: userSubDomains 우선, 없으면 aiSubDomains.
+     */
+    public List<String> getEffectiveSubDomains() {
+        if (isNonEmpty(userSubDomains)) return userSubDomains;
+        if (isNonEmpty(aiSubDomains)) return aiSubDomains;
+        return List.of();
+    }
+
+    /**
+     * 매칭용 전체 소분류(태그) 리스트: userTags 우선, 없으면 aiTags.
+     */
+    public List<String> getEffectiveTags() {
+        if (isNonEmpty(userTags)) return userTags;
+        if (isNonEmpty(aiTags)) return aiTags;
+        return List.of();
+    }
+
     private static boolean isNonEmpty(List<String> list) {
         return list != null && !list.isEmpty();
     }

--- a/src/main/java/org/example/shield/lawyer/application/LawyerEmbeddingBackfillRunner.java
+++ b/src/main/java/org/example/shield/lawyer/application/LawyerEmbeddingBackfillRunner.java
@@ -1,0 +1,106 @@
+package org.example.shield.lawyer.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.shield.common.enums.VerificationStatus;
+import org.example.shield.lawyer.domain.LawyerProfile;
+import org.example.shield.lawyer.infrastructure.LawyerProfileRepository;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+/**
+ * 기존 VERIFIED 변호사 임베딩 백필 Runner (Issue #50).
+ *
+ * <p>실행 조건:</p>
+ * <ul>
+ *   <li>{@code ingest} 프로파일 (SPRING_PROFILES_ACTIVE=ingest)</li>
+ *   <li>CLI 인자 {@code --backfill=lawyer-embeddings}</li>
+ * </ul>
+ *
+ * <p>예시:</p>
+ * <pre>
+ * SPRING_PROFILES_ACTIVE=ingest ./gradlew bootRun --args='--backfill=lawyer-embeddings'
+ * </pre>
+ *
+ * <p>VERIFIED 변호사를 페이지 단위(100개)로 순회하며
+ * {@link LawyerEmbeddingService#upsertEmbedding(LawyerProfile)} 호출.
+ * 동일 해시면 Cohere 호출은 자동 skip.</p>
+ */
+@Component
+@Profile("ingest")
+@Order(30)
+@RequiredArgsConstructor
+@Slf4j
+public class LawyerEmbeddingBackfillRunner implements ApplicationRunner {
+
+    private static final int PAGE_SIZE = 100;
+
+    private final LawyerProfileRepository lawyerProfileRepository;
+    private final LawyerEmbeddingService lawyerEmbeddingService;
+    private final ConfigurableApplicationContext context;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (!args.containsOption("backfill")
+                || !args.getOptionValues("backfill").contains("lawyer-embeddings")) {
+            log.info("LawyerEmbeddingBackfillRunner: --backfill=lawyer-embeddings 인자 없음, 스킵");
+            return;
+        }
+
+        log.info("===== 변호사 임베딩 백필 시작 =====");
+        int processed = 0;
+        int failed = 0;
+        int exitCode = 0;
+
+        try {
+            int pageNumber = 0;
+            while (true) {
+                Pageable pageable = PageRequest.of(pageNumber, PAGE_SIZE, Sort.by("createdAt"));
+                Page<LawyerProfile> page = lawyerProfileRepository
+                        .findAllByVerificationStatus(VerificationStatus.VERIFIED, pageable);
+
+                if (page.isEmpty()) break;
+
+                for (LawyerProfile profile : page.getContent()) {
+                    try {
+                        lawyerEmbeddingService.upsertEmbedding(profile);
+                        processed++;
+                    } catch (Exception ex) {
+                        failed++;
+                        log.warn("백필 개별 실패 lawyerId={} error={}", profile.getId(), ex.getMessage());
+                    }
+                }
+
+                log.info("진행: page={} processed={} failed={}", pageNumber, processed, failed);
+                if (!page.hasNext()) break;
+                pageNumber++;
+            }
+
+            log.info("===== 변호사 임베딩 백필 종료: processed={} failed={} =====", processed, failed);
+            exitCode = failed == 0 ? 0 : 2;
+        } catch (Exception e) {
+            log.error("===== 변호사 임베딩 백필 실패: {} =====", e.getMessage(), e);
+            exitCode = 1;
+        }
+
+        // 웹 서버 기동 없이 즉시 종료
+        int rc = exitCode;
+        new Thread(() -> {
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+            int code = org.springframework.boot.SpringApplication.exit(context, () -> rc);
+            System.exit(code);
+        }, "lawyer-embedding-backfill-shutdown").start();
+    }
+}

--- a/src/main/java/org/example/shield/lawyer/application/LawyerEmbeddingService.java
+++ b/src/main/java/org/example/shield/lawyer/application/LawyerEmbeddingService.java
@@ -1,0 +1,110 @@
+package org.example.shield.lawyer.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.shield.ai.config.CohereApiConfig;
+import org.example.shield.ai.infrastructure.CohereClient;
+import org.example.shield.lawyer.domain.LawyerEmbedding;
+import org.example.shield.lawyer.domain.LawyerProfile;
+import org.example.shield.lawyer.infrastructure.LawyerEmbeddingRepository;
+import org.example.shield.lawyer.infrastructure.LawyerProfileRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * 변호사 임베딩 생성·재계산 서비스 (Issue #50).
+ *
+ * <p>변호사 승인 / 프로필 수정 이벤트 훅에서 호출된다.
+ * 동일 {@code sourceHash} 면 임베딩 호출을 건너뛰어 Cohere 비용과 지연을 절감.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LawyerEmbeddingService {
+
+    private final LawyerProfileRepository lawyerProfileRepository;
+    private final LawyerEmbeddingRepository lawyerEmbeddingRepository;
+    private final LawyerEmbeddingTextBuilder textBuilder;
+    private final CohereClient cohereClient;
+    private final CohereApiConfig cohereConfig;
+
+    /**
+     * 변호사 id 로 프로필을 조회해 임베딩을 생성/갱신한다.
+     * 프로필 또는 텍스트가 비면 skip.
+     */
+    @Transactional
+    public void upsertEmbedding(UUID lawyerId) {
+        Optional<LawyerProfile> profileOpt = lawyerProfileRepository.findById(lawyerId);
+        if (profileOpt.isEmpty()) {
+            log.warn("변호사 임베딩 skip: 프로필 없음 lawyerId={}", lawyerId);
+            return;
+        }
+        upsertEmbedding(profileOpt.get());
+    }
+
+    /**
+     * 변호사 프로필에서 텍스트를 조립 → 해시 비교 → 변경 시에만 Cohere 호출·저장.
+     */
+    @Transactional
+    public void upsertEmbedding(LawyerProfile profile) {
+        UUID lawyerId = profile.getId();
+        String text = textBuilder.build(
+                profile.getDomains(),
+                profile.getSubDomains(),
+                profile.getTags(),
+                profile.getBio());
+
+        if (text.isBlank()) {
+            log.info("변호사 임베딩 skip: 빈 텍스트 lawyerId={}", lawyerId);
+            return;
+        }
+
+        String hash = sha256(text);
+        String model = cohereConfig.getEmbedModel();
+
+        Optional<LawyerEmbedding> existingOpt = lawyerEmbeddingRepository.findById(lawyerId);
+        if (existingOpt.isPresent()) {
+            LawyerEmbedding existing = existingOpt.get();
+            if (hash.equals(existing.getSourceHash()) && model.equals(existing.getEmbeddingModel())) {
+                log.debug("변호사 임베딩 skip: 해시 동일 lawyerId={}", lawyerId);
+                return;
+            }
+            float[] vec = embed(text);
+            existing.updateEmbedding(vec, model, hash, text);
+            log.info("변호사 임베딩 갱신 lawyerId={}", lawyerId);
+            return;
+        }
+
+        float[] vec = embed(text);
+        LawyerEmbedding entity = LawyerEmbedding.create(lawyerId, vec, model, hash, text);
+        lawyerEmbeddingRepository.save(entity);
+        log.info("변호사 임베딩 신규 생성 lawyerId={}", lawyerId);
+    }
+
+    private float[] embed(String text) {
+        List<float[]> vectors = cohereClient.embedDocuments(
+                cohereConfig.getEmbedModel(), List.of(text));
+        if (vectors == null || vectors.isEmpty() || vectors.get(0) == null) {
+            throw new IllegalStateException("Cohere 임베딩 응답이 비어있음");
+        }
+        return vectors.get(0);
+    }
+
+    private String sha256(String text) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(text.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 사용 불가", e);
+        }
+    }
+}

--- a/src/main/java/org/example/shield/lawyer/application/LawyerEmbeddingTextBuilder.java
+++ b/src/main/java/org/example/shield/lawyer/application/LawyerEmbeddingTextBuilder.java
@@ -1,0 +1,91 @@
+package org.example.shield.lawyer.application;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 변호사 임베딩용 텍스트 조립기 (Issue #50).
+ *
+ * <p>문서(변호사 프로필) 와 쿼리(Brief 분류 결과) 양쪽에 동일한 템플릿을 사용해
+ * 같은 벡터 공간에 매핑되도록 보장한다.</p>
+ *
+ * <pre>
+ * [전문 분야]
+ * {domains 3회 반복, ". " 구분}
+ * [세부 분야]
+ * {subDomains 2회 반복, ". " 구분}
+ * [태그]
+ * {tags 1회, ". " 구분}
+ * [자기소개]
+ * {bio 전문}
+ * </pre>
+ *
+ * <p>반복 가중치로 domains &gt; subDomains &gt; tags 순 영향력을 준다.
+ * null / 빈 리스트는 섹션을 건너뛴다.</p>
+ */
+@Component
+public class LawyerEmbeddingTextBuilder {
+
+    private static final int DOMAINS_REPEAT = 3;
+    private static final int SUB_DOMAINS_REPEAT = 2;
+    private static final int TAGS_REPEAT = 1;
+
+    /**
+     * 변호사 프로필 / 쿼리 공통 텍스트 빌드.
+     *
+     * @param domains    전문 분야 (가중치 3)
+     * @param subDomains 세부 분야 (가중치 2)
+     * @param tags       태그 (가중치 1)
+     * @param bio        자기소개 (null 허용)
+     * @return 임베딩에 태울 조립 텍스트 (섹션이 모두 비면 빈 문자열)
+     */
+    public String build(List<String> domains,
+                        List<String> subDomains,
+                        List<String> tags,
+                        String bio) {
+        StringBuilder sb = new StringBuilder();
+
+        appendSection(sb, "[전문 분야]", domains, DOMAINS_REPEAT);
+        appendSection(sb, "[세부 분야]", subDomains, SUB_DOMAINS_REPEAT);
+        appendSection(sb, "[태그]", tags, TAGS_REPEAT);
+
+        if (bio != null && !bio.isBlank()) {
+            if (sb.length() > 0) {
+                sb.append('\n');
+            }
+            sb.append("[자기소개]\n").append(bio.trim());
+        }
+
+        return sb.toString();
+    }
+
+    private void appendSection(StringBuilder sb,
+                               String header,
+                               List<String> values,
+                               int repeat) {
+        if (values == null || values.isEmpty()) {
+            return;
+        }
+        List<String> cleaned = values.stream()
+                .filter(v -> v != null && !v.isBlank())
+                .map(String::trim)
+                .toList();
+        if (cleaned.isEmpty()) {
+            return;
+        }
+
+        if (sb.length() > 0) {
+            sb.append('\n');
+        }
+        sb.append(header).append('\n');
+
+        String joined = String.join(". ", cleaned);
+        for (int i = 0; i < repeat; i++) {
+            if (i > 0) {
+                sb.append(". ");
+            }
+            sb.append(joined);
+        }
+    }
+}

--- a/src/main/java/org/example/shield/lawyer/application/LawyerService.java
+++ b/src/main/java/org/example/shield/lawyer/application/LawyerService.java
@@ -1,6 +1,7 @@
 package org.example.shield.lawyer.application;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.shield.common.enums.VerificationStatus;
 import org.example.shield.common.response.PageResponse;
 import org.example.shield.lawyer.controller.dto.LawyerResponse;
@@ -20,6 +21,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -28,6 +30,7 @@ public class LawyerService {
     private final LawyerReader lawyerReader;
     private final LawyerWriter lawyerWriter;
     private final UserReader userReader;
+    private final LawyerEmbeddingService lawyerEmbeddingService;
 
     public PageResponse<LawyerResponse> getLawyers(Pageable pageable, String specialization, Integer minExperience) {
         Page<LawyerProfile> profiles = lawyerReader.findVerifiedLawyers(
@@ -72,6 +75,17 @@ public class LawyerService {
                 request.bio(),
                 request.region()
         );
+
+        // VERIFIED 변호사 가 프로필 을 바꾸면 임베딩을 새로 계산 (Issue #50)
+        if (profile.getVerificationStatus() == VerificationStatus.VERIFIED) {
+            try {
+                lawyerEmbeddingService.upsertEmbedding(profile);
+            } catch (Exception ex) {
+                log.warn("변호사 임베딩 재계산 실패 (프로필 저장은 성공) lawyerId={} error={}",
+                        profile.getId(), ex.getMessage());
+            }
+        }
+
         User user = userReader.findById(userId);
         return LawyerResponse.from(profile, user.getName(), user.getProfileImageUrl());
     }

--- a/src/main/java/org/example/shield/lawyer/domain/LawyerEmbedding.java
+++ b/src/main/java/org/example/shield/lawyer/domain/LawyerEmbedding.java
@@ -1,0 +1,93 @@
+package org.example.shield.lawyer.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * 변호사 임베딩 엔티티 (Issue #50, lawyer_embeddings 테이블 매핑).
+ *
+ * <p>Flyway V8 마이그레이션으로 생성된 {@code lawyer_embeddings} 와 1:1 매핑.
+ * {@code lawyer_id} 가 PK 이자 {@code lawyers.id} 의 FK (ON DELETE CASCADE).</p>
+ *
+ * <p>문서 벡터는 {@link LawyerEmbeddingTextBuilder} 로 조립한 텍스트를
+ * Cohere embed-v4.0 (1024차원) 에 태워 생성한다. 재임베딩 판단은 {@code sourceHash}
+ * (SHA-256) 로 비교.</p>
+ *
+ * <p>LegalChunkEntity 와 동일한 {@code SqlTypes.VECTOR} + {@code float[]} 매핑 패턴.</p>
+ */
+@Entity
+@Table(name = "lawyer_embeddings")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LawyerEmbedding {
+
+    @Id
+    @Column(name = "lawyer_id", nullable = false)
+    private UUID lawyerId;
+
+    @JdbcTypeCode(SqlTypes.VECTOR)
+    @Column(name = "embedding", nullable = false, columnDefinition = "vector(1024)")
+    private float[] embedding;
+
+    @Column(name = "embedding_model", nullable = false, length = 64)
+    private String embeddingModel;
+
+    @Column(name = "source_hash", nullable = false, length = 64)
+    private String sourceHash;
+
+    @Column(name = "source_text", columnDefinition = "text")
+    private String sourceText;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    /**
+     * 신규 임베딩 생성.
+     */
+    public static LawyerEmbedding create(UUID lawyerId,
+                                         float[] embedding,
+                                         String embeddingModel,
+                                         String sourceHash,
+                                         String sourceText) {
+        LawyerEmbedding e = new LawyerEmbedding();
+        e.lawyerId = lawyerId;
+        e.embedding = embedding;
+        e.embeddingModel = embeddingModel;
+        e.sourceHash = sourceHash;
+        e.sourceText = sourceText;
+        return e;
+    }
+
+    /**
+     * 재임베딩 (프로필 변경 또는 모델 교체).
+     */
+    public void updateEmbedding(float[] embedding,
+                                String embeddingModel,
+                                String sourceHash,
+                                String sourceText) {
+        this.embedding = embedding;
+        this.embeddingModel = embeddingModel;
+        this.sourceHash = sourceHash;
+        this.sourceText = sourceText;
+    }
+}

--- a/src/main/java/org/example/shield/lawyer/infrastructure/LawyerEmbeddingRepository.java
+++ b/src/main/java/org/example/shield/lawyer/infrastructure/LawyerEmbeddingRepository.java
@@ -1,0 +1,59 @@
+package org.example.shield.lawyer.infrastructure;
+
+import org.example.shield.lawyer.domain.LawyerEmbedding;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 변호사 임베딩 리포지토리 (Issue #50).
+ *
+ * <p>pgvector 코사인 거리 연산자 {@code <=>} 를 이용해
+ * 쿼리 벡터에 가까운 VERIFIED 변호사 목록을 유사도 내림차순으로 반환한다.</p>
+ *
+ * <p>쿼리 벡터는 {@code PgLegalRetrievalService.floatArrayToPgVector} 와 동일한
+ * {@code "[0.123456,...]"} 문자열 포맷으로 전달하며, SQL 에서 {@code CAST(:queryVec AS vector)} 로 변환한다.</p>
+ */
+public interface LawyerEmbeddingRepository extends JpaRepository<LawyerEmbedding, UUID> {
+
+    /**
+     * 코사인 유사도 기반 상위 변호사 조회 (VERIFIED 만).
+     *
+     * <p>{@code similarity = 1 - cosine_distance}, 즉 1 에 가까울수록 유사.
+     * HNSW 인덱스 (vector_cosine_ops) 를 타기 위해 ORDER BY 는 {@code <=>} 연산자 그대로 사용.</p>
+     */
+    @Query(value = """
+            SELECT l.id AS lawyerId,
+                   l.user_id AS userId,
+                   l.domains AS domains,
+                   l.sub_domains AS subDomains,
+                   l.tags AS tags,
+                   l.bio AS bio,
+                   l.experience_years AS experienceYears,
+                   l.region AS region,
+                   1 - (e.embedding <=> CAST(:queryVec AS vector)) AS similarity
+            FROM lawyer_embeddings e
+            JOIN lawyers l ON l.id = e.lawyer_id
+            WHERE CAST(l.verification_status AS TEXT) = 'VERIFIED'
+            ORDER BY e.embedding <=> CAST(:queryVec AS vector)
+            LIMIT :limit OFFSET :offset
+            """, nativeQuery = true)
+    List<LawyerMatchProjection> findTopBySimilarity(
+            @Param("queryVec") String queryVec,
+            @Param("limit") int limit,
+            @Param("offset") int offset);
+
+    /**
+     * VERIFIED 변호사 중 임베딩이 존재하는 총 개수 (페이지네이션 total).
+     */
+    @Query(value = """
+            SELECT COUNT(*)
+            FROM lawyer_embeddings e
+            JOIN lawyers l ON l.id = e.lawyer_id
+            WHERE CAST(l.verification_status AS TEXT) = 'VERIFIED'
+            """, nativeQuery = true)
+    long countVerifiedWithEmbedding();
+}

--- a/src/main/java/org/example/shield/lawyer/infrastructure/LawyerMatchProjection.java
+++ b/src/main/java/org/example/shield/lawyer/infrastructure/LawyerMatchProjection.java
@@ -1,0 +1,24 @@
+package org.example.shield.lawyer.infrastructure;
+
+import java.util.UUID;
+
+/**
+ * {@link LawyerEmbeddingRepository#findTopBySimilarity} 결과 투영 (Issue #50).
+ *
+ * <p>JPA Native Query + Interface-based Projection. 컬럼 별칭과 getter 이름을 맞춘다.</p>
+ *
+ * <p>{@code domains}, {@code subDomains}, {@code tags} 는 jsonb 컬럼이며
+ * 드라이버가 문자열 (JSON 배열) 로 반환한다. 서비스 레이어에서 {@code ObjectMapper}
+ * 로 {@code List<String>} 으로 역직렬화한다.</p>
+ */
+public interface LawyerMatchProjection {
+    UUID getLawyerId();
+    UUID getUserId();
+    String getDomains();
+    String getSubDomains();
+    String getTags();
+    String getBio();
+    Integer getExperienceYears();
+    String getRegion();
+    Double getSimilarity();
+}

--- a/src/main/resources/db/migration/V8__create_lawyer_embeddings.sql
+++ b/src/main/resources/db/migration/V8__create_lawyer_embeddings.sql
@@ -1,0 +1,41 @@
+-- Issue #50: 변호사 매칭 임베딩 — lawyer_embeddings (1:1 with lawyers)
+--
+-- 별도 테이블 분리 이유:
+--  * lawyers 프로필 수정과 임베딩 갱신의 LOCK 경합 방지
+--  * legal_chunks/legal_cases 와 동일 패턴 유지
+--  * 1024차원 벡터 로드를 필요할 때만 JOIN 으로 수행
+--  * embedding_model 교체 이력 추적 가능
+--
+-- 전제: V3 에서 CREATE EXTENSION IF NOT EXISTS vector 이미 수행됨.
+
+CREATE TABLE IF NOT EXISTS lawyer_embeddings (
+    lawyer_id        UUID            PRIMARY KEY
+                                     REFERENCES lawyers(id) ON DELETE CASCADE,
+    embedding        vector(1024)    NOT NULL,
+    embedding_model  VARCHAR(64)     NOT NULL,
+    source_hash      VARCHAR(64)     NOT NULL,
+    source_text      TEXT,
+    created_at       TIMESTAMPTZ     NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ     NOT NULL DEFAULT now()
+);
+
+-- HNSW 인덱스 (legal_chunks 와 동일 파라미터)
+CREATE INDEX IF NOT EXISTS idx_lawyer_embeddings_hnsw
+    ON lawyer_embeddings
+    USING hnsw (embedding vector_cosine_ops)
+    WITH (m = 16, ef_construction = 64);
+
+-- source_hash 조회용 (재임베딩 판단 시 WHERE source_hash = ? 가능)
+CREATE INDEX IF NOT EXISTS idx_lawyer_embeddings_source_hash
+    ON lawyer_embeddings (source_hash);
+
+-- updated_at 자동 갱신 (V3 에서 이미 정의된 touch_updated_at() 재사용)
+CREATE TRIGGER trg_lawyer_embeddings_touch
+    BEFORE UPDATE ON lawyer_embeddings
+    FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+COMMENT ON TABLE lawyer_embeddings IS '변호사 프로필 임베딩 (Issue #50). 매칭 시 brief_embeddings 와 코사인 유사도 계산.';
+COMMENT ON COLUMN lawyer_embeddings.embedding IS 'Cohere embed-v4.0 (1024-dim) 문서 임베딩.';
+COMMENT ON COLUMN lawyer_embeddings.embedding_model IS '임베딩 생성 모델 ID. 모델 교체 시 재임베딩 판단용.';
+COMMENT ON COLUMN lawyer_embeddings.source_hash IS 'SHA-256 of LawyerEmbeddingTextBuilder 출력. 프로필 변경 시 재임베딩 판단용.';
+COMMENT ON COLUMN lawyer_embeddings.source_text IS '임베딩 입력 원문 (디버깅/감사). 옵션이며 용량 부담 시 후속 PR 에서 drop 고려.';

--- a/src/test/java/org/example/shield/brief/application/LawyerMatchingServiceTest.java
+++ b/src/test/java/org/example/shield/brief/application/LawyerMatchingServiceTest.java
@@ -7,6 +7,8 @@ import org.example.shield.brief.domain.Brief;
 import org.example.shield.brief.domain.BriefReader;
 import org.example.shield.brief.exception.BriefNotFoundException;
 import org.example.shield.common.enums.VerificationStatus;
+import org.example.shield.consultation.domain.Consultation;
+import org.example.shield.consultation.domain.ConsultationReader;
 import org.example.shield.common.response.PageResponse;
 import org.example.shield.lawyer.application.LawyerEmbeddingTextBuilder;
 import org.example.shield.lawyer.domain.LawyerProfile;
@@ -45,6 +47,7 @@ import static org.mockito.Mockito.when;
 class LawyerMatchingServiceTest {
 
     @Mock private BriefReader briefReader;
+    @Mock private ConsultationReader consultationReader;
     @Mock private LawyerReader lawyerReader;
     @Mock private UserReader userReader;
     @Mock private LawyerEmbeddingRepository lawyerEmbeddingRepository;
@@ -69,13 +72,23 @@ class LawyerMatchingServiceTest {
     }
 
     private Brief createBrief(UUID userId) throws Exception {
+        return createBrief(userId, true);
+    }
+
+    private Brief createBrief(UUID userId, boolean stubConsultation) throws Exception {
         Brief brief = Brief.create(
                 UUID.randomUUID(), userId, "title", "형사",
                 "사건 내용", List.of("사기", "횡령"), List.of(), "전략");
-        // id 강제 주입
         Field idField = findField(brief.getClass(), "id");
         idField.setAccessible(true);
         idField.set(brief, UUID.randomUUID());
+        if (stubConsultation) {
+            Consultation consultation = mock(Consultation.class);
+            when(consultation.getEffectiveDomains()).thenReturn(List.of());
+            when(consultation.getEffectiveSubDomains()).thenReturn(List.of());
+            when(consultation.getEffectiveTags()).thenReturn(List.of());
+            when(consultationReader.findById(brief.getConsultationId())).thenReturn(consultation);
+        }
         return brief;
     }
 
@@ -92,7 +105,7 @@ class LawyerMatchingServiceTest {
     void 브리프_소유자가_아니면_BriefNotFoundException() throws Exception {
         UUID ownerId = UUID.randomUUID();
         UUID otherId = UUID.randomUUID();
-        Brief brief = createBrief(ownerId);
+        Brief brief = createBrief(ownerId, false);
         UUID briefId = brief.getId();
         when(briefReader.findById(briefId)).thenReturn(brief);
 

--- a/src/test/java/org/example/shield/brief/application/LawyerMatchingServiceTest.java
+++ b/src/test/java/org/example/shield/brief/application/LawyerMatchingServiceTest.java
@@ -1,0 +1,185 @@
+package org.example.shield.brief.application;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.shield.ai.application.QueryEmbeddingService;
+import org.example.shield.brief.controller.dto.MatchingResponse;
+import org.example.shield.brief.domain.Brief;
+import org.example.shield.brief.domain.BriefReader;
+import org.example.shield.brief.exception.BriefNotFoundException;
+import org.example.shield.common.enums.VerificationStatus;
+import org.example.shield.common.response.PageResponse;
+import org.example.shield.lawyer.application.LawyerEmbeddingTextBuilder;
+import org.example.shield.lawyer.domain.LawyerProfile;
+import org.example.shield.lawyer.domain.LawyerReader;
+import org.example.shield.lawyer.infrastructure.LawyerEmbeddingRepository;
+import org.example.shield.lawyer.infrastructure.LawyerMatchProjection;
+import org.example.shield.user.domain.User;
+import org.example.shield.user.domain.UserReader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LawyerMatchingServiceTest {
+
+    @Mock private BriefReader briefReader;
+    @Mock private LawyerReader lawyerReader;
+    @Mock private UserReader userReader;
+    @Mock private LawyerEmbeddingRepository lawyerEmbeddingRepository;
+    @Mock private QueryEmbeddingService queryEmbeddingService;
+
+    private final LawyerEmbeddingTextBuilder embeddingTextBuilder = new LawyerEmbeddingTextBuilder();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private LawyerMatchingService service;
+
+    @BeforeEach
+    void injectRealBeans() throws Exception {
+        set(service, "embeddingTextBuilder", embeddingTextBuilder);
+        set(service, "objectMapper", objectMapper);
+    }
+
+    private void set(Object target, String field, Object value) throws Exception {
+        Field f = target.getClass().getDeclaredField(field);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    private Brief createBrief(UUID userId) throws Exception {
+        Brief brief = Brief.create(
+                UUID.randomUUID(), userId, "title", "형사",
+                "사건 내용", List.of("사기", "횡령"), List.of(), "전략");
+        // id 강제 주입
+        Field idField = findField(brief.getClass(), "id");
+        idField.setAccessible(true);
+        idField.set(brief, UUID.randomUUID());
+        return brief;
+    }
+
+    private Field findField(Class<?> clazz, String name) {
+        Class<?> c = clazz;
+        while (c != null) {
+            try { return c.getDeclaredField(name); }
+            catch (NoSuchFieldException e) { c = c.getSuperclass(); }
+        }
+        throw new IllegalStateException(name);
+    }
+
+    @Test
+    void 브리프_소유자가_아니면_BriefNotFoundException() throws Exception {
+        UUID ownerId = UUID.randomUUID();
+        UUID otherId = UUID.randomUUID();
+        Brief brief = createBrief(ownerId);
+        UUID briefId = brief.getId();
+        when(briefReader.findById(briefId)).thenReturn(brief);
+
+        assertThatThrownBy(() -> service.findMatching(briefId, otherId, PageRequest.of(0, 10)))
+                .isInstanceOf(BriefNotFoundException.class);
+    }
+
+    @Test
+    void 벡터_검색_정상경로_projection을_MatchingResponse로_매핑() throws Exception {
+        UUID userId = UUID.randomUUID();
+        Brief brief = createBrief(userId);
+        UUID briefId = brief.getId();
+        Pageable pageable = PageRequest.of(0, 5);
+
+        when(briefReader.findById(briefId)).thenReturn(brief);
+        when(queryEmbeddingService.embedQuery(anyString()))
+                .thenReturn(new float[]{0.1f, 0.2f});
+
+        UUID lawyerUserId = UUID.randomUUID();
+        LawyerMatchProjection proj = mock(LawyerMatchProjection.class);
+        when(proj.getUserId()).thenReturn(lawyerUserId);
+        when(proj.getDomains()).thenReturn("[\"형사\"]");
+        when(proj.getSubDomains()).thenReturn("[\"사기\"]");
+        when(proj.getTags()).thenReturn("[\"사기\",\"항소\"]");
+        when(proj.getBio()).thenReturn("소개");
+        when(proj.getExperienceYears()).thenReturn(7);
+        when(proj.getRegion()).thenReturn("서울");
+        when(proj.getSimilarity()).thenReturn(0.85);
+
+        when(lawyerEmbeddingRepository.findTopBySimilarity(anyString(), anyInt(), anyInt()))
+                .thenReturn(List.of(proj));
+        when(lawyerEmbeddingRepository.countVerifiedWithEmbedding()).thenReturn(1L);
+
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(lawyerUserId);
+        when(user.getName()).thenReturn("홍길동");
+        when(user.getProfileImageUrl()).thenReturn(null);
+        when(userReader.findAllByIds(anyList())).thenReturn(List.of(user));
+
+        PageResponse<MatchingResponse> response = service.findMatching(briefId, userId, pageable);
+
+        assertThat(response.content()).hasSize(1);
+        MatchingResponse r = response.content().get(0);
+        assertThat(r.lawyerId()).isEqualTo(lawyerUserId);
+        assertThat(r.name()).isEqualTo("홍길동");
+        assertThat(r.domains()).containsExactly("형사");
+        assertThat(r.tags()).containsExactly("사기", "항소");
+        assertThat(r.matchedKeywords()).containsExactly("사기"); // briefKeywords ∩ tags
+        assertThat(r.score()).isEqualTo(0.85);
+    }
+
+    @Test
+    void 쿼리_임베딩_실패시_키워드_fallback() throws Exception {
+        UUID userId = UUID.randomUUID();
+        Brief brief = createBrief(userId);
+        UUID briefId = brief.getId();
+        Pageable pageable = PageRequest.of(0, 5);
+
+        when(briefReader.findById(briefId)).thenReturn(brief);
+        when(queryEmbeddingService.embedQuery(anyString()))
+                .thenThrow(new RuntimeException("Cohere down"));
+
+        UUID lawyerUserId = UUID.randomUUID();
+        LawyerProfile lawyer = LawyerProfile.builder()
+                .userId(lawyerUserId)
+                .barAssociationNumber("123")
+                .domains(List.of("형사"))
+                .subDomains(List.of("사기"))
+                .tags(List.of("사기"))
+                .experienceYears(5)
+                .bio("소개")
+                .region("서울")
+                .build();
+        Page<LawyerProfile> page = new PageImpl<>(List.of(lawyer), pageable, 1);
+        when(lawyerReader.findAllByVerificationStatus(eq(VerificationStatus.VERIFIED), any(Pageable.class)))
+                .thenReturn(page);
+
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(lawyerUserId);
+        when(user.getName()).thenReturn("이몽룡");
+        when(userReader.findAllByIds(anyList())).thenReturn(List.of(user));
+
+        PageResponse<MatchingResponse> response = service.findMatching(briefId, userId, pageable);
+
+        assertThat(response.content()).hasSize(1);
+        // 키워드 2개 중 1개 매치
+        assertThat(response.content().get(0).score()).isEqualTo(0.5);
+        verify(queryEmbeddingService).embedQuery(anyString());
+    }
+}

--- a/src/test/java/org/example/shield/lawyer/application/LawyerEmbeddingServiceTest.java
+++ b/src/test/java/org/example/shield/lawyer/application/LawyerEmbeddingServiceTest.java
@@ -1,0 +1,189 @@
+package org.example.shield.lawyer.application;
+
+import org.example.shield.ai.config.CohereApiConfig;
+import org.example.shield.ai.infrastructure.CohereClient;
+import org.example.shield.lawyer.domain.LawyerEmbedding;
+import org.example.shield.lawyer.domain.LawyerProfile;
+import org.example.shield.lawyer.infrastructure.LawyerEmbeddingRepository;
+import org.example.shield.lawyer.infrastructure.LawyerProfileRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LawyerEmbeddingServiceTest {
+
+    @Mock
+    private LawyerProfileRepository lawyerProfileRepository;
+
+    @Mock
+    private LawyerEmbeddingRepository lawyerEmbeddingRepository;
+
+    @Mock
+    private CohereClient cohereClient;
+
+    @Mock
+    private CohereApiConfig cohereConfig;
+
+    private final LawyerEmbeddingTextBuilder textBuilder = new LawyerEmbeddingTextBuilder();
+
+    @InjectMocks
+    private LawyerEmbeddingService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // textBuilder 는 실제 구현 주입 (@InjectMocks 가 Mock 만 주입해서 수동 설정)
+        Field f = LawyerEmbeddingService.class.getDeclaredField("textBuilder");
+        f.setAccessible(true);
+        f.set(service, textBuilder);
+    }
+
+    private LawyerProfile createProfile(UUID lawyerId) throws Exception {
+        LawyerProfile profile = LawyerProfile.builder()
+                .userId(UUID.randomUUID())
+                .barAssociationNumber("123")
+                .domains(List.of("형사"))
+                .subDomains(List.of("사기"))
+                .tags(List.of("변호"))
+                .experienceYears(10)
+                .bio("소개")
+                .region("서울")
+                .build();
+        // BaseEntity.id 강제 주입 (protected)
+        Field idField = findField(profile.getClass(), "id");
+        idField.setAccessible(true);
+        idField.set(profile, lawyerId);
+        return profile;
+    }
+
+    private Field findField(Class<?> clazz, String name) {
+        Class<?> c = clazz;
+        while (c != null) {
+            try {
+                return c.getDeclaredField(name);
+            } catch (NoSuchFieldException e) {
+                c = c.getSuperclass();
+            }
+        }
+        throw new IllegalStateException("field not found: " + name);
+    }
+
+    @Test
+    void 신규_임베딩은_Cohere_호출하고_save() throws Exception {
+        UUID lawyerId = UUID.randomUUID();
+        LawyerProfile profile = createProfile(lawyerId);
+
+        when(cohereConfig.getEmbedModel()).thenReturn("embed-v4.0");
+        when(lawyerEmbeddingRepository.findById(lawyerId)).thenReturn(Optional.empty());
+        when(cohereClient.embedDocuments(anyString(), anyList()))
+                .thenReturn(List.of(new float[]{0.1f, 0.2f}));
+
+        service.upsertEmbedding(profile);
+
+        ArgumentCaptor<LawyerEmbedding> cap = ArgumentCaptor.forClass(LawyerEmbedding.class);
+        verify(lawyerEmbeddingRepository, times(1)).save(cap.capture());
+        LawyerEmbedding saved = cap.getValue();
+        assertThat(saved.getLawyerId()).isEqualTo(lawyerId);
+        assertThat(saved.getEmbeddingModel()).isEqualTo("embed-v4.0");
+        assertThat(saved.getSourceHash()).hasSize(64); // SHA-256 hex
+        assertThat(saved.getEmbedding()).containsExactly(0.1f, 0.2f);
+    }
+
+    @Test
+    void 동일_해시는_Cohere_재호출_없이_skip() throws Exception {
+        UUID lawyerId = UUID.randomUUID();
+        LawyerProfile profile = createProfile(lawyerId);
+
+        when(cohereConfig.getEmbedModel()).thenReturn("embed-v4.0");
+
+        // 기존 임베딩 엔티티: 동일 텍스트 해시 + 모델
+        String expectedText = textBuilder.build(
+                profile.getDomains(), profile.getSubDomains(),
+                profile.getTags(), profile.getBio());
+        String expectedHash = sha256(expectedText);
+
+        LawyerEmbedding existing = LawyerEmbedding.create(
+                lawyerId, new float[]{0.9f}, "embed-v4.0", expectedHash, expectedText);
+        when(lawyerEmbeddingRepository.findById(lawyerId)).thenReturn(Optional.of(existing));
+
+        service.upsertEmbedding(profile);
+
+        verify(cohereClient, never()).embedDocuments(anyString(), anyList());
+        verify(lawyerEmbeddingRepository, never()).save(any());
+    }
+
+    @Test
+    void 해시_다르면_updateEmbedding_호출() throws Exception {
+        UUID lawyerId = UUID.randomUUID();
+        LawyerProfile profile = createProfile(lawyerId);
+
+        when(cohereConfig.getEmbedModel()).thenReturn("embed-v4.0");
+
+        LawyerEmbedding existing = LawyerEmbedding.create(
+                lawyerId, new float[]{0.0f}, "embed-v4.0", "old-hash", "old-text");
+        when(lawyerEmbeddingRepository.findById(lawyerId)).thenReturn(Optional.of(existing));
+        when(cohereClient.embedDocuments(anyString(), anyList()))
+                .thenReturn(List.of(new float[]{0.5f, 0.6f}));
+
+        service.upsertEmbedding(profile);
+
+        assertThat(existing.getEmbedding()).containsExactly(0.5f, 0.6f);
+        assertThat(existing.getSourceHash()).isNotEqualTo("old-hash");
+        verify(lawyerEmbeddingRepository, never()).save(any()); // dirty checking, save 불필요
+    }
+
+    @Test
+    void 빈_텍스트는_skip() throws Exception {
+        UUID lawyerId = UUID.randomUUID();
+        LawyerProfile profile = LawyerProfile.builder()
+                .userId(UUID.randomUUID())
+                .barAssociationNumber("123")
+                .build();
+        Field idField = findField(profile.getClass(), "id");
+        idField.setAccessible(true);
+        idField.set(profile, lawyerId);
+
+        service.upsertEmbedding(profile);
+
+        verify(cohereClient, never()).embedDocuments(anyString(), anyList());
+        verify(lawyerEmbeddingRepository, never()).save(any());
+    }
+
+    @Test
+    void UUID_오버로드는_프로필_없으면_skip() {
+        UUID lawyerId = UUID.randomUUID();
+        when(lawyerProfileRepository.findById(lawyerId)).thenReturn(Optional.empty());
+
+        service.upsertEmbedding(lawyerId);
+
+        verify(cohereClient, never()).embedDocuments(anyString(), anyList());
+    }
+
+    private String sha256(String text) {
+        try {
+            java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(text.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            return java.util.HexFormat.of().formatHex(digest);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/org/example/shield/lawyer/application/LawyerEmbeddingTextBuilderTest.java
+++ b/src/test/java/org/example/shield/lawyer/application/LawyerEmbeddingTextBuilderTest.java
@@ -1,0 +1,116 @@
+package org.example.shield.lawyer.application;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LawyerEmbeddingTextBuilderTest {
+
+    private final LawyerEmbeddingTextBuilder builder = new LawyerEmbeddingTextBuilder();
+
+    @Test
+    void 모든_섹션이_있으면_템플릿대로_조립한다() {
+        String text = builder.build(
+                List.of("형사", "민사"),
+                List.of("사기", "횡령"),
+                List.of("변호", "항소"),
+                "10년 경력의 형사 전문 변호사");
+
+        assertThat(text).contains("[전문 분야]");
+        assertThat(text).contains("[세부 분야]");
+        assertThat(text).contains("[태그]");
+        assertThat(text).contains("[자기소개]");
+        assertThat(text).contains("10년 경력의 형사 전문 변호사");
+    }
+
+    @Test
+    void domains는_3회_반복된다() {
+        String text = builder.build(
+                List.of("형사"),
+                List.of(),
+                List.of(),
+                null);
+
+        // "형사" 가 3번 나타나야 함
+        int count = text.split("형사", -1).length - 1;
+        assertThat(count).isEqualTo(3);
+    }
+
+    @Test
+    void subDomains는_2회_반복된다() {
+        String text = builder.build(
+                List.of(),
+                List.of("사기"),
+                List.of(),
+                null);
+
+        int count = text.split("사기", -1).length - 1;
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    void tags는_1회만_나타난다() {
+        String text = builder.build(
+                List.of(),
+                List.of(),
+                List.of("변호"),
+                null);
+
+        int count = text.split("변호", -1).length - 1;
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void 빈_섹션은_건너뛴다() {
+        String text = builder.build(
+                null,
+                List.of(),
+                List.of("변호"),
+                null);
+
+        assertThat(text).doesNotContain("[전문 분야]");
+        assertThat(text).doesNotContain("[세부 분야]");
+        assertThat(text).doesNotContain("[자기소개]");
+        assertThat(text).contains("[태그]");
+    }
+
+    @Test
+    void 모두_비면_빈_문자열() {
+        String text = builder.build(null, null, null, null);
+        assertThat(text).isEmpty();
+    }
+
+    @Test
+    void bio_만_있어도_섹션이_조립된다() {
+        String text = builder.build(null, null, null, "자기소개 본문");
+        assertThat(text).isEqualTo("[자기소개]\n자기소개 본문");
+    }
+
+    @Test
+    void blank_요소는_필터링된다() {
+        String text = builder.build(
+                List.of("형사", "  ", ""),
+                List.of(),
+                List.of(),
+                null);
+
+        // 빈/공백 요소가 걸러져서 "형사" 만 남고 3회 반복
+        int count = text.split("형사", -1).length - 1;
+        assertThat(count).isEqualTo(3);
+    }
+
+    @Test
+    void 문서와_쿼리_동일_입력에_대해_동일_출력을_보장한다() {
+        List<String> domains = List.of("형사");
+        List<String> subDomains = List.of("사기");
+        List<String> tags = List.of("변호");
+        String bio = "소개";
+
+        String docText = builder.build(domains, subDomains, tags, bio);
+        String queryText = builder.build(domains, subDomains, tags, bio);
+
+        assertThat(docText).isEqualTo(queryText);
+    }
+}


### PR DESCRIPTION
## 요약
Cohere `embed-v4.0` (1024-dim) + Postgres pgvector (HNSW) 기반 변호사 매칭.
상담의 대/중/소분류(`user*` 우선, 없으면 `ai*`)를 그대로 쿼리 벡터 조립에 사용.

## 주요 변경
### 인프라
- V8 마이그레이션: `lawyer_embeddings` (vector(1024), HNSW m=16 ef_construction=64)
- `LawyerEmbedding` 엔티티 + Repository (코사인 Native Query + projection)

### 임베딩 파이프라인
- `LawyerEmbeddingTextBuilder`: 문서·쿼리 공통 템플릿 (domains x3 / subDomains x2 / tags x1 / bio)
- `LawyerEmbeddingService`: SHA-256 hash skip 으로 재계산 방지
- 이벤트 훅: `AdminService.processVerification` (VERIFIED 전환), `LawyerService.updateMyProfile` (프로필 수정)
- 백필 러너: `--backfill=lawyer-embeddings` (ingest 프로파일)

### 매칭 API
- `GET /api/briefs/{briefId}/lawyer-recommendations?page&size`
- 쿼리 조립: **Consultation** 3-tier 분류 (`getEffectiveDomains/SubDomains/Tags`) 우선, 없으면 `Brief.legalField` 폴백
- 응답: Notion 명세와 100% 일치 (`MatchingResponse` 필드 11개)
- Cohere / 벡터 검색 실패 시 키워드 fallback

## 매칭 품질 검증
시뮬레이션 (Cohere 실호출):

| 순위 | 변호사 | 점수 |
|------|--------|------|
| 1 | 부동산 임대차 (완전 일치) | 0.7252 |
| 2 | 부동산 매매 (대분류만 일치) | 0.4939 |
| 3 | 민사 손해배상 (완전 불일치) | 0.3362 |

중분류 일치만으로 +0.23 상승 확인.

## 테스트
- 단위 테스트 17개 (TextBuilder, Service, MatchingService) 전부 통과
- 전체 회귀 테스트 BUILD SUCCESSFUL

## 실운영 검증
박서연 변호사 (민사/손해배상) 임베딩 실제 수행 완료 — 셀프 코사인 = 1.0 확인.

Closes #50