### PR TITLE
[FEAT] Refresh Token 블랙리스트 (Issue #80)

### DIFF
--- a/src/main/java/org/example/shield/auth/application/AuthService.java
+++ b/src/main/java/org/example/shield/auth/application/AuthService.java
@@ -25,6 +25,7 @@ public class AuthService {
     private final JwtService jwtService;
     private final UserReader userReader;
     private final UserWriter userWriter;
+    private final TokenBlacklistService tokenBlacklistService;
 
     public record LoginResult(LoginResponse response, String refreshToken) {}
 
@@ -93,14 +94,36 @@ public class AuthService {
         return new LoginResult(response, tokenPair.refreshToken());
     }
 
+    /**
+     * 로그아웃: 현재 Refresh Token 을 블랙리스트에 등록하고 DB 의 토큰을 비운다 (Issue #80).
+     *
+     * <p>블랙리스트 등록 후 즉시 모든 갱신 시도가 거부되므로, 단순 DB null 처리만 하던
+     * 기존 동작 대비 토큰 탈취 시점부터의 강제 무효화 보안이 강화된다.</p>
+     */
     public void logout(UUID userId) {
         User user = userReader.findById(userId);
+        String currentToken = user.getRefreshToken();
+        if (currentToken != null && !currentToken.isBlank()) {
+            try {
+                tokenBlacklistService.blacklist(
+                        currentToken,
+                        jwtService.getRemainingTtl(currentToken)
+                );
+            } catch (Exception e) {
+                // 토큰 자체가 이미 만료되어 파싱 실패 등의 케이스는 무시 (어차피 무효 토큰)
+            }
+        }
         user.updateRefreshToken(null);
     }
 
     public JwtToken refreshToken(String refreshToken) {
         if (!jwtService.validateToken(refreshToken)) {
             throw new InvalidTokenException(ErrorCode.TOKEN_EXPIRED);
+        }
+
+        // Issue #80: 블랙리스트 hit 이면 즉시 거부 (DB 검증 이전 단계에서 차단)
+        if (tokenBlacklistService.isBlacklisted(refreshToken)) {
+            throw new InvalidTokenException(ErrorCode.REFRESH_TOKEN_BLACKLISTED);
         }
 
         UUID userId = jwtService.getUserIdFromToken(refreshToken);

--- a/src/main/java/org/example/shield/auth/application/JwtService.java
+++ b/src/main/java/org/example/shield/auth/application/JwtService.java
@@ -6,6 +6,8 @@ import org.example.shield.auth.domain.JwtToken;
 import org.example.shield.auth.infrastructure.JwtTokenProvider;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.UUID;
 
 @Service
@@ -32,5 +34,17 @@ public class JwtService {
     public String getRoleFromToken(String token) {
         Claims claims = jwtTokenProvider.parseClaims(token);
         return claims.get("role", String.class);
+    }
+
+    /**
+     * 토큰의 잔여 만료 시간을 반환한다 (현재 시각 기준).
+     * 만료된 토큰이면 {@link Duration#ZERO}.
+     * 블랙리스트 TTL 산정용 (Issue #80).
+     */
+    public Duration getRemainingTtl(String token) {
+        Claims claims = jwtTokenProvider.parseClaims(token);
+        Instant expiration = claims.getExpiration().toInstant();
+        Duration remaining = Duration.between(Instant.now(), expiration);
+        return remaining.isNegative() ? Duration.ZERO : remaining;
     }
 }

--- a/src/main/java/org/example/shield/auth/application/TokenBlacklistService.java
+++ b/src/main/java/org/example/shield/auth/application/TokenBlacklistService.java
@@ -1,0 +1,82 @@
+package org.example.shield.auth.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.HexFormat;
+
+/**
+ * Refresh Token 블랙리스트 서비스 (Issue #80).
+ *
+ * <p>로그아웃 시 Refresh Token 을 즉시 무효화하기 위해 Redis 에 토큰 해시를 저장한다.
+ * Refresh Token 갱신 요청이 들어올 때마다 블랙리스트를 조회해 hit 이면 거부한다.</p>
+ *
+ * <p>저장 형태:
+ * <ul>
+ *   <li>Key: {@code blacklist::refresh::{sha256(token)}}</li>
+ *   <li>Value: 마커 문자열 (실질 정보 없음, 존재 여부만 확인)</li>
+ *   <li>TTL: 토큰의 잔여 만료 시간 (만료 후엔 어차피 무의미하므로 자동 정리)</li>
+ * </ul>
+ *
+ * <p>토큰 평문이 아닌 SHA-256 해시로 저장하여 Redis 가 노출돼도 토큰이 유출되지 않도록 한다.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenBlacklistService {
+
+    private static final String KEY_PREFIX = "blacklist::refresh::";
+    private static final String MARKER_VALUE = "1";
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    /**
+     * Refresh Token 을 블랙리스트에 등록한다.
+     *
+     * @param token 평문 Refresh Token
+     * @param ttl   유지 시간 (보통 토큰 잔여 만료 시간). 0 이하면 등록 생략.
+     */
+    public void blacklist(String token, Duration ttl) {
+        if (token == null || token.isBlank()) {
+            return;
+        }
+        if (ttl == null || ttl.isZero() || ttl.isNegative()) {
+            log.debug("블랙리스트 등록 skip: TTL 0 이하");
+            return;
+        }
+        String key = buildKey(token);
+        redisTemplate.opsForValue().set(key, MARKER_VALUE, ttl);
+    }
+
+    /**
+     * 토큰이 블랙리스트에 있는지 확인한다.
+     */
+    public boolean isBlacklisted(String token) {
+        if (token == null || token.isBlank()) {
+            return false;
+        }
+        String key = buildKey(token);
+        Boolean exists = redisTemplate.hasKey(key);
+        return Boolean.TRUE.equals(exists);
+    }
+
+    private String buildKey(String token) {
+        return KEY_PREFIX + sha256Hex(token);
+    }
+
+    private String sha256Hex(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 미지원 환경", e);
+        }
+    }
+}

--- a/src/main/java/org/example/shield/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/shield/common/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다"),
     TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
     REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 일치하지 않습니다"),
+    REFRESH_TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED, "이미 로그아웃된 토큰입니다"),
 
     // Auth - OAuth
     OAUTH_CODE_INVALID(HttpStatus.UNAUTHORIZED, "OAuth 인증 코드가 유효하지 않습니다"),

--- a/src/test/java/org/example/shield/auth/application/TokenBlacklistServiceTest.java
+++ b/src/test/java/org/example/shield/auth/application/TokenBlacklistServiceTest.java
@@ -1,0 +1,139 @@
+package org.example.shield.auth.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #80 — Refresh Token 블랙리스트 서비스 단위 테스트.
+ */
+@ExtendWith(MockitoExtension.class)
+class TokenBlacklistServiceTest {
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
+
+    private TokenBlacklistService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TokenBlacklistService(redisTemplate);
+    }
+
+    @Test
+    @DisplayName("토큰을 블랙리스트에 등록하면 SHA-256 해시 키로 TTL 과 함께 저장된다")
+    void blacklist_storesHashedKeyWithTtl() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        String token = "eyJhbGci.someRefreshToken";
+        Duration ttl = Duration.ofMinutes(30);
+
+        service.blacklist(token, ttl);
+
+        ArgumentCaptor<String> keyCap = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Object> valCap = ArgumentCaptor.forClass(Object.class);
+        ArgumentCaptor<Duration> ttlCap = ArgumentCaptor.forClass(Duration.class);
+        verify(valueOperations).set(keyCap.capture(), valCap.capture(), ttlCap.capture());
+
+        // 키는 prefix + 64자 hex (SHA-256)
+        assertThat(keyCap.getValue()).startsWith("blacklist::refresh::");
+        assertThat(keyCap.getValue().substring("blacklist::refresh::".length()))
+                .hasSize(64)
+                .matches("[0-9a-f]+");
+        assertThat(ttlCap.getValue()).isEqualTo(ttl);
+    }
+
+    @Test
+    @DisplayName("TTL 이 0 이하면 등록을 생략한다")
+    void blacklist_skipsWhenTtlIsZeroOrNegative() {
+        service.blacklist("token", Duration.ZERO);
+        service.blacklist("token", Duration.ofSeconds(-10));
+
+        verify(redisTemplate, never()).opsForValue();
+    }
+
+    @Test
+    @DisplayName("토큰이 null/blank 면 등록을 생략한다")
+    void blacklist_skipsWhenTokenIsBlank() {
+        service.blacklist(null, Duration.ofMinutes(10));
+        service.blacklist("", Duration.ofMinutes(10));
+        service.blacklist("   ", Duration.ofMinutes(10));
+
+        verify(redisTemplate, never()).opsForValue();
+    }
+
+    @Test
+    @DisplayName("같은 토큰을 두 번 hash 하면 동일한 키가 나온다 (결정적 해시)")
+    void blacklist_sameTokenProducesSameKey() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        String token = "same-token";
+        service.blacklist(token, Duration.ofMinutes(1));
+        service.blacklist(token, Duration.ofMinutes(2));
+
+        ArgumentCaptor<String> keyCap = ArgumentCaptor.forClass(String.class);
+        verify(valueOperations, org.mockito.Mockito.times(2))
+                .set(keyCap.capture(), any(), any(Duration.class));
+
+        assertThat(keyCap.getAllValues()).hasSize(2);
+        assertThat(keyCap.getAllValues().get(0)).isEqualTo(keyCap.getAllValues().get(1));
+    }
+
+    @Test
+    @DisplayName("isBlacklisted: Redis 에 키가 있으면 true")
+    void isBlacklisted_trueWhenKeyExists() {
+        when(redisTemplate.hasKey(anyString())).thenReturn(true);
+
+        boolean result = service.isBlacklisted("token");
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("isBlacklisted: Redis 에 키가 없으면 false")
+    void isBlacklisted_falseWhenKeyMissing() {
+        when(redisTemplate.hasKey(anyString())).thenReturn(false);
+
+        boolean result = service.isBlacklisted("token");
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("isBlacklisted: hasKey 가 null 반환해도 안전하게 false")
+    void isBlacklisted_falseWhenHasKeyReturnsNull() {
+        when(redisTemplate.hasKey(anyString())).thenReturn(null);
+
+        boolean result = service.isBlacklisted("token");
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("isBlacklisted: 토큰이 null/blank 면 Redis 조회 없이 false")
+    void isBlacklisted_falseWhenTokenBlank() {
+        assertThat(service.isBlacklisted(null)).isFalse();
+        assertThat(service.isBlacklisted("")).isFalse();
+
+        verify(redisTemplate, never()).hasKey(anyString());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #80

Issue #76 Phase 5 분리 PR. 로그아웃 시 Refresh Token 을 즉시 무효화하기 위해 Redis 기반 블랙리스트 도입.

## 변경 내용

### 신규: `TokenBlacklistService`
- 키: `blacklist::refresh::{sha256(token)}` — **SHA-256 해시 저장으로 평문 노출 차단**
- 값: 마커 문자열 (존재 여부만 체크)
- TTL: 토큰 잔여 만료 시간 (만료 후 자동 정리)
- API:
  - `blacklist(token, ttl)` — 등록 (TTL ≤ 0 또는 토큰 blank 면 skip)
  - `isBlacklisted(token)` — 조회

### 신규: `JwtService.getRemainingTtl()`
- 현재 시각 기준 토큰 잔여 만료 시간(`Duration`) 반환
- 만료된 토큰이면 `Duration.ZERO`
- 블랙리스트 TTL 산정 전용

### 수정: `AuthService.logout()`
- DB null 처리 **이전에** 현재 Refresh Token 을 블랙리스트에 등록
- 토큰 파싱 실패 등 예외는 무시 (이미 무효 토큰)

### 수정: `AuthService.refreshToken()`
- 토큰 형식 검증 직후, DB 검증 **이전** 단계에서 블랙리스트 조회
- hit 시 `InvalidTokenException(REFRESH_TOKEN_BLACKLISTED)` 으로 401 응답

### 신규: `ErrorCode.REFRESH_TOKEN_BLACKLISTED`
- HTTP 401 + 메시지 "이미 로그아웃된 토큰입니다"

## 보안

- 토큰을 평문이 아닌 SHA-256 해시로 저장 → Redis 가 노출돼도 토큰 유출 차단
- DB 의 `user.refresh_token` 평문 저장은 **별도 이슈로 분리** (마이그레이션 부담 분리)

## Out of Scope

- Refresh Token 회전 race condition 의 근본 해결 (분산 락 / sliding window) — 별도 이슈
- Access Token 블랙리스트 (매 요청 Redis 조회 비용) — 추후 검토
- DB `user.refresh_token` 평문 → 해시 전환 — 별도 이슈

## Test Plan

- [x] 단위 테스트 8건 통과 (`TokenBlacklistServiceTest`)
  - 정상 등록 + SHA-256 해시 + TTL 검증
  - TTL 0/음수 → skip
  - 토큰 null/blank → skip
  - 동일 토큰 → 동일 키 (결정적 해시)
  - isBlacklisted true/false/null/blank 케이스
- [x] 전체 `./gradlew test` 통과 (회귀 없음)
- [ ] Jenkins 빌드 / 배포 성공
- [ ] 운영 검증:
  - [ ] 로그아웃 → 동일 Refresh Token 으로 갱신 시도 → 401 (REFRESH_TOKEN_BLACKLISTED)
  - [ ] Redis 에 `blacklist::refresh::*` 키 생성 + TTL 정상 (`redis6-cli KEYS 'blacklist::*'`)
  - [ ] 새 로그인 후 새 토큰은 정상 갱신 가능