### PR TITLE
feat: Brief 응답에 수락 변호사 정보 + 중복 수락 차단 (#68)

### DIFF
--- a/src/main/java/org/example/shield/brief/application/BriefService.java
+++ b/src/main/java/org/example/shield/brief/application/BriefService.java
@@ -6,11 +6,14 @@ import org.example.shield.brief.controller.dto.BriefSummaryResponse;
 import org.example.shield.brief.controller.dto.BriefUpdateRequest;
 import org.example.shield.brief.controller.dto.BriefUpdateResponse;
 import org.example.shield.brief.domain.Brief;
+import org.example.shield.brief.domain.BriefDelivery;
+import org.example.shield.brief.domain.BriefDeliveryReader;
 import org.example.shield.brief.domain.BriefReader;
 import org.example.shield.brief.domain.BriefWriter;
 import org.example.shield.brief.exception.BriefAlreadyConfirmedException;
 import org.example.shield.common.enums.BriefStatus;
 import org.example.shield.common.enums.ConsultationStatus;
+import org.example.shield.common.enums.DeliveryStatus;
 import org.example.shield.common.enums.PrivacySetting;
 import org.example.shield.common.exception.BusinessException;
 import org.example.shield.common.exception.ErrorCode;
@@ -18,12 +21,19 @@ import org.example.shield.common.response.PageResponse;
 import org.example.shield.consultation.domain.Consultation;
 import org.example.shield.consultation.domain.ConsultationReader;
 import org.example.shield.consultation.domain.ConsultationWriter;
+import org.example.shield.user.domain.User;
+import org.example.shield.user.domain.UserReader;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +42,8 @@ public class BriefService {
 
     private final BriefReader briefReader;
     private final BriefWriter briefWriter;
+    private final BriefDeliveryReader deliveryReader;
+    private final UserReader userReader;
     private final ConsultationReader consultationReader;
     private final ConsultationWriter consultationWriter;
 
@@ -43,14 +55,30 @@ public class BriefService {
         } else {
             briefs = briefReader.findAllByUserId(userId, pageable);
         }
-        Page<BriefSummaryResponse> responsePage = briefs.map(BriefSummaryResponse::from);
+
+        // N+1 방지: 페이지의 brief 들에 대한 수락된 delivery 를 한 번에 조회
+        List<UUID> briefIds = briefs.getContent().stream().map(Brief::getId).toList();
+        Map<UUID, BriefDelivery> acceptedByBriefId = fetchAcceptedDeliveries(briefIds);
+        Map<UUID, String> lawyerNameById = fetchLawyerNames(acceptedByBriefId.values());
+
+        Page<BriefSummaryResponse> responsePage = briefs.map(b -> {
+            BriefDelivery accepted = acceptedByBriefId.get(b.getId());
+            String lawyerName = accepted != null ? lawyerNameById.get(accepted.getLawyerId()) : null;
+            return BriefSummaryResponse.of(b, accepted, lawyerName);
+        });
         return PageResponse.from(responsePage);
     }
 
     public BriefResponse getBrief(UUID briefId, UUID userId) {
         Brief brief = briefReader.findById(briefId);
         validateOwner(brief, userId);
-        return BriefResponse.from(brief);
+
+        BriefDelivery accepted = pickAcceptedDelivery(briefId);
+        String lawyerName = accepted != null
+                ? userReader.findById(accepted.getLawyerId()).getName()
+                : null;
+
+        return BriefResponse.of(brief, accepted, lawyerName);
     }
 
     @Transactional
@@ -107,5 +135,43 @@ public class BriefService {
         if (!brief.getUserId().equals(userId)) {
             throw new org.example.shield.brief.exception.BriefNotFoundException(brief.getId());
         }
+    }
+
+    /**
+     * 단건 조회용: brief 의 CONFIRMED delivery 중 가장 먼저 수락된 1건.
+     * 가드 도입 후에는 최대 1건만 존재해야 하나 기존 데이터 호환을 위해 안전망으로 정렬 후 선택.
+     */
+    private BriefDelivery pickAcceptedDelivery(UUID briefId) {
+        return deliveryReader.findAllByBriefId(briefId).stream()
+                .filter(d -> d.getStatus() == DeliveryStatus.CONFIRMED)
+                .min(Comparator.comparing(
+                        BriefDelivery::getRespondedAt,
+                        Comparator.nullsLast(Comparator.naturalOrder())))
+                .orElse(null);
+    }
+
+    /**
+     * 목록 조회용 배치: briefId → 가장 먼저 수락된 delivery 매핑.
+     */
+    private Map<UUID, BriefDelivery> fetchAcceptedDeliveries(List<UUID> briefIds) {
+        if (briefIds.isEmpty()) return Map.of();
+        return deliveryReader.findAllByBriefIdInAndStatus(briefIds, DeliveryStatus.CONFIRMED).stream()
+                .collect(Collectors.toMap(
+                        BriefDelivery::getBriefId,
+                        Function.identity(),
+                        (a, b) -> {
+                            // 안전망: 동일 brief 에 CONFIRMED 가 여러 건 있을 경우 가장 이른 수락자 선택
+                            if (a.getRespondedAt() == null) return b;
+                            if (b.getRespondedAt() == null) return a;
+                            return a.getRespondedAt().isBefore(b.getRespondedAt()) ? a : b;
+                        }
+                ));
+    }
+
+    private Map<UUID, String> fetchLawyerNames(java.util.Collection<BriefDelivery> deliveries) {
+        if (deliveries.isEmpty()) return Map.of();
+        List<UUID> lawyerIds = deliveries.stream().map(BriefDelivery::getLawyerId).toList();
+        return userReader.findAllByIds(lawyerIds).stream()
+                .collect(Collectors.toMap(User::getId, User::getName));
     }
 }

--- a/src/main/java/org/example/shield/brief/application/DeliveryService.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryService.java
@@ -65,6 +65,13 @@ public class DeliveryService {
             throw new BusinessException(ErrorCode.DELIVERY_ALREADY_PROCESSED) {};
         }
 
+        // 이미 다른 변호사가 수락한 의뢰서는 추가 수락 차단.
+        // 변호사 1인 선임 원칙 + 목록/상세 derived 필드의 유일성 보장용.
+        if (status == DeliveryStatus.CONFIRMED
+                && deliveryReader.existsByBriefIdAndStatus(delivery.getBriefId(), DeliveryStatus.CONFIRMED)) {
+            throw new BusinessException(ErrorCode.BRIEF_ALREADY_ACCEPTED) {};
+        }
+
         switch (status) {
             case CONFIRMED -> delivery.accept();
             case REJECTED -> {

--- a/src/main/java/org/example/shield/brief/controller/dto/BriefResponse.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/BriefResponse.java
@@ -1,6 +1,7 @@
 package org.example.shield.brief.controller.dto;
 
 import org.example.shield.brief.domain.Brief;
+import org.example.shield.brief.domain.BriefDelivery;
 import org.example.shield.brief.domain.KeyIssue;
 
 import java.time.LocalDateTime;
@@ -17,9 +18,19 @@ public record BriefResponse(
         String strategy,
         String privacySetting,
         String status,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        UUID acceptedLawyerId,
+        String acceptedLawyerName,
+        LocalDateTime acceptedAt
 ) {
     public static BriefResponse from(Brief brief) {
+        return of(brief, null, null);
+    }
+
+    /**
+     * acceptedDelivery 와 lawyerName 이 null 이면 수락된 변호사 없음.
+     */
+    public static BriefResponse of(Brief brief, BriefDelivery acceptedDelivery, String lawyerName) {
         return new BriefResponse(
                 brief.getId(),
                 brief.getTitle(),
@@ -30,7 +41,10 @@ public record BriefResponse(
                 brief.getStrategy(),
                 brief.getPrivacySetting().name(),
                 brief.getStatus().name(),
-                brief.getCreatedAt()
+                brief.getCreatedAt(),
+                acceptedDelivery != null ? acceptedDelivery.getLawyerId() : null,
+                lawyerName,
+                acceptedDelivery != null ? acceptedDelivery.getRespondedAt() : null
         );
     }
 }

--- a/src/main/java/org/example/shield/brief/controller/dto/BriefSummaryResponse.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/BriefSummaryResponse.java
@@ -1,6 +1,7 @@
 package org.example.shield.brief.controller.dto;
 
 import org.example.shield.brief.domain.Brief;
+import org.example.shield.brief.domain.BriefDelivery;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -9,14 +10,24 @@ public record BriefSummaryResponse(
         UUID briefId,
         String title,
         String status,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        UUID acceptedLawyerId,
+        String acceptedLawyerName,
+        LocalDateTime acceptedAt
 ) {
     public static BriefSummaryResponse from(Brief brief) {
+        return of(brief, null, null);
+    }
+
+    public static BriefSummaryResponse of(Brief brief, BriefDelivery acceptedDelivery, String lawyerName) {
         return new BriefSummaryResponse(
                 brief.getId(),
                 brief.getTitle(),
                 brief.getStatus().name(),
-                brief.getCreatedAt()
+                brief.getCreatedAt(),
+                acceptedDelivery != null ? acceptedDelivery.getLawyerId() : null,
+                lawyerName,
+                acceptedDelivery != null ? acceptedDelivery.getRespondedAt() : null
         );
     }
 }

--- a/src/main/java/org/example/shield/brief/domain/BriefDeliveryReader.java
+++ b/src/main/java/org/example/shield/brief/domain/BriefDeliveryReader.java
@@ -14,5 +14,7 @@ public interface BriefDeliveryReader {
     Page<BriefDelivery> findAllByLawyerId(UUID lawyerId, Pageable pageable);
     Page<BriefDelivery> findAllByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status, Pageable pageable);
     boolean existsByBriefIdAndLawyerId(UUID briefId, UUID lawyerId);
+    boolean existsByBriefIdAndStatus(UUID briefId, DeliveryStatus status);
+    List<BriefDelivery> findAllByBriefIdInAndStatus(List<UUID> briefIds, DeliveryStatus status);
     Map<DeliveryStatus, Long> countGroupByStatus(UUID lawyerId);
 }

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryReaderImpl.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryReaderImpl.java
@@ -48,6 +48,17 @@ public class BriefDeliveryReaderImpl implements BriefDeliveryReader {
     }
 
     @Override
+    public boolean existsByBriefIdAndStatus(UUID briefId, DeliveryStatus status) {
+        return briefDeliveryRepository.existsByBriefIdAndStatus(briefId, status);
+    }
+
+    @Override
+    public List<BriefDelivery> findAllByBriefIdInAndStatus(List<UUID> briefIds, DeliveryStatus status) {
+        if (briefIds == null || briefIds.isEmpty()) return List.of();
+        return briefDeliveryRepository.findAllByBriefIdInAndStatus(briefIds, status);
+    }
+
+    @Override
     public Map<DeliveryStatus, Long> countGroupByStatus(UUID lawyerId) {
         return briefDeliveryRepository.countGroupByStatus(lawyerId).stream()
                 .collect(Collectors.toMap(

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryRepository.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryRepository.java
@@ -15,6 +15,8 @@ public interface BriefDeliveryRepository extends JpaRepository<BriefDelivery, UU
     Page<BriefDelivery> findAllByLawyerId(UUID lawyerId, Pageable pageable);
     Page<BriefDelivery> findAllByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status, Pageable pageable);
     boolean existsByBriefIdAndLawyerId(UUID briefId, UUID lawyerId);
+    boolean existsByBriefIdAndStatus(UUID briefId, DeliveryStatus status);
+    List<BriefDelivery> findAllByBriefIdInAndStatus(List<UUID> briefIds, DeliveryStatus status);
 
     @Query("SELECT d.status, COUNT(d) FROM BriefDelivery d WHERE d.lawyerId = :lawyerId GROUP BY d.status")
     List<Object[]> countGroupByStatus(UUID lawyerId);

--- a/src/main/java/org/example/shield/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/shield/common/exception/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
     // Brief
     BRIEF_NOT_FOUND(HttpStatus.NOT_FOUND, "의뢰서를 찾을 수 없습니다"),
     BRIEF_ALREADY_CONFIRMED(HttpStatus.CONFLICT, "이미 확정된 의뢰서입니다"),
+    BRIEF_ALREADY_ACCEPTED(HttpStatus.CONFLICT, "이미 다른 변호사가 수락한 의뢰서입니다"),
 
     // Delivery
     DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 전달 건입니다"),


### PR DESCRIPTION
## Summary

- Brief 응답 DTO 에 수락 변호사 파생 필드 (`acceptedLawyerId` / `acceptedLawyerName` / `acceptedAt`) 추가
- `DeliveryService.updateDeliveryStatus` 에 중복 수락 차단 가드 (이미 CONFIRMED 된 delivery 가 있으면 `BRIEF_ALREADY_ACCEPTED` 409)
- N+1 방지 배치 조회 (목록용)

BriefStatus enum / DB 스키마는 건드리지 않고 derived 필드 방식으로 처리.

Closes #68
관련 프론트 PR: capstoneSHIELD/SHIELD_FE 의 이슈 #15 PR

## Test plan

- [ ] 의뢰서에 수락된 delivery 없을 때: 응답의 `acceptedLawyerId` 등 null
- [ ] 변호사 1명이 수락한 뒤 응답: 해당 변호사 정보로 채워짐
- [ ] 다른 변호사가 수락 시도 → 409 `BRIEF_ALREADY_ACCEPTED`
- [ ] 의뢰서 목록 조회 시 N+1 없이 한 번에 조회되는지 (로그 확인)
