### PR TITLE
[FEAT] Redis 도입 Phase 1 — 인프라 + Spring Boot 연동 (Issue #76)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
-    // spring-boot-starter-data-redis removed (Issue #38): 쿼리 임베딩 캐시 레이어 제거
+    // Redis (Issue #76): 변호사 추천 캐싱 + Refresh Token 블랙리스트
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     // spring-boot-starter-data-mongodb removed: RAG storage migrated to PostgreSQL + pgvector
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 

--- a/src/main/java/org/example/shield/ShieldApplication.java
+++ b/src/main/java/org/example/shield/ShieldApplication.java
@@ -2,12 +2,14 @@ package org.example.shield;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.util.TimeZone;
 
 @SpringBootApplication
 @EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
+@EnableCaching
 public class ShieldApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/example/shield/common/config/RedisConfig.java
+++ b/src/main/java/org/example/shield/common/config/RedisConfig.java
@@ -80,7 +80,8 @@ public class RedisConfig {
     /**
      * 다형 타입 정보를 포함한 Jackson 기반 Redis 직렬화기.
      * - LocalDateTime 등 java.time 지원
-     * - 다형 타입 안전을 위해 PolymorphicTypeValidator 사용
+     * - 다형 타입 안전을 위해 PolymorphicTypeValidator 의 화이트리스트 사용
+     *   (allowIfBaseType(Object.class) 는 RCE 위험 → 명시적 prefix 만 허용)
      */
     private GenericJackson2JsonRedisSerializer jsonRedisSerializer() {
         ObjectMapper mapper = new ObjectMapper();
@@ -88,7 +89,16 @@ public class RedisConfig {
         mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
         mapper.activateDefaultTyping(
                 BasicPolymorphicTypeValidator.builder()
-                        .allowIfBaseType(Object.class)
+                        // 애플리케이션 도메인/DTO
+                        .allowIfBaseType("org.example.shield")
+                        .allowIfSubType("org.example.shield")
+                        // 컬렉션 (List, ArrayList, Map, HashMap 등)
+                        .allowIfBaseType("java.util.")
+                        .allowIfSubType("java.util.")
+                        // LocalDateTime, LocalDate, OffsetDateTime 등
+                        .allowIfBaseType("java.time.")
+                        .allowIfSubType("java.time.")
+                        // String, Number, Boolean 등 final 타입은 NON_FINAL 정책상 자동 통과
                         .build(),
                 ObjectMapper.DefaultTyping.NON_FINAL,
                 com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY

--- a/src/main/java/org/example/shield/common/config/RedisConfig.java
+++ b/src/main/java/org/example/shield/common/config/RedisConfig.java
@@ -1,0 +1,98 @@
+package org.example.shield.common.config;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Redis 설정 (Issue #76).
+ *
+ * <ul>
+ *   <li>{@link RedisTemplate} : 직접 키/값 조작용 (예: Refresh Token 블랙리스트)</li>
+ *   <li>{@link CacheManager} : 어노테이션 기반 캐시용 ({@code @Cacheable / @CacheEvict})</li>
+ * </ul>
+ *
+ * <p>캐시별 TTL:
+ * <ul>
+ *   <li>{@code lawyer-recommendations} : 10분 — 변호사 풀 변동 빈도 낮음</li>
+ *   <li>기본 : 5분</li>
+ * </ul>
+ */
+@Configuration
+public class RedisConfig {
+
+    public static final String CACHE_LAWYER_RECOMMENDATIONS = "lawyer-recommendations";
+
+    /**
+     * 직접 사용용 RedisTemplate.
+     * - Key: String
+     * - Value: JSON 직렬화 (Jackson, Java Time 모듈 포함)
+     */
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(jsonRedisSerializer());
+        template.setHashValueSerializer(jsonRedisSerializer());
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    /**
+     * 어노테이션 기반 캐시용 CacheManager.
+     */
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(5))
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(jsonRedisSerializer()));
+
+        Map<String, RedisCacheConfiguration> perCacheConfigs = new HashMap<>();
+        perCacheConfigs.put(CACHE_LAWYER_RECOMMENDATIONS,
+                defaultConfig.entryTtl(Duration.ofMinutes(10)));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(defaultConfig)
+                .withInitialCacheConfigurations(perCacheConfigs)
+                .build();
+    }
+
+    /**
+     * 다형 타입 정보를 포함한 Jackson 기반 Redis 직렬화기.
+     * - LocalDateTime 등 java.time 지원
+     * - 다형 타입 안전을 위해 PolymorphicTypeValidator 사용
+     */
+    private GenericJackson2JsonRedisSerializer jsonRedisSerializer() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
+        mapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfBaseType(Object.class)
+                        .build(),
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
+        );
+        return new GenericJackson2JsonRedisSerializer(mapper);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,17 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
+  # Redis (Issue #76)
+  # - 캐시 (변호사 추천 등) + Refresh Token 블랙리스트
+  # - 운영 환경: EC2 내부 localhost 6379 (외부 미노출)
+  # - 로컬: REDIS_HOST 미설정이면 localhost 가정
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      timeout: 2000ms
+      connect-timeout: 2000ms
+
   mail:
     host: smtp.gmail.com
     port: 587


### PR DESCRIPTION
## Summary

Issue #76 의 Phase 1 (Spring Boot ↔ Redis 연동 인프라) 구현. 캐시 적용 자체는 Phase 2 이후 별도 단계에서 진행.

## 변경 내용

### 1. 의존성 (`build.gradle`)
- `spring-boot-starter-data-redis` 추가
- 기존 "removed (Issue #38)" 주석 제거

### 2. 설정 (`application.yml`)
```yaml
spring:
  data:
    redis:
      host: ${REDIS_HOST:localhost}
      port: ${REDIS_PORT:6379}
      timeout: 2000ms
      connect-timeout: 2000ms
```

### 3. `RedisConfig` 신규
- `RedisTemplate<String, Object>`: Refresh Token 블랙리스트 등 직접 사용용
- `CacheManager`: `@Cacheable / @CacheEvict` 어노테이션 기반 캐시용
- TTL 정책:
  - `lawyer-recommendations`: 10분
  - 기본: 5분
- Jackson 기반 JSON 직렬화 (java.time 지원, 다형 타입 안전)

### 4. `@EnableCaching`
- `ShieldApplication` 에 어노테이션 추가

## 인프라 (EC2 사이드, 본 PR 외 작업 완료)

- [x] EC2 에 redis6 설치 + systemd 등록
- [x] `redis6-cli ping` → PONG
- [x] `127.0.0.1:6379` 만 listen, 외부 미노출 확인
- [x] 보안그룹에 6379 외부 노출 없음

## Test Plan

- [x] `./gradlew compileJava` 성공
- [x] `./gradlew test` 전체 통과 (Spring 컨텍스트 정상 로드)
- [ ] Jenkins 자동 빌드/배포 성공
- [ ] 배포 후 EC2 에서 Spring Boot 가 Redis 정상 연결 확인 (로그)

## 다음 단계 (별도 PR)

- Phase 2: 변호사 추천 API `@Cacheable` 적용
- Phase 3: `@CacheEvict` 무효화 전략
- Phase 4: 성능 재측정 (Before/After 그래프)
- Phase 5: Refresh Token 블랙리스트 (별도 이슈로 분리 예정)