### PR TITLE
[FIX] Redis 캐시 역직렬화 500 에러 수정 (Issue #76)

### DIFF
--- a/src/main/java/org/example/shield/common/config/RedisConfig.java
+++ b/src/main/java/org/example/shield/common/config/RedisConfig.java
@@ -79,9 +79,19 @@ public class RedisConfig {
 
     /**
      * 다형 타입 정보를 포함한 Jackson 기반 Redis 직렬화기.
-     * - LocalDateTime 등 java.time 지원
-     * - 다형 타입 안전을 위해 PolymorphicTypeValidator 의 화이트리스트 사용
-     *   (allowIfBaseType(Object.class) 는 RCE 위험 → 명시적 prefix 만 허용)
+     *
+     * <p>역직렬화 시 GenericJackson2JsonRedisSerializer 가 root 를 Object 로 읽기 때문에
+     * 모든 객체(record 같은 final 포함)에 {@code @class} 가 필요하다.
+     * 따라서 {@link ObjectMapper.DefaultTyping#EVERYTHING} 사용.
+     * (NON_FINAL 사용 시 record 직렬화 후 역직렬화 단계에서 타입 정보 누락으로 실패함)</p>
+     *
+     * <p>다형 타입 안전을 위해 PolymorphicTypeValidator 화이트리스트 적용:
+     * <ul>
+     *   <li>{@code org.example.shield.*} — 애플리케이션 도메인/DTO</li>
+     *   <li>{@code java.util.*} — 컬렉션</li>
+     *   <li>{@code java.time.*} — LocalDateTime 등</li>
+     *   <li>{@code org.springframework.data.domain.*} — PageImpl, Sort 등 페이지네이션</li>
+     * </ul>
      */
     private GenericJackson2JsonRedisSerializer jsonRedisSerializer() {
         ObjectMapper mapper = new ObjectMapper();
@@ -89,18 +99,16 @@ public class RedisConfig {
         mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
         mapper.activateDefaultTyping(
                 BasicPolymorphicTypeValidator.builder()
-                        // 애플리케이션 도메인/DTO
                         .allowIfBaseType("org.example.shield")
                         .allowIfSubType("org.example.shield")
-                        // 컬렉션 (List, ArrayList, Map, HashMap 등)
                         .allowIfBaseType("java.util.")
                         .allowIfSubType("java.util.")
-                        // LocalDateTime, LocalDate, OffsetDateTime 등
                         .allowIfBaseType("java.time.")
                         .allowIfSubType("java.time.")
-                        // String, Number, Boolean 등 final 타입은 NON_FINAL 정책상 자동 통과
+                        .allowIfBaseType("org.springframework.data.domain.")
+                        .allowIfSubType("org.springframework.data.domain.")
                         .build(),
-                ObjectMapper.DefaultTyping.NON_FINAL,
+                ObjectMapper.DefaultTyping.EVERYTHING,
                 com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
         );
         return new GenericJackson2JsonRedisSerializer(mapper);


### PR DESCRIPTION
## Summary

Phase 2 운영 검증에서 발견된 캐시 hit 시 500 에러 핫픽스.

## 재현

```bash
# 첫 호출: 200 (DB 조회 + 캐시 저장)
time curl ... → HTTP 200, 0.439s

# Redis 키 정상 생성됨
redis6-cli KEYS 'lawyer-recommendations*'
# → lawyer-recommendations::briefId:userId:0:20:experienceYears: DESC

# 두 번째 호출: 500 (캐시 hit 후 역직렬화 실패)
time curl ... → HTTP 500
```

## 원인

```
SerializationException: Could not read JSON:
  Could not resolve subtype of [simple type, class java.lang.Object]:
  missing type id property '@class'
```

- `DefaultTyping.NON_FINAL` 은 **final 클래스에 `@class` 미포함**
- record `MatchingResponse` 는 final 이므로 직렬화 시 타입 정보 누락
- `GenericJackson2JsonRedisSerializer` 는 root 를 `Object` 로 읽어 역직렬화 시 어떤 타입인지 모름 → 500

## 수정

```diff
- ObjectMapper.DefaultTyping.NON_FINAL
+ ObjectMapper.DefaultTyping.EVERYTHING

+ .allowIfBaseType("org.springframework.data.domain.")
+ .allowIfSubType("org.springframework.data.domain.")
```

1. `EVERYTHING` 으로 모든 객체에 `@class` 강제 → record/final 클래스도 타입 정보 포함
2. 화이트리스트에 Spring 페이지네이션 도메인(`PageImpl`, `Sort` 등) 추가

PolymorphicTypeValidator 화이트리스트는 그대로 유지하여 RCE 방어선 보존.

## 운영 후속 작업

머지 + 배포 후 EC2 에서:
```bash
# 잘못된 형식으로 저장된 기존 캐시 삭제
redis6-cli --scan --pattern 'lawyer-recommendations*' | xargs -r redis6-cli DEL
```

## Test Plan

- [x] `./gradlew test` 전체 통과
- [ ] 머지 + Jenkins 배포
- [ ] 운영에서 두 번째 호출 200 확인 (캐시 hit 정상 동작)