### PR TITLE
[CHORE] Jenkins 배포 롤백 기능 추가 (Issue #58)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,27 @@ pipeline {
 
         stage('Deploy') {
             steps {
+                // 백업 디렉토리 준비
+                sh "sudo mkdir -p ${DEPLOY_DIR}/backup"
+
+                // 기존 jar 백업 (첫 배포면 스킵)
+                sh """
+                    if [ -f ${DEPLOY_DIR}/${JAR_NAME} ]; then
+                        TS=\$(date +%Y%m%d-%H%M%S)
+                        sudo cp ${DEPLOY_DIR}/${JAR_NAME} ${DEPLOY_DIR}/backup/shield-\${TS}.jar
+                        echo "Backup created: shield-\${TS}.jar"
+                    else
+                        echo "No existing jar to backup (first deploy)"
+                    fi
+                """
+
+                // 최근 5개만 유지 (오래된 백업 삭제)
+                sh """
+                    cd ${DEPLOY_DIR}/backup
+                    sudo ls -t shield-*.jar 2>/dev/null | tail -n +6 | xargs -r sudo rm -v || true
+                """
+
+                // 새 jar 배포
                 sh "sudo cp build/libs/shield-*.jar ${DEPLOY_DIR}/${JAR_NAME}"
                 sh 'sudo systemctl restart shield-backend'
             }

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# SHIELD 백엔드 롤백 스크립트
+# 사용법: sudo bash /home/ec2-user/shield/rollback.sh
+
+set -e
+
+DEPLOY_DIR=/home/ec2-user/shield
+BACKUP_DIR=${DEPLOY_DIR}/backup
+JAR=${DEPLOY_DIR}/shield.jar
+
+if [ ! -d "${BACKUP_DIR}" ] || [ -z "$(ls -A ${BACKUP_DIR} 2>/dev/null)" ]; then
+    echo "❌ 백업 파일이 없습니다: ${BACKUP_DIR}"
+    echo "   최소 1회 이상 배포가 진행된 후에만 롤백 가능합니다."
+    exit 1
+fi
+
+echo "=========================================="
+echo "  SHIELD 롤백 스크립트"
+echo "=========================================="
+echo ""
+echo "사용 가능한 백업 목록 (최신순):"
+echo ""
+ls -lt ${BACKUP_DIR}/shield-*.jar | awk '{print "  "$9"  ("$6" "$7" "$8")"}'
+echo ""
+read -p "복원할 파일명 (예: shield-20260423-140000.jar): " TARGET
+
+if [ -z "${TARGET}" ]; then
+    echo "❌ 파일명이 비어있습니다"
+    exit 1
+fi
+
+if [ ! -f "${BACKUP_DIR}/${TARGET}" ]; then
+    echo "❌ 파일을 찾을 수 없음: ${BACKUP_DIR}/${TARGET}"
+    exit 1
+fi
+
+echo ""
+echo "롤백 준비:"
+echo "  - 대상: ${BACKUP_DIR}/${TARGET}"
+echo "  - 적용: ${JAR}"
+echo ""
+read -p "진행하시겠습니까? (y/N): " CONFIRM
+
+if [ "${CONFIRM}" != "y" ] && [ "${CONFIRM}" != "Y" ]; then
+    echo "취소되었습니다"
+    exit 0
+fi
+
+# 현재 운영 jar도 한 번 더 백업 (롤백의 롤백 대비)
+CURRENT_TS=$(date +%Y%m%d-%H%M%S)
+sudo cp "${JAR}" "${BACKUP_DIR}/shield-${CURRENT_TS}-before-rollback.jar"
+echo "✓ 현재 jar를 ${BACKUP_DIR}/shield-${CURRENT_TS}-before-rollback.jar 로 백업"
+
+# 롤백 수행
+sudo cp "${BACKUP_DIR}/${TARGET}" "${JAR}"
+sudo systemctl restart shield-backend
+echo "✓ 서비스 재시작 중..."
+
+sleep 15
+
+# 헬스체크
+if curl -sf http://localhost:8080/actuator/health > /dev/null; then
+    echo ""
+    echo "✅ 롤백 성공: ${TARGET}"
+    sudo systemctl status shield-backend --no-pager | head -3
+else
+    echo ""
+    echo "❌ 헬스체크 실패 - 로그 확인 필요"
+    echo "   sudo journalctl -u shield-backend -n 50 --no-pager"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Closes #58

- Jenkinsfile 배포 단계에 기존 jar 자동 백업 추가 (최근 5개 유지)
- `scripts/rollback.sh` 신규 추가 - 백업 목록에서 선택하여 1분 내 복구

## 변경 내용

### Jenkinsfile
- 배포 직전 `shield.jar` 를 `/home/ec2-user/shield/backup/shield-YYYYMMDD-HHMMSS.jar` 로 복사
- 첫 배포면 기존 jar 없으므로 스킵
- 백업 5개 초과 시 오래된 것부터 삭제

### scripts/rollback.sh
- 백업 목록 출력 → 파일명 입력 → 확인 → 복구 → 서비스 재시작 → 헬스체크
- 롤백 직전의 현재 jar 도 자동 재백업 (롤백의 롤백 대비)

## Test Plan

- [ ] Jenkins 빌드 성공 확인
- [ ] 첫 배포 후 EC2 `/home/ec2-user/shield/backup/` 디렉토리 생성 확인
- [ ] 2회 이상 배포 후 백업 파일 누적 확인
- [ ] `scripts/rollback.sh` 를 EC2에 설치 후 실행 테스트

## 효과

- 긴급 롤백 시간: 2~3분 (git revert + 재빌드) → **1분 이내**
- 배포 이력 보존 (최근 5개 버전)