### PR TITLE
[FEAT] 네이버 OAuth 로그인 추가 (Issue #83)

### DIFF
--- a/src/main/java/org/example/shield/auth/application/AuthService.java
+++ b/src/main/java/org/example/shield/auth/application/AuthService.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 public class AuthService {
 
     private final GoogleOAuthService googleOAuthService;
+    private final NaverOAuthService naverOAuthService;
     private final JwtService jwtService;
     private final UserReader userReader;
     private final UserWriter userWriter;
@@ -33,7 +34,7 @@ public class AuthService {
         OAuthUserInfo userInfo = googleOAuthService.getUserInfo(authorizationCode);
 
         // 신규 가입 여부를 구분하기 위해 조회 시점을 명시적으로 분리한다.
-        var existing = userReader.findByGoogleId(userInfo.googleId());
+        var existing = userReader.findByGoogleId(userInfo.providerId());
         boolean isNewUser = existing.isEmpty();
 
         // 보안: 신규 가입 시에는 클라이언트가 전달한 role 을 신뢰하지 않고
@@ -50,7 +51,44 @@ public class AuthService {
                         .name(userInfo.name())
                         .role(UserRole.USER)
                         .provider("GOOGLE")
-                        .googleId(userInfo.googleId())
+                        .googleId(userInfo.providerId())
+                        .build()
+        ));
+
+        JwtToken tokenPair = jwtService.createTokenPair(user.getId(), user.getRole().name());
+        user.updateRefreshToken(tokenPair.refreshToken());
+
+        LoginResponse response = new LoginResponse(
+                tokenPair.accessToken(),
+                tokenPair.refreshToken(),
+                user.getId(),
+                user.getName(),
+                user.getRole().name(),
+                isNewUser
+        );
+        return new LoginResult(response, tokenPair.refreshToken());
+    }
+
+    /**
+     * Naver OAuth 로그인 (Issue #83). googleLogin 과 동일 구조, naverId 컬럼으로 user 식별.
+     */
+    public LoginResult naverLogin(String authorizationCode, String role) {
+        OAuthUserInfo userInfo = naverOAuthService.getUserInfo(authorizationCode);
+
+        var existing = userReader.findByNaverId(userInfo.providerId());
+        boolean isNewUser = existing.isEmpty();
+
+        if (role != null && !role.isBlank()) {
+            parseRole(role);
+        }
+
+        User user = existing.orElseGet(() -> userWriter.save(
+                User.builder()
+                        .email(userInfo.email())
+                        .name(userInfo.name())
+                        .role(UserRole.USER)
+                        .provider("NAVER")
+                        .naverId(userInfo.providerId())
                         .build()
         ));
 
@@ -76,6 +114,7 @@ public class AuthService {
                                 .name(name)
                                 .role(parseRole(role))
                                 .provider("DEV")
+                                // dev 계정은 dev-{uuid} 를 googleId 자리에 채워 unique 충돌 방지
                                 .googleId("dev-" + UUID.randomUUID())
                                 .build()
                 ));

--- a/src/main/java/org/example/shield/auth/application/NaverOAuthService.java
+++ b/src/main/java/org/example/shield/auth/application/NaverOAuthService.java
@@ -5,12 +5,18 @@ import org.example.shield.auth.domain.OAuthUserInfo;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
+/**
+ * Naver OAuth 사용자 정보 조회 서비스 (Issue #83).
+ *
+ * <p>{@link org.example.shield.auth.infrastructure.NaverOAuthClient} 를 명시적으로
+ * 주입받아 사용. {@code GoogleOAuthService} 와 동일한 구조 유지.</p>
+ */
 @Service
-public class GoogleOAuthService {
+public class NaverOAuthService {
 
     private final OAuthClient oAuthClient;
 
-    public GoogleOAuthService(@Qualifier("googleOAuthClient") OAuthClient oAuthClient) {
+    public NaverOAuthService(@Qualifier("naverOAuthClient") OAuthClient oAuthClient) {
         this.oAuthClient = oAuthClient;
     }
 

--- a/src/main/java/org/example/shield/auth/controller/AuthController.java
+++ b/src/main/java/org/example/shield/auth/controller/AuthController.java
@@ -10,6 +10,7 @@ import org.example.shield.auth.application.AuthService;
 import org.example.shield.auth.controller.dto.DevLoginRequest;
 import org.example.shield.auth.domain.JwtToken;
 import org.example.shield.auth.controller.dto.GoogleLoginRequest;
+import org.example.shield.auth.controller.dto.NaverLoginRequest;
 import org.example.shield.auth.controller.dto.LoginResponse;
 import org.example.shield.auth.controller.dto.TokenRefreshResponse;
 import org.example.shield.auth.exception.InvalidTokenException;
@@ -38,6 +39,18 @@ public class AuthController {
             @Valid @RequestBody GoogleLoginRequest request,
             HttpServletResponse response) {
         AuthService.LoginResult result = authService.googleLogin(
+                request.authorizationCode(), request.role());
+
+        addRefreshTokenCookie(response, result.refreshToken());
+        return ResponseEntity.ok(ApiResponse.success("로그인 성공", result.response()));
+    }
+
+    @Operation(summary = "Naver 로그인", description = "Naver OAuth 인증 코드로 로그인 및 JWT 발급 (Issue #83)")
+    @PostMapping("/naver")
+    public ResponseEntity<ApiResponse<LoginResponse>> naverLogin(
+            @Valid @RequestBody NaverLoginRequest request,
+            HttpServletResponse response) {
+        AuthService.LoginResult result = authService.naverLogin(
                 request.authorizationCode(), request.role());
 
         addRefreshTokenCookie(response, result.refreshToken());

--- a/src/main/java/org/example/shield/auth/controller/dto/NaverLoginRequest.java
+++ b/src/main/java/org/example/shield/auth/controller/dto/NaverLoginRequest.java
@@ -1,0 +1,13 @@
+package org.example.shield.auth.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Naver OAuth 로그인 요청 (Issue #83).
+ */
+public record NaverLoginRequest(
+        @NotBlank(message = "인증 코드는 필수입니다")
+        String authorizationCode,
+
+        String role
+) {}

--- a/src/main/java/org/example/shield/auth/domain/OAuthUserInfo.java
+++ b/src/main/java/org/example/shield/auth/domain/OAuthUserInfo.java
@@ -1,7 +1,15 @@
 package org.example.shield.auth.domain;
 
+/**
+ * 외부 OAuth 프로바이더에서 받은 사용자 정보 (provider 무관 일반화).
+ *
+ * <p>{@code providerId} 는 해당 프로바이더에서 발급한 외부 사용자 식별자다.
+ * - Google: Google 계정 ID
+ * - Naver: Naver 계정 ID
+ * 저장 시 User 엔티티의 provider 별 컬럼(googleId / naverId)에 매핑한다.</p>
+ */
 public record OAuthUserInfo(
         String email,
         String name,
-        String googleId
+        String providerId
 ) {}

--- a/src/main/java/org/example/shield/auth/infrastructure/GoogleOAuthClient.java
+++ b/src/main/java/org/example/shield/auth/infrastructure/GoogleOAuthClient.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Slf4j
-@Component
+@Component("googleOAuthClient")
 public class GoogleOAuthClient implements OAuthClient {
 
     private final WebClient webClient;
@@ -74,7 +74,7 @@ public class GoogleOAuthClient implements OAuthClient {
             if (response == null || response.email() == null) {
                 throw new OAuthFailedException(ErrorCode.OAUTH_USER_INFO_FAILED);
             }
-            return new OAuthUserInfo(response.email(), response.name(), response.id());
+            return new OAuthUserInfo(response.email(), response.name(), response.id());  // providerId = Google ID
         } catch (OAuthFailedException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/java/org/example/shield/auth/infrastructure/NaverOAuthClient.java
+++ b/src/main/java/org/example/shield/auth/infrastructure/NaverOAuthClient.java
@@ -1,0 +1,123 @@
+package org.example.shield.auth.infrastructure;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.extern.slf4j.Slf4j;
+import org.example.shield.auth.domain.OAuthClient;
+import org.example.shield.auth.domain.OAuthUserInfo;
+import org.example.shield.auth.exception.OAuthFailedException;
+import org.example.shield.common.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * Naver OAuth 2.0 클라이언트 (Issue #83).
+ *
+ * <ul>
+ *   <li>토큰 교환: {@code https://nid.naver.com/oauth2.0/token}</li>
+ *   <li>유저 정보: {@code https://openapi.naver.com/v1/nid/me}</li>
+ *   <li>응답 구조: {@code { resultcode, message, response: { id, email, name, ... } }}</li>
+ * </ul>
+ */
+@Slf4j
+@Component("naverOAuthClient")
+public class NaverOAuthClient implements OAuthClient {
+
+    private static final String TOKEN_URI = "https://nid.naver.com/oauth2.0/token";
+    private static final String USER_INFO_URI = "https://openapi.naver.com/v1/nid/me";
+
+    private final WebClient webClient;
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUri;
+
+    public NaverOAuthClient(
+            @Value("${naver.client-id}") String clientId,
+            @Value("${naver.client-secret}") String clientSecret,
+            @Value("${naver.redirect-uri}") String redirectUri) {
+        this.webClient = WebClient.create();
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUri = redirectUri;
+    }
+
+    @Override
+    public OAuthUserInfo getUserInfo(String authorizationCode) {
+        String accessToken = exchangeCodeForToken(authorizationCode);
+        return fetchUserInfo(accessToken);
+    }
+
+    private String exchangeCodeForToken(String authorizationCode) {
+        try {
+            String url = UriComponentsBuilder.fromUriString(TOKEN_URI)
+                    .queryParam("grant_type", "authorization_code")
+                    .queryParam("client_id", clientId)
+                    .queryParam("client_secret", clientSecret)
+                    .queryParam("redirect_uri", redirectUri)
+                    .queryParam("code", authorizationCode)
+                    .build()
+                    .toUriString();
+
+            NaverTokenResponse response = webClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .bodyToMono(NaverTokenResponse.class)
+                    .block();
+
+            if (response == null || response.accessToken() == null) {
+                throw new OAuthFailedException(ErrorCode.OAUTH_CODE_INVALID);
+            }
+            return response.accessToken();
+        } catch (OAuthFailedException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Naver OAuth token exchange failed", e);
+            throw new OAuthFailedException(ErrorCode.OAUTH_CODE_INVALID);
+        }
+    }
+
+    private OAuthUserInfo fetchUserInfo(String accessToken) {
+        try {
+            NaverUserResponse response = webClient.get()
+                    .uri(USER_INFO_URI)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .bodyToMono(NaverUserResponse.class)
+                    .block();
+
+            if (response == null
+                    || response.response() == null
+                    || response.response().email() == null) {
+                throw new OAuthFailedException(ErrorCode.OAUTH_USER_INFO_FAILED);
+            }
+            NaverUserResponse.Profile profile = response.response();
+            return new OAuthUserInfo(profile.email(), profile.name(), profile.id());
+        } catch (OAuthFailedException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Naver OAuth user info fetch failed", e);
+            throw new OAuthFailedException(ErrorCode.OAUTH_USER_INFO_FAILED);
+        }
+    }
+
+    private record NaverTokenResponse(
+            @JsonProperty("access_token") String accessToken,
+            @JsonProperty("token_type") String tokenType,
+            @JsonProperty("expires_in") String expiresIn
+    ) {}
+
+    private record NaverUserResponse(
+            String resultcode,
+            String message,
+            Profile response
+    ) {
+        record Profile(
+                String id,
+                String email,
+                String name,
+                String nickname,
+                @JsonProperty("profile_image") String profileImage
+        ) {}
+    }
+}

--- a/src/main/java/org/example/shield/user/domain/User.java
+++ b/src/main/java/org/example/shield/user/domain/User.java
@@ -40,8 +40,15 @@ public class User {
     @Column(nullable = false)
     private String provider;
 
-    @Column(nullable = false, unique = true)
+    @Column(unique = true)
     private String googleId;
+
+    /**
+     * 네이버 OAuth 사용자 식별자 (Issue #83).
+     * provider = "NAVER" 인 경우에만 값을 가진다.
+     */
+    @Column(unique = true)
+    private String naverId;
 
     private String refreshToken;
 
@@ -56,12 +63,13 @@ public class User {
 
     @Builder
     public User(String email, String name, UserRole role, String provider,
-                String googleId, String profileImageUrl, String phone) {
+                String googleId, String naverId, String profileImageUrl, String phone) {
         this.email = email;
         this.name = name;
         this.role = role;
         this.provider = provider;
         this.googleId = googleId;
+        this.naverId = naverId;
         this.profileImageUrl = profileImageUrl;
         this.phone = phone;
     }

--- a/src/main/java/org/example/shield/user/domain/UserReader.java
+++ b/src/main/java/org/example/shield/user/domain/UserReader.java
@@ -12,5 +12,7 @@ public interface UserReader {
 
     Optional<User> findByGoogleId(String googleId);
 
+    Optional<User> findByNaverId(String naverId);
+
     Optional<User> findByEmail(String email);
 }

--- a/src/main/java/org/example/shield/user/infrastructure/UserReaderImpl.java
+++ b/src/main/java/org/example/shield/user/infrastructure/UserReaderImpl.java
@@ -33,6 +33,11 @@ public class UserReaderImpl implements UserReader {
     }
 
     @Override
+    public Optional<User> findByNaverId(String naverId) {
+        return userRepository.findByNaverId(naverId);
+    }
+
+    @Override
     public Optional<User> findByEmail(String email) {
         return userRepository.findByEmail(email);
     }

--- a/src/main/java/org/example/shield/user/infrastructure/UserRepository.java
+++ b/src/main/java/org/example/shield/user/infrastructure/UserRepository.java
@@ -10,5 +10,7 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
     Optional<User> findByGoogleId(String googleId);
 
+    Optional<User> findByNaverId(String naverId);
+
     Optional<User> findByEmail(String email);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -97,6 +97,14 @@ google:
   client-secret: ${GOOGLE_CLIENT_SECRET}
   redirect-uri: ${GOOGLE_REDIRECT_URI}
 
+# Naver OAuth (Issue #83)
+# 테스트/로컬에서 env 미설정 시에도 컨텍스트 로드되도록 기본값 제공.
+# 운영 환경(EC2)에는 실제 NAVER_* 환경변수가 주입됨.
+naver:
+  client-id: ${NAVER_CLIENT_ID:dummy-naver-client-id}
+  client-secret: ${NAVER_CLIENT_SECRET:dummy-naver-secret}
+  redirect-uri: ${NAVER_REDIRECT_URI:https://shieldai.kr/auth/naver/callback}
+
 # Supabase Storage
 supabase:
   url: ${SUPABASE_URL}

--- a/src/main/resources/db/migration/V11__add_naver_id_to_users.sql
+++ b/src/main/resources/db/migration/V11__add_naver_id_to_users.sql
@@ -1,0 +1,17 @@
+-- Issue #83: 네이버 OAuth 로그인 도입 (V11 — V10 은 PR #82 동시성 보호용)
+--
+-- users.naver_id 컬럼 추가 (Naver 계정 식별자 저장)
+-- - NULLABLE: 기존 Google 사용자는 null
+-- - UNIQUE: 동일 Naver ID 로 두 user 생성 방지
+--
+-- google_id NOT NULL 제약 제거:
+-- - 신규 Naver 사용자는 google_id 없이 가입됨
+-- - 기존 Google 사용자는 그대로 google_id 보존
+
+ALTER TABLE users
+    ADD COLUMN naver_id VARCHAR(255) UNIQUE;
+
+ALTER TABLE users
+    ALTER COLUMN google_id DROP NOT NULL;
+
+-- 인덱스는 UNIQUE 제약과 함께 자동 생성됨


### PR DESCRIPTION
## Summary

Closes #83

사용자 접근성 향상을 위해 네이버 로그인을 추가. Google OAuth 와 동일한 구조로 구현했고, 로컬 통합 테스트 (실제 인가코드 → JWT 발급) 완료.

## 변경 내용

### 신규: `NaverOAuthClient`
- 토큰 교환: `https://nid.naver.com/oauth2.0/token`
- 유저 정보: `https://openapi.naver.com/v1/nid/me`
- 응답 매핑: `response.id` / `response.email` / `response.name`
- `@Component("naverOAuthClient")` 로 빈 이름 명시

### 신규: `NaverOAuthService`
- `@Qualifier("naverOAuthClient")` 명시 주입
- 명시적 생성자 사용 (Lombok `@RequiredArgsConstructor` 가 `@Qualifier` 전달 못 해서)

### 신규: `POST /api/auth/naver`
- Request: `{ authorizationCode, role }`
- Response: Google 과 동일 포맷 (`accessToken`, `refreshToken`, `isNewUser` 등)

### 수정: 공통화
- `OAuthUserInfo.googleId` → `providerId` 로 일반화 (Google/Naver 공용)
- `GoogleOAuthClient` 에 `@Component("googleOAuthClient")` 명시 + `GoogleOAuthService` 도 `@Qualifier` 적용
- `User` 엔티티에 `naverId` 필드 추가, `googleId` nullable 로 완화
- `UserReader` / `UserRepository` 에 `findByNaverId` 추가

### 신규: Flyway V11
- `users.naver_id` 컬럼 (VARCHAR(255), UNIQUE)
- `google_id` NOT NULL 제약 제거 (Naver 신규 유저는 google_id 없음)

### 설정
- `application.yml`: `naver.client-id/secret/redirect-uri` 블록 추가 (테스트 환경용 기본값 제공)

## 외부 설정

- 네이버 개발자 센터: SHIELD 앱 등록 + Callback URL `https://shieldai.kr/auth/naver/callback` 등록 완료
- EC2 env 에 `NAVER_CLIENT_ID/SECRET/REDIRECT_URI` 추가 완료
- 동의 항목: 이메일, 이름

## Test Plan

- [x] `./gradlew test` 전체 통과 (회귀 없음)
- [x] 로컬 통합 테스트: 실제 Naver 인가코드 → `POST /api/auth/naver` → JWT 발급 성공
- [x] DB: `users` 테이블에 `provider=NAVER`, `naver_id=...` 정상 저장 확인
- [ ] Jenkins 빌드 / 배포 성공
- [ ] 운영 환경: 프론트에서 Naver 로그인 버튼 → 정상 동작

## Out of Scope

- 카카오 로그인 (별도 이슈)
- 다중 소셜 계정 통합 (한 사용자가 여러 provider 연결)
- DB `user.refresh_token` 평문 → 해시 전환 (별도 이슈)

## Note

- Naver Client Secret 은 채팅에 노출된 적이 있어 정식 운영 오픈 전 재발급 예정