### PR TITLE
[FEAT] Redis 도입 Phase 2+3 — 변호사 추천 캐싱 + 무효화 전략 (Issue #76)

### DIFF
--- a/src/main/java/org/example/shield/admin/application/AdminService.java
+++ b/src/main/java/org/example/shield/admin/application/AdminService.java
@@ -26,6 +26,7 @@ import org.example.shield.lawyer.infrastructure.LawyerDocumentRepository;
 import org.example.shield.lawyer.infrastructure.LawyerProfileRepository;
 import org.example.shield.user.domain.User;
 import org.example.shield.user.domain.UserReader;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -33,6 +34,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+
+import static org.example.shield.common.config.RedisConfig.CACHE_LAWYER_RECOMMENDATIONS;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -185,7 +188,12 @@ public class AdminService {
         return LawyerDetailResponse.from(lawyer, user);
     }
 
+    /**
+     * 변호사 검증 상태 변경. VERIFIED 풀의 변동은 추천 결과 전체에 영향을 주므로
+     * 추천 캐시를 모두 무효화한다 (Issue #76 Phase 3).
+     */
     @Transactional
+    @CacheEvict(value = CACHE_LAWYER_RECOMMENDATIONS, allEntries = true)
     public VerificationResponse processVerification(UUID lawyerId, UUID adminId,
                                                      String statusStr, String reason) {
         log.info("변호사 인증 처리. lawyerId={}, adminId={}, status={}", lawyerId, adminId, statusStr);

--- a/src/main/java/org/example/shield/brief/application/BriefService.java
+++ b/src/main/java/org/example/shield/brief/application/BriefService.java
@@ -23,6 +23,7 @@ import org.example.shield.consultation.domain.ConsultationReader;
 import org.example.shield.consultation.domain.ConsultationWriter;
 import org.example.shield.user.domain.User;
 import org.example.shield.user.domain.UserReader;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static org.example.shield.common.config.RedisConfig.CACHE_LAWYER_RECOMMENDATIONS;
 
 @Service
 @RequiredArgsConstructor
@@ -81,7 +84,15 @@ public class BriefService {
         return BriefResponse.of(brief, accepted, lawyerName);
     }
 
+    /**
+     * 의뢰서 내용 수정. 키워드/내용 변경은 추천 결과를 좌우하므로 추천 캐시를
+     * 모두 무효화한다 (Issue #76 Phase 3).
+     *
+     * <p>키 패턴 매칭으로 해당 briefId 캐시만 비우는 방식도 가능하나, 호출 빈도가
+     * 낮아 안전하게 전체 무효화 채택.</p>
+     */
     @Transactional
+    @CacheEvict(value = CACHE_LAWYER_RECOMMENDATIONS, allEntries = true)
     public BriefUpdateResponse updateBrief(UUID briefId, UUID userId, BriefUpdateRequest request) {
         Brief brief = briefReader.findById(briefId);
         validateOwner(brief, userId);

--- a/src/main/java/org/example/shield/brief/application/LawyerMatchingService.java
+++ b/src/main/java/org/example/shield/brief/application/LawyerMatchingService.java
@@ -20,11 +20,14 @@ import org.example.shield.lawyer.infrastructure.LawyerEmbeddingRepository;
 import org.example.shield.lawyer.infrastructure.LawyerMatchProjection;
 import org.example.shield.user.domain.User;
 import org.example.shield.user.domain.UserReader;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.example.shield.common.config.RedisConfig.CACHE_LAWYER_RECOMMENDATIONS;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,6 +62,24 @@ public class LawyerMatchingService {
     private final QueryEmbeddingService queryEmbeddingService;
     private final ObjectMapper objectMapper;
 
+    /**
+     * 변호사 매칭 결과 조회 (Issue #76 Phase 2 — Redis 캐싱 적용).
+     *
+     * <p>캐시 키 구성: {@code briefId:userId:page:size}
+     * <ul>
+     *   <li>briefId: 의뢰서마다 결과 다름</li>
+     *   <li>userId: 소유권 검증을 우회하지 않도록 키에 포함 — 다른 사용자가 같은 briefId 로
+     *       호출해도 캐시 히트 없이 본문이 실행되어 BriefNotFoundException 으로 거부된다</li>
+     *   <li>page/size: 페이지마다 결과 셋이 다름</li>
+     * </ul>
+     * TTL: 10분 ({@link org.example.shield.common.config.RedisConfig})
+     *
+     * <p>캐시 무효화는 Phase 3 ({@code @CacheEvict}) 에서 처리.
+     */
+    @Cacheable(
+            value = CACHE_LAWYER_RECOMMENDATIONS,
+            key = "#briefId + ':' + #userId + ':' + #pageable.pageNumber + ':' + #pageable.pageSize"
+    )
     public PageResponse<MatchingResponse> findMatching(UUID briefId, UUID userId, Pageable pageable) {
         Brief brief = briefReader.findById(briefId);
         if (!brief.getUserId().equals(userId)) {

--- a/src/main/java/org/example/shield/brief/application/LawyerMatchingService.java
+++ b/src/main/java/org/example/shield/brief/application/LawyerMatchingService.java
@@ -65,12 +65,13 @@ public class LawyerMatchingService {
     /**
      * 변호사 매칭 결과 조회 (Issue #76 Phase 2 — Redis 캐싱 적용).
      *
-     * <p>캐시 키 구성: {@code briefId:userId:page:size}
+     * <p>캐시 키 구성: {@code briefId:userId:page:size:sort}
      * <ul>
      *   <li>briefId: 의뢰서마다 결과 다름</li>
      *   <li>userId: 소유권 검증을 우회하지 않도록 키에 포함 — 다른 사용자가 같은 briefId 로
      *       호출해도 캐시 히트 없이 본문이 실행되어 BriefNotFoundException 으로 거부된다</li>
      *   <li>page/size: 페이지마다 결과 셋이 다름</li>
+     *   <li>sort: 정렬 기준에 따라 결과 순서 다름 (예: 유사도 vs 경력순)</li>
      * </ul>
      * TTL: 10분 ({@link org.example.shield.common.config.RedisConfig})
      *
@@ -78,7 +79,7 @@ public class LawyerMatchingService {
      */
     @Cacheable(
             value = CACHE_LAWYER_RECOMMENDATIONS,
-            key = "#briefId + ':' + #userId + ':' + #pageable.pageNumber + ':' + #pageable.pageSize"
+            key = "#briefId + ':' + #userId + ':' + #pageable.pageNumber + ':' + #pageable.pageSize + ':' + #pageable.sort"
     )
     public PageResponse<MatchingResponse> findMatching(UUID briefId, UUID userId, Pageable pageable) {
         Brief brief = briefReader.findById(briefId);

--- a/src/main/java/org/example/shield/lawyer/application/LawyerEmbeddingService.java
+++ b/src/main/java/org/example/shield/lawyer/application/LawyerEmbeddingService.java
@@ -8,6 +8,7 @@ import org.example.shield.lawyer.domain.LawyerEmbedding;
 import org.example.shield.lawyer.domain.LawyerProfile;
 import org.example.shield.lawyer.infrastructure.LawyerEmbeddingRepository;
 import org.example.shield.lawyer.infrastructure.LawyerProfileRepository;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,8 @@ import java.util.HexFormat;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import static org.example.shield.common.config.RedisConfig.CACHE_LAWYER_RECOMMENDATIONS;
 
 /**
  * 변호사 임베딩 생성·재계산 서비스 (Issue #50).
@@ -52,8 +55,13 @@ public class LawyerEmbeddingService {
 
     /**
      * 변호사 프로필에서 텍스트를 조립 → 해시 비교 → 변경 시에만 Cohere 호출·저장.
+     *
+     * <p>임베딩이 갱신되면 추천 결과 점수 자체가 바뀌므로 추천 캐시 전체를 무효화한다
+     * (Issue #76 Phase 3). 해시 동일로 skip 되는 케이스에도 캐시는 비워지지만,
+     * 호출 빈도가 낮아 무시 가능한 비용.</p>
      */
     @Transactional
+    @CacheEvict(value = CACHE_LAWYER_RECOMMENDATIONS, allEntries = true)
     public void upsertEmbedding(LawyerProfile profile) {
         UUID lawyerId = profile.getId();
         String text = textBuilder.build(

--- a/src/main/java/org/example/shield/lawyer/application/LawyerEmbeddingService.java
+++ b/src/main/java/org/example/shield/lawyer/application/LawyerEmbeddingService.java
@@ -42,8 +42,14 @@ public class LawyerEmbeddingService {
     /**
      * 변호사 id 로 프로필을 조회해 임베딩을 생성/갱신한다.
      * 프로필 또는 텍스트가 비면 skip.
+     *
+     * <p>{@code @CacheEvict} 를 이 메서드에도 직접 부착한다. Spring AOP 프록시는
+     * 동일 클래스 내부 호출(self-invocation)을 가로채지 못하므로,
+     * {@link #upsertEmbedding(LawyerProfile)} 의 어노테이션만으로는 이 진입점에서
+     * 캐시가 비워지지 않는다 (Issue #76 Phase 3 보안 리뷰 반영).</p>
      */
     @Transactional
+    @CacheEvict(value = CACHE_LAWYER_RECOMMENDATIONS, allEntries = true)
     public void upsertEmbedding(UUID lawyerId) {
         Optional<LawyerProfile> profileOpt = lawyerProfileRepository.findById(lawyerId);
         if (profileOpt.isEmpty()) {

--- a/src/main/java/org/example/shield/lawyer/application/LawyerService.java
+++ b/src/main/java/org/example/shield/lawyer/application/LawyerService.java
@@ -11,10 +11,13 @@ import org.example.shield.lawyer.domain.LawyerReader;
 import org.example.shield.lawyer.domain.LawyerWriter;
 import org.example.shield.user.domain.User;
 import org.example.shield.user.domain.UserReader;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.example.shield.common.config.RedisConfig.CACHE_LAWYER_RECOMMENDATIONS;
 
 import java.util.List;
 import java.util.Map;
@@ -63,7 +66,12 @@ public class LawyerService {
         return LawyerResponse.from(profile, user.getName(), user.getProfileImageUrl());
     }
 
+    /**
+     * 변호사 프로필 수정. 변경된 필드(분야/태그/소개 등)는 추천 결과에 영향을 주므로
+     * 전체 추천 캐시를 무효화한다 (Issue #76 Phase 3).
+     */
     @Transactional
+    @CacheEvict(value = CACHE_LAWYER_RECOMMENDATIONS, allEntries = true)
     public LawyerResponse updateMyProfile(UUID userId, ProfileUpdateRequest request) {
         LawyerProfile profile = lawyerReader.findByUserId(userId);
         profile.updateProfile(


### PR DESCRIPTION
## Summary

Issue #76 의 Phase 2 (캐시 적용) + Phase 3 (캐시 무효화) 묶음 PR. 두 Phase 를 분리하면 단기간 stale 데이터 노출 위험이 있어 함께 머지.

## Phase 2: 변호사 추천 캐싱

### `LawyerMatchingService.findMatching()` 에 `@Cacheable` 적용

```java
@Cacheable(
    value = CACHE_LAWYER_RECOMMENDATIONS,
    key = "#briefId + ':' + #userId + ':' + #pageable.pageNumber + ':' + #pageable.pageSize"
)
```

- **TTL**: 10분 (RedisConfig 정의)
- **키 구성**: `briefId:userId:page:size`
  - `userId` 포함 이유: 다른 사용자가 같은 briefId 로 호출해도 캐시 우회 없이 본문 실행 → 소유권 검증 (`BriefNotFoundException`) 정상 발동 보장 (보안 필수)
  - `page/size`: 페이지마다 결과 셋이 다르므로 분리

## Phase 3: 캐시 무효화 전략

추천 결과에 영향을 주는 4개 트리거에 `@CacheEvict(allEntries=true)` 적용:

| 메서드 | 무효화 사유 |
|--------|------------|
| `LawyerService.updateMyProfile()` | 변호사 분야/태그/소개 변경 → 추천 결과 영향 |
| `AdminService.processVerification()` | VERIFIED 풀 변동 → 추천 후보 자체 변경 |
| `LawyerEmbeddingService.upsertEmbedding()` | 벡터 변경 → 유사도 점수 재계산 필요 |
| `BriefService.updateBrief()` | 의뢰서 키워드/내용 변경 → 추천 결과 영향 |

### 전체 무효화 선택 이유

- 위 트리거들의 호출 빈도가 낮음 (사용자/관리자 인터랙션 시점에만)
- 패턴 매칭 부분 삭제는 `RedisTemplate.keys()` 직접 사용 필요 → 코드 복잡도 증가
- 안전 우선 원칙 (stale 데이터 노출 < 캐시 효율)

## 보안 고려

- 캐시 키에 `userId` 포함으로 권한 검증 우회 차단
- `RedisConfig` 의 PolymorphicTypeValidator 화이트리스트 (Phase 1 PR #77 에서 적용)

## 예상 효과

| 지표 | Before | After (캐시 히트 시) |
|------|--------|--------------------|
| 변호사 추천 p95 | 673ms | ~50ms 이하 |
| Cohere 임베딩 호출 | 매 요청 | 10분에 1회 |
| DB pgvector 검색 | 매 요청 | 10분에 1회 |

실측은 Phase 4 에서 동일 baseline 시나리오로 재측정 후 Before/After 그래프로 검증.

## Test Plan

- [x] `./gradlew compileJava` 성공
- [x] `./gradlew test` 전체 통과 (회귀 없음)
- [ ] Jenkins 빌드/배포 성공
- [ ] 운영 환경 검증:
  - [ ] 추천 API 첫 호출 → `redis6-cli KEYS 'lawyer-recommendations*'` 에 키 생성 확인
  - [ ] 같은 API 재호출 → 응답 시간 단축 확인 (수백 ms → 수십 ms)
  - [ ] 변호사 프로필 수정 후 → 키 사라짐 확인 (`KEYS` 빈 결과)
  - [ ] 다른 사용자가 같은 briefId 호출 → 404/403 거부 확인 (소유권 검증 우회 차단)

## 다음 단계

- Phase 4: 동일 시나리오로 성능 재측정 → Before/After 비교 그래프 생성
- Phase 5 (별도 이슈): Refresh Token 블랙리스트