### PR TITLE
[FIX] 변호사 프로필 PATCH 시 null 필드 덮어쓰기 방지 (Issue #61)

### DIFF
--- a/src/main/java/org/example/shield/lawyer/domain/LawyerProfile.java
+++ b/src/main/java/org/example/shield/lawyer/domain/LawyerProfile.java
@@ -83,16 +83,20 @@ public class LawyerProfile extends BaseEntity {
         this.caseCount = 0;
     }
 
+    /**
+     * 부분 업데이트 (PATCH semantics). null 인 필드는 기존 값을 유지한다.
+     * 명시적 초기화가 필요하면 빈 컬렉션 또는 빈 문자열을 전달해야 한다.
+     */
     public void updateProfile(List<String> domains, List<String> subDomains,
                               Integer experienceYears, List<String> certifications,
                               List<String> tags, String bio, String region) {
-        this.domains = domains;
-        this.subDomains = subDomains;
-        this.experienceYears = experienceYears;
-        this.certifications = certifications;
-        this.tags = tags;
-        this.bio = bio;
-        this.region = region;
+        if (domains != null) this.domains = domains;
+        if (subDomains != null) this.subDomains = subDomains;
+        if (experienceYears != null) this.experienceYears = experienceYears;
+        if (certifications != null) this.certifications = certifications;
+        if (tags != null) this.tags = tags;
+        if (bio != null) this.bio = bio;
+        if (region != null) this.region = region;
     }
 
     public void requestVerification(String barAssociationNumber) {

--- a/src/test/java/org/example/shield/lawyer/domain/LawyerProfileUpdateProfileTest.java
+++ b/src/test/java/org/example/shield/lawyer/domain/LawyerProfileUpdateProfileTest.java
@@ -1,0 +1,104 @@
+package org.example.shield.lawyer.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #61 — LawyerProfile.updateProfile 의 부분 업데이트 (null 유지) 동작 검증.
+ */
+class LawyerProfileUpdateProfileTest {
+
+    private LawyerProfile newProfile() {
+        return LawyerProfile.builder()
+                .userId(UUID.randomUUID())
+                .barAssociationNumber("KBA-2020-12345")
+                .domains(List.of("임대차보호"))
+                .subDomains(List.of("주택임대차보호"))
+                .experienceYears(8)
+                .tags(List.of("보증금 반환"))
+                .bio("서울대 법학전문대학원 졸업")
+                .certifications(List.of("변호사"))
+                .region("서울")
+                .build();
+    }
+
+    @Test
+    @DisplayName("bio 만 전달하면 experienceYears 는 기존 값이 유지된다")
+    void partialUpdate_keepExperienceYears_whenOnlyBioProvided() {
+        LawyerProfile profile = newProfile();
+
+        profile.updateProfile(null, null, null, null, null, "새 자기소개", null);
+
+        assertThat(profile.getBio()).isEqualTo("새 자기소개");
+        assertThat(profile.getExperienceYears()).isEqualTo(8);
+        assertThat(profile.getRegion()).isEqualTo("서울");
+        assertThat(profile.getDomains()).containsExactly("임대차보호");
+    }
+
+    @Test
+    @DisplayName("experienceYears 만 전달하면 bio 는 기존 값이 유지된다")
+    void partialUpdate_keepBio_whenOnlyExperienceYearsProvided() {
+        LawyerProfile profile = newProfile();
+
+        profile.updateProfile(null, null, 10, null, null, null, null);
+
+        assertThat(profile.getExperienceYears()).isEqualTo(10);
+        assertThat(profile.getBio()).isEqualTo("서울대 법학전문대학원 졸업");
+    }
+
+    @Test
+    @DisplayName("모든 필드를 전달하면 전체가 갱신된다")
+    void fullUpdate_overridesAllFields() {
+        LawyerProfile profile = newProfile();
+
+        profile.updateProfile(
+                List.of("이혼·위자료·재산분할"),
+                List.of("협의이혼"),
+                15,
+                List.of("변호사", "세무사"),
+                List.of("재산분할"),
+                "갱신된 소개",
+                "경기 성남"
+        );
+
+        assertThat(profile.getDomains()).containsExactly("이혼·위자료·재산분할");
+        assertThat(profile.getSubDomains()).containsExactly("협의이혼");
+        assertThat(profile.getExperienceYears()).isEqualTo(15);
+        assertThat(profile.getCertifications()).containsExactly("변호사", "세무사");
+        assertThat(profile.getTags()).containsExactly("재산분할");
+        assertThat(profile.getBio()).isEqualTo("갱신된 소개");
+        assertThat(profile.getRegion()).isEqualTo("경기 성남");
+    }
+
+    @Test
+    @DisplayName("모든 인자가 null 이면 아무 필드도 변경되지 않는다")
+    void noUpdate_whenAllArgsAreNull() {
+        LawyerProfile profile = newProfile();
+
+        profile.updateProfile(null, null, null, null, null, null, null);
+
+        assertThat(profile.getDomains()).containsExactly("임대차보호");
+        assertThat(profile.getSubDomains()).containsExactly("주택임대차보호");
+        assertThat(profile.getExperienceYears()).isEqualTo(8);
+        assertThat(profile.getCertifications()).containsExactly("변호사");
+        assertThat(profile.getTags()).containsExactly("보증금 반환");
+        assertThat(profile.getBio()).isEqualTo("서울대 법학전문대학원 졸업");
+        assertThat(profile.getRegion()).isEqualTo("서울");
+    }
+
+    @Test
+    @DisplayName("빈 리스트를 전달하면 명시적 초기화로 적용된다 (null 과 구분)")
+    void partialUpdate_emptyListIsExplicitReset() {
+        LawyerProfile profile = newProfile();
+
+        profile.updateProfile(null, null, null, List.of(), null, null, null);
+
+        assertThat(profile.getCertifications()).isEmpty();
+        assertThat(profile.getDomains()).containsExactly("임대차보호"); // null 인 필드는 그대로
+    }
+}


### PR DESCRIPTION
## Summary

Closes #61

변호사 프로필 수정 API 호출 시 일부 필드만 보내면 나머지가 null 로 덮어써지던 문제를 수정.

## 변경 내용

### `LawyerProfile.updateProfile()`
- 전달된 인자가 `null` 이면 기존 값 유지 (PATCH semantics)
- `null` 이 아닌 필드만 교체
- 빈 컬렉션/빈 문자열은 명시적 초기화로 동작

```java
// Before (버그)
this.experienceYears = experienceYears;  // null 오면 기존 값 파괴

// After
if (experienceYears != null) this.experienceYears = experienceYears;
```

### 테스트 추가
`LawyerProfileUpdateProfileTest` 5 건:
1. bio 만 전달 → experienceYears 유지
2. experienceYears 만 전달 → bio 유지
3. 전체 전달 → 전체 갱신
4. 모두 null → 변경 없음
5. 빈 리스트 → 명시적 초기화로 적용

## Test Plan

- [x] 단위 테스트 5건 추가
- [ ] Jenkins 빌드 & 테스트 통과
- [ ] 실제 배포 환경에서 프로필 수정 → 경력/소개 반영 확인