### PR TITLE
feat: FCM 푸시 알림 시스템 구현 (#70)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,11 @@ application-local.yml
 application-secret.yml
 **/secrets/
 
+### Firebase Service Account (절대 커밋 금지) ###
+src/main/resources/firebase/
+**/firebase-adminsdk-*.json
+*-firebase-adminsdk-*.json
+
 ### OS ###
 .DS_Store
 Thumbs.db

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+    // Firebase Admin SDK (FCM 푸시 알림 — Issue #70)
+    implementation 'com.google.firebase:firebase-admin:9.4.3'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/org/example/shield/brief/application/DeliveryService.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryService.java
@@ -90,6 +90,7 @@ public class DeliveryService {
         User lawyer = userReader.findById(lawyerId);
 
         eventPublisher.publishEvent(new DeliveryStatusEvent(
+                client.getId(),
                 client.getEmail(),
                 client.getName(),
                 lawyer.getName(),

--- a/src/main/java/org/example/shield/brief/application/DeliveryStatusEvent.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryStatusEvent.java
@@ -1,6 +1,9 @@
 package org.example.shield.brief.application;
 
+import java.util.UUID;
+
 public record DeliveryStatusEvent(
+        UUID clientUserId,
         String clientEmail,
         String clientName,
         String lawyerName,

--- a/src/main/java/org/example/shield/common/config/AsyncConfig.java
+++ b/src/main/java/org/example/shield/common/config/AsyncConfig.java
@@ -34,4 +34,15 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    @Bean(name = "fcmExecutor")
+    public Executor fcmExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("fcm-");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/org/example/shield/common/config/FirebaseConfig.java
+++ b/src/main/java/org/example/shield/common/config/FirebaseConfig.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 @Configuration
 public class FirebaseConfig {
 
-    @Value("${firebase.service-account.path}")
+    @Value("${firebase.service-account-path}")
     private String SERVICE_ACCOUNT_PATH;
 
     @Bean

--- a/src/main/java/org/example/shield/common/config/FirebaseConfig.java
+++ b/src/main/java/org/example/shield/common/config/FirebaseConfig.java
@@ -1,0 +1,49 @@
+package org.example.shield.common.config;
+
+
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+
+@Slf4j
+@Configuration
+public class FirebaseConfig {
+
+    @Value("${firebase.service-account.path}")
+    private String SERVICE_ACCOUNT_PATH;
+
+    @Bean
+    public FirebaseApp firebaseApp() throws IOException {
+        try{
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(
+                            GoogleCredentials.fromStream(new ClassPathResource(SERVICE_ACCOUNT_PATH).getInputStream())
+                    )
+                    .build();
+
+            log.info("Firebase app이 성공적으로 실행되었습니다.");
+            return FirebaseApp.initializeApp(options);
+        } catch (IOException e){
+            log.error("Firebase app이 실패하였습니다. 에러메세지 : {}", e.getMessage());
+            return null;
+        }
+    }
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp){
+        return FirebaseMessaging.getInstance(firebaseApp);
+    }
+
+
+
+
+}

--- a/src/main/java/org/example/shield/fcm/application/FcmNotificationSender.java
+++ b/src/main/java/org/example/shield/fcm/application/FcmNotificationSender.java
@@ -1,0 +1,118 @@
+package org.example.shield.fcm.application;
+
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.SendResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.shield.brief.application.DeliveryStatusEvent;
+import org.example.shield.fcm.domain.FcmToken;
+import org.example.shield.fcm.domain.FcmTokenReader;
+import org.example.shield.fcm.domain.FcmTokenWriter;
+import org.example.shield.fcm.event.PushNotificationEvent;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FcmNotificationSender {
+
+    private final FirebaseMessaging firebaseMessaging;
+    private final FcmTokenReader fcmTokenReader;
+    private final FcmTokenWriter fcmTokenWriter;
+
+    @Async("fcmExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onPushEvent(PushNotificationEvent event) {
+        try {
+            sendToUser(event.userId(), event.title(), event.body(), event.data());
+        } catch (Exception e) {
+            log.error("FCM 발송 중 예외: userId={}, title={}", event.userId(), event.title(), e);
+        }
+    }
+
+    @Async("fcmExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onDeliveryStatusChanged(DeliveryStatusEvent event) {
+        try {
+            String title;
+            String body;
+            if ("CONFIRMED".equals(event.status())) {
+                title = "변호사 매칭 완료";
+                body = event.lawyerName() + " 변호사가 \"" + event.briefTitle() + "\" 의뢰서를 수락했습니다";
+            } else {
+                title = "의뢰서 거절됨";
+                body = event.lawyerName() + " 변호사가 의뢰서를 거절했습니다";
+            }
+            Map<String, String> data = Map.of(
+                    "type", "DELIVERY_STATUS",
+                    "status", event.status()
+            );
+            sendToUser(event.clientUserId(), title, body, data);
+        } catch (Exception e) {
+            log.error("의뢰서 상태 변경 푸시 발송 중 예외: clientUserId={}, status={}",
+                    event.clientUserId(), event.status(), e);
+        }
+    }
+
+    private void sendToUser(UUID userId, String title, String body, Map<String, String> data) {
+        List<FcmToken> tokens = fcmTokenReader.findAllByUserId(userId);
+        if (tokens.isEmpty()) {
+            log.debug("FCM 토큰 없음, 발송 스킵: userId={}", userId);
+            return;
+        }
+
+        List<String> tokenStrings = tokens.stream().map(FcmToken::getToken).toList();
+
+        MulticastMessage.Builder builder = MulticastMessage.builder()
+                .addAllTokens(tokenStrings)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build());
+
+        if (data != null && !data.isEmpty()) {
+            builder.putAllData(data);
+        }
+
+        try {
+            BatchResponse response = firebaseMessaging.sendEachForMulticast(builder.build());
+            log.info("FCM 발송 완료: userId={}, success={}, failure={}",
+                    userId, response.getSuccessCount(), response.getFailureCount());
+
+            if (response.getFailureCount() > 0) {
+                cleanupInvalidTokens(response.getResponses(), tokenStrings);
+            }
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM 발송 실패: userId={}, code={}", userId, e.getMessagingErrorCode(), e);
+        }
+    }
+
+    private void cleanupInvalidTokens(List<SendResponse> responses, List<String> tokens) {
+        for (int i = 0; i < responses.size(); i++) {
+            SendResponse r = responses.get(i);
+            if (r.isSuccessful()) continue;
+
+            FirebaseMessagingException ex = r.getException();
+            if (ex == null) continue;
+
+            MessagingErrorCode code = ex.getMessagingErrorCode();
+            if (code == MessagingErrorCode.UNREGISTERED || code == MessagingErrorCode.INVALID_ARGUMENT) {
+                String invalidToken = tokens.get(i);
+                fcmTokenWriter.deleteByToken(invalidToken);
+                log.info("무효 FCM 토큰 삭제: code={}", code);
+            }
+        }
+    }
+}

--- a/src/main/java/org/example/shield/fcm/application/FcmTokenService.java
+++ b/src/main/java/org/example/shield/fcm/application/FcmTokenService.java
@@ -1,0 +1,43 @@
+package org.example.shield.fcm.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.shield.fcm.domain.DeviceType;
+import org.example.shield.fcm.domain.FcmToken;
+import org.example.shield.fcm.domain.FcmTokenReader;
+import org.example.shield.fcm.domain.FcmTokenWriter;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FcmTokenService {
+
+    private final FcmTokenReader fcmTokenReader;
+    private final FcmTokenWriter fcmTokenWriter;
+
+    @Transactional
+    public void register(UUID userId, String token, DeviceType deviceType) {
+        Optional<FcmToken> existing = fcmTokenReader.findByToken(token);
+        if (existing.isPresent()) {
+            FcmToken fcmToken = existing.get();
+            fcmToken.reassign(userId, deviceType);
+            fcmTokenWriter.save(fcmToken);
+            log.info("FCM 토큰 재할당: userId={}, deviceType={}", userId, deviceType);
+        } else {
+            fcmTokenWriter.save(FcmToken.create(userId, token, deviceType));
+            log.info("FCM 토큰 등록: userId={}, deviceType={}", userId, deviceType);
+        }
+    }
+
+    @Transactional
+    public void unregister(String token) {
+        fcmTokenWriter.deleteByToken(token);
+        log.info("FCM 토큰 해제");
+    }
+}

--- a/src/main/java/org/example/shield/fcm/controller/FcmTokenController.java
+++ b/src/main/java/org/example/shield/fcm/controller/FcmTokenController.java
@@ -1,0 +1,44 @@
+package org.example.shield.fcm.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.shield.common.response.ApiResponse;
+import org.example.shield.fcm.application.FcmTokenService;
+import org.example.shield.fcm.controller.dto.RegisterFcmTokenRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@Tag(name = "FCM", description = "푸시 알림 토큰 API")
+@RestController
+@RequestMapping("/api/fcm/tokens")
+@RequiredArgsConstructor
+public class FcmTokenController {
+
+    private final FcmTokenService fcmTokenService;
+
+    @Operation(summary = "FCM 토큰 등록", description = "디바이스의 FCM 토큰을 등록합니다. 동일 토큰이 이미 있으면 사용자/디바이스 정보를 갱신합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> register(
+            @AuthenticationPrincipal UUID userId,
+            @Valid @RequestBody RegisterFcmTokenRequest request) {
+        fcmTokenService.register(userId, request.token(), request.deviceType());
+        return ResponseEntity.ok(ApiResponse.success("FCM 토큰 등록 성공"));
+    }
+
+    @Operation(summary = "FCM 토큰 해제", description = "로그아웃 또는 디바이스 비활성화 시 토큰을 제거합니다.")
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<Void>> unregister(@RequestParam String token) {
+        fcmTokenService.unregister(token);
+        return ResponseEntity.ok(ApiResponse.success("FCM 토큰 해제 성공"));
+    }
+}

--- a/src/main/java/org/example/shield/fcm/controller/dto/RegisterFcmTokenRequest.java
+++ b/src/main/java/org/example/shield/fcm/controller/dto/RegisterFcmTokenRequest.java
@@ -1,0 +1,13 @@
+package org.example.shield.fcm.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.example.shield.fcm.domain.DeviceType;
+
+public record RegisterFcmTokenRequest(
+        @NotBlank(message = "FCM 토큰은 필수입니다")
+        String token,
+
+        @NotNull(message = "디바이스 타입은 필수입니다")
+        DeviceType deviceType
+) {}

--- a/src/main/java/org/example/shield/fcm/domain/DeviceType.java
+++ b/src/main/java/org/example/shield/fcm/domain/DeviceType.java
@@ -1,0 +1,7 @@
+package org.example.shield.fcm.domain;
+
+public enum DeviceType {
+    ANDROID,
+    IOS,
+    WEB
+}

--- a/src/main/java/org/example/shield/fcm/domain/FcmToken.java
+++ b/src/main/java/org/example/shield/fcm/domain/FcmToken.java
@@ -1,0 +1,37 @@
+package org.example.shield.fcm.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.shield.common.domain.BaseEntity;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "fcm_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FcmToken extends BaseEntity {
+
+    @Column(nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false, unique = true, columnDefinition = "text")
+    private String token;
+
+    @Column(length = 20)
+    private String deviceType;
+
+    private FcmToken(UUID userId, String token, String deviceType) {
+        this.userId = userId;
+        this.token = token;
+        this.deviceType = deviceType;
+    }
+
+    public static FcmToken create(UUID userId, String token, String deviceType) {
+        return new FcmToken(userId, token, deviceType);
+    }
+}

--- a/src/main/java/org/example/shield/fcm/domain/FcmToken.java
+++ b/src/main/java/org/example/shield/fcm/domain/FcmToken.java
@@ -2,6 +2,8 @@ package org.example.shield.fcm.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -22,16 +24,22 @@ public class FcmToken extends BaseEntity {
     @Column(nullable = false, unique = true, columnDefinition = "text")
     private String token;
 
-    @Column(length = 20)
-    private String deviceType;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "device_type", length = 20)
+    private DeviceType deviceType;
 
-    private FcmToken(UUID userId, String token, String deviceType) {
+    private FcmToken(UUID userId, String token, DeviceType deviceType) {
         this.userId = userId;
         this.token = token;
         this.deviceType = deviceType;
     }
 
-    public static FcmToken create(UUID userId, String token, String deviceType) {
+    public static FcmToken create(UUID userId, String token, DeviceType deviceType) {
         return new FcmToken(userId, token, deviceType);
+    }
+
+    public void reassign(UUID userId, DeviceType deviceType) {
+        this.userId = userId;
+        this.deviceType = deviceType;
     }
 }

--- a/src/main/java/org/example/shield/fcm/domain/FcmTokenReader.java
+++ b/src/main/java/org/example/shield/fcm/domain/FcmTokenReader.java
@@ -1,0 +1,14 @@
+package org.example.shield.fcm.domain;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface FcmTokenReader {
+
+    List<FcmToken> findAllByUserId(UUID userId);
+
+    Optional<FcmToken> findByToken(String token);
+
+    boolean existsByToken(String token);
+}

--- a/src/main/java/org/example/shield/fcm/domain/FcmTokenWriter.java
+++ b/src/main/java/org/example/shield/fcm/domain/FcmTokenWriter.java
@@ -1,0 +1,8 @@
+package org.example.shield.fcm.domain;
+
+public interface FcmTokenWriter {
+
+    FcmToken save(FcmToken token);
+
+    void deleteByToken(String token);
+}

--- a/src/main/java/org/example/shield/fcm/event/PushNotificationEvent.java
+++ b/src/main/java/org/example/shield/fcm/event/PushNotificationEvent.java
@@ -1,0 +1,15 @@
+package org.example.shield.fcm.event;
+
+import java.util.Map;
+import java.util.UUID;
+
+public record PushNotificationEvent(
+        UUID userId,
+        String title,
+        String body,
+        Map<String, String> data
+) {
+    public static PushNotificationEvent of(UUID userId, String title, String body) {
+        return new PushNotificationEvent(userId, title, body, Map.of());
+    }
+}

--- a/src/main/java/org/example/shield/fcm/infrastructure/FcmTokenJpaRepository.java
+++ b/src/main/java/org/example/shield/fcm/infrastructure/FcmTokenJpaRepository.java
@@ -1,0 +1,19 @@
+package org.example.shield.fcm.infrastructure;
+
+import org.example.shield.fcm.domain.FcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface FcmTokenJpaRepository extends JpaRepository<FcmToken, UUID> {
+
+    List<FcmToken> findAllByUserId(UUID userId);
+
+    Optional<FcmToken> findByToken(String token);
+
+    boolean existsByToken(String token);
+
+    void deleteByToken(String token);
+}

--- a/src/main/java/org/example/shield/fcm/infrastructure/FcmTokenReaderImpl.java
+++ b/src/main/java/org/example/shield/fcm/infrastructure/FcmTokenReaderImpl.java
@@ -1,0 +1,32 @@
+package org.example.shield.fcm.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.example.shield.fcm.domain.FcmToken;
+import org.example.shield.fcm.domain.FcmTokenReader;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class FcmTokenReaderImpl implements FcmTokenReader {
+
+    private final FcmTokenJpaRepository fcmTokenJpaRepository;
+
+    @Override
+    public List<FcmToken> findAllByUserId(UUID userId) {
+        return fcmTokenJpaRepository.findAllByUserId(userId);
+    }
+
+    @Override
+    public Optional<FcmToken> findByToken(String token) {
+        return fcmTokenJpaRepository.findByToken(token);
+    }
+
+    @Override
+    public boolean existsByToken(String token) {
+        return fcmTokenJpaRepository.existsByToken(token);
+    }
+}

--- a/src/main/java/org/example/shield/fcm/infrastructure/FcmTokenWriterImpl.java
+++ b/src/main/java/org/example/shield/fcm/infrastructure/FcmTokenWriterImpl.java
@@ -1,0 +1,25 @@
+package org.example.shield.fcm.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.example.shield.fcm.domain.FcmToken;
+import org.example.shield.fcm.domain.FcmTokenWriter;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class FcmTokenWriterImpl implements FcmTokenWriter {
+
+    private final FcmTokenJpaRepository fcmTokenJpaRepository;
+
+    @Override
+    public FcmToken save(FcmToken token) {
+        return fcmTokenJpaRepository.save(token);
+    }
+
+    @Override
+    @Transactional
+    public void deleteByToken(String token) {
+        fcmTokenJpaRepository.deleteByToken(token);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,6 +93,11 @@ supabase:
   storage:
     bucket: lawyer_documents
 
+# Firebase Cloud Messaging
+firebase:
+  enabled: ${FIREBASE_ENABLED:true}
+  service-account-path: ${FIREBASE_SERVICE_ACCOUNT_PATH:firebase/service-account.json}
+
 # Swagger
 springdoc:
   swagger-ui:

--- a/src/main/resources/db/migration/V9__create_fcm_tokens.sql
+++ b/src/main/resources/db/migration/V9__create_fcm_tokens.sql
@@ -1,0 +1,28 @@
+-- Issue #70: FCM 푸시 알림 — fcm_tokens
+--
+-- 디바이스 토큰 저장 테이블. 한 사용자가 여러 디바이스 (PC + 모바일 + 태블릿) 에서
+-- 알림을 받을 수 있도록 1:N 관계로 설계.
+--
+-- 운영 시나리오:
+--  * 사용자가 기기에서 알림 권한 허용 → FE 가 FCM 에서 token 발급 → BE 에 등록
+--  * 사용자가 알림 끔 → FE 가 token 삭제 요청 → BE 에서 row 제거
+--  * 토큰 만료/회전 → 새 token 등록 (UNIQUE 제약으로 중복 방지)
+--  * FCM 발송 시 send 결과의 invalid token error → 해당 row 자동 삭제
+--
+-- device_type: 'WEB' | 'ANDROID' | 'IOS' (선택). 디바이스별 통계·디버깅용.
+
+CREATE TABLE IF NOT EXISTS fcm_tokens (
+    id           UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id      UUID         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token        TEXT         NOT NULL UNIQUE,
+    device_type  VARCHAR(20),
+    created_at   TIMESTAMP    NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMP    NOT NULL DEFAULT now()
+);
+
+-- 사용자별 토큰 조회용 (알림 발송 시 user_id → tokens 룩업)
+CREATE INDEX IF NOT EXISTS idx_fcm_tokens_user_id ON fcm_tokens(user_id);
+
+COMMENT ON TABLE  fcm_tokens IS 'Firebase Cloud Messaging 디바이스 토큰. user 1:N device.';
+COMMENT ON COLUMN fcm_tokens.token       IS 'FCM 디바이스 토큰. 갱신 시 upsert 필요.';
+COMMENT ON COLUMN fcm_tokens.device_type IS '''WEB'' | ''ANDROID'' | ''IOS'' (선택).';


### PR DESCRIPTION
## Summary

- Firebase Cloud Messaging 기반 푸시 알림 백엔드 인프라 구축
- 의뢰서 수락/거절 시 사용자에게 푸시 자동 발송 (이메일과 병행)
- 다중 디바이스 지원 (multicast) + 무효 토큰 자동 정리

## 핵심 변경

### 신규 도메인
- `fcm/domain/FcmToken` 엔티티 + `Reader/Writer` 인터페이스
- `fcm/infrastructure/*` JPA 구현체
- `db/migration/V9__create_fcm_tokens.sql` 테이블

### 발송 로직
- `FcmNotificationSender` — `@TransactionalEventListener(AFTER_COMMIT)` + `@Async("fcmExecutor")`
  - `PushNotificationEvent` 범용 푸시 이벤트 구독
  - `DeliveryStatusEvent` (의뢰서 수락/거절) 구독 → 자동 푸시
- multicast 발송 (`sendEachForMulticast`)
- `UNREGISTERED` / `INVALID_ARGUMENT` 응답 시 무효 토큰 자동 삭제

### API
- `POST /api/fcm/tokens` — 토큰 등록 (UPSERT: 중복 토큰은 userId 재할당)
- `DELETE /api/fcm/tokens?token=...` — 토큰 해제

### 인프라
- `firebase-admin` 의존성 추가
- `FirebaseConfig` 빈 (FirebaseApp, FirebaseMessaging)
- `AsyncConfig` 에 `fcmExecutor` 추가 (코어 2, 최대 5)
- `application.yml` 에 firebase 설정 블록
- service-account.json gitignore 처리 (보안)

### 비즈니스 통합
- `DeliveryStatusEvent` 에 `clientUserId` 필드 추가
- `DeliveryService` 가 이벤트 발행 시 `client.getId()` 포함

## Test plan

- [x] BE 로컬 기동 확인 (Firebase 빈 정상 등록)
- [x] FE 로그인 후 토큰 자동 등록 확인 (`POST /api/fcm/tokens` 200)
- [x] Firebase Console "테스트 메시지" 로 브라우저 알림 도달 확인
- [x] `DeliveryStatusEvent` 발행 → `FcmNotificationSender.onDeliveryStatusChanged` 발동 → "변호사 매칭 완료" 알림 도달 (production code path)
- [x] 포그라운드/백그라운드 알림 양쪽 정상 표시
- [ ] 폰 PWA 설치 후 알림 도달 (배포 후 진행 예정)

## 후속 작업

- 65 브랜치 (RAG) 를 이 PR 머지 후 develop 위로 rebase
- 폰 시연은 배포 환경에서 PWA 설치하여 검증 예정