### PR TITLE
[FIX] Firebase service-account 외부 경로 지원

### DIFF
--- a/src/main/java/org/example/shield/common/config/FirebaseConfig.java
+++ b/src/main/java/org/example/shield/common/config/FirebaseConfig.java
@@ -1,49 +1,53 @@
 package org.example.shield.common.config;
 
-
-
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 @Slf4j
 @Configuration
+@RequiredArgsConstructor
 public class FirebaseConfig {
 
+    private final ResourceLoader resourceLoader;
+
     @Value("${firebase.service-account-path}")
-    private String SERVICE_ACCOUNT_PATH;
+    private String serviceAccountPath;
 
     @Bean
     public FirebaseApp firebaseApp() throws IOException {
-        try{
-            FirebaseOptions options = FirebaseOptions.builder()
-                    .setCredentials(
-                            GoogleCredentials.fromStream(new ClassPathResource(SERVICE_ACCOUNT_PATH).getInputStream())
-                    )
-                    .build();
+        // classpath: / file: prefix 모두 지원. prefix 없으면 classpath 로 처리하여 기존 동작 유지.
+        String location = serviceAccountPath.contains(":")
+                ? serviceAccountPath
+                : "classpath:" + serviceAccountPath;
 
-            log.info("Firebase app이 성공적으로 실행되었습니다.");
+        Resource resource = resourceLoader.getResource(location);
+        if (!resource.exists()) {
+            throw new IOException("Firebase service account 파일을 찾을 수 없습니다: " + location);
+        }
+
+        try (InputStream is = resource.getInputStream()) {
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(is))
+                    .build();
+            log.info("Firebase 초기화 성공. location={}", location);
             return FirebaseApp.initializeApp(options);
-        } catch (IOException e){
-            log.error("Firebase app이 실패하였습니다. 에러메세지 : {}", e.getMessage());
-            return null;
         }
     }
 
     @Bean
-    public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp){
+    public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
         return FirebaseMessaging.getInstance(firebaseApp);
     }
-
-
-
-
 }


### PR DESCRIPTION
## 문제

PR #71 (FCM) 머지 후 Jenkins 빌드가 Health Check 단계에서 실패. BE 가 부팅 자체를 못 함.

```
+ curl -f http://localhost:8080/actuator/health
curl: (7) Failed to connect to localhost port 8080
+ exit 1
```

원인:
- \`FirebaseConfig\` 가 \`ClassPathResource\` 만 사용 → JAR 안의 파일만 찾음
- \`.gitignore\` 에 \`src/main/resources/firebase/\` 가 들어있어 git clone 한 Jenkins 환경에선 service-account.json 이 JAR 에 빠짐
- \`ClassPathResource\` 가 IOException → catch 후 null 반환 → \`firebaseMessaging(null)\` 에서 NPE → ApplicationContext 시작 실패

## 해결

- \`ClassPathResource\` → \`ResourceLoader\` 로 교체. \`classpath:\` / \`file:\` prefix 모두 지원
- prefix 없으면 자동으로 \`classpath:\` 처리 → 기존 로컬 동작 보존
- IOException catch 후 null 반환 제거 → 파일 못 찾으면 명시적 부팅 실패 (디버깅 용이)

## EC2 사전 작업 (이미 완료)

- \`service-account.json\` 을 \`/home/ec2-user/shield/config/\` 에 업로드 (권한 600)
- \`/etc/shield/shield.env\` 에 \`FIREBASE_SERVICE_ACCOUNT_PATH=file:/home/ec2-user/shield/config/firebase-service-account.json\` 추가

## 검증

- 로컬 \`./gradlew clean bootJar -x test\` 통과 (Jenkins 와 동일 명령)
- 머지 후 Jenkins 빌드 + Health Check 통과 예상

## 환경별 동작

| 환경 | 환경변수 | 동작 |
|---|---|---|
| 로컬 | 미설정 | default \`firebase/service-account.json\` → classpath → JAR 안 파일 |
| Jenkins → EC2 | \`file:/home/ec2-user/shield/config/firebase-service-account.json\` | 외부 파일 |