### PR TITLE
[CHORE] Jenkins Health Check sleep 20초 → 40초 (Issue #74)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
 
         stage('Health Check') {
             steps {
-                sh 'sleep 20'
+                sh 'sleep 40'
                 sh 'curl -f http://localhost:8080/actuator/health || exit 1'
             }
         }


### PR DESCRIPTION
## Summary

Closes #74

FCM 도입 후 기동 시간이 늘어나 Health Check 단계가 서버 기동 전에 실행되는 경우를 방지하기 위해 sleep 시간을 20초 → 40초로 연장.

## 변경

```diff
- sh 'sleep 20'
+ sh 'sleep 40'
```

## Test Plan

- [ ] Jenkins 빌드 성공
- [ ] Health Check 단계 정상 통과