### PR TITLE
[FEAT] 카카오 OAuth 로그인 추가

### DIFF
--- a/src/main/java/org/example/shield/auth/application/AuthService.java
+++ b/src/main/java/org/example/shield/auth/application/AuthService.java
@@ -23,6 +23,7 @@ public class AuthService {
 
     private final GoogleOAuthService googleOAuthService;
     private final NaverOAuthService naverOAuthService;
+    private final KakaoOAuthService kakaoOAuthService;
     private final JwtService jwtService;
     private final UserReader userReader;
     private final UserWriter userWriter;
@@ -89,6 +90,43 @@ public class AuthService {
                         .role(UserRole.USER)
                         .provider("NAVER")
                         .naverId(userInfo.providerId())
+                        .build()
+        ));
+
+        JwtToken tokenPair = jwtService.createTokenPair(user.getId(), user.getRole().name());
+        user.updateRefreshToken(tokenPair.refreshToken());
+
+        LoginResponse response = new LoginResponse(
+                tokenPair.accessToken(),
+                tokenPair.refreshToken(),
+                user.getId(),
+                user.getName(),
+                user.getRole().name(),
+                isNewUser
+        );
+        return new LoginResult(response, tokenPair.refreshToken());
+    }
+
+    /**
+     * Kakao OAuth 로그인. googleLogin/naverLogin 과 동일 구조, kakaoId 컬럼으로 user 식별.
+     */
+    public LoginResult kakaoLogin(String authorizationCode, String role) {
+        OAuthUserInfo userInfo = kakaoOAuthService.getUserInfo(authorizationCode);
+
+        var existing = userReader.findByKakaoId(userInfo.providerId());
+        boolean isNewUser = existing.isEmpty();
+
+        if (role != null && !role.isBlank()) {
+            parseRole(role);
+        }
+
+        User user = existing.orElseGet(() -> userWriter.save(
+                User.builder()
+                        .email(userInfo.email())
+                        .name(userInfo.name())
+                        .role(UserRole.USER)
+                        .provider("KAKAO")
+                        .kakaoId(userInfo.providerId())
                         .build()
         ));
 

--- a/src/main/java/org/example/shield/auth/application/KakaoOAuthService.java
+++ b/src/main/java/org/example/shield/auth/application/KakaoOAuthService.java
@@ -1,0 +1,26 @@
+package org.example.shield.auth.application;
+
+import org.example.shield.auth.domain.OAuthClient;
+import org.example.shield.auth.domain.OAuthUserInfo;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+/**
+ * Kakao OAuth 사용자 정보 조회 서비스.
+ *
+ * <p>{@link org.example.shield.auth.infrastructure.KakaoOAuthClient} 를 명시적으로
+ * 주입받아 사용. {@code GoogleOAuthService}/{@code NaverOAuthService} 와 동일한 구조 유지.</p>
+ */
+@Service
+public class KakaoOAuthService {
+
+    private final OAuthClient oAuthClient;
+
+    public KakaoOAuthService(@Qualifier("kakaoOAuthClient") OAuthClient oAuthClient) {
+        this.oAuthClient = oAuthClient;
+    }
+
+    public OAuthUserInfo getUserInfo(String authorizationCode) {
+        return oAuthClient.getUserInfo(authorizationCode);
+    }
+}

--- a/src/main/java/org/example/shield/auth/controller/AuthController.java
+++ b/src/main/java/org/example/shield/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import org.example.shield.auth.controller.dto.DevLoginRequest;
 import org.example.shield.auth.domain.JwtToken;
 import org.example.shield.auth.controller.dto.GoogleLoginRequest;
 import org.example.shield.auth.controller.dto.NaverLoginRequest;
+import org.example.shield.auth.controller.dto.KakaoLoginRequest;
 import org.example.shield.auth.controller.dto.LoginResponse;
 import org.example.shield.auth.controller.dto.TokenRefreshResponse;
 import org.example.shield.auth.exception.InvalidTokenException;
@@ -51,6 +52,18 @@ public class AuthController {
             @Valid @RequestBody NaverLoginRequest request,
             HttpServletResponse response) {
         AuthService.LoginResult result = authService.naverLogin(
+                request.authorizationCode(), request.role());
+
+        addRefreshTokenCookie(response, result.refreshToken());
+        return ResponseEntity.ok(ApiResponse.success("로그인 성공", result.response()));
+    }
+
+    @Operation(summary = "Kakao 로그인", description = "Kakao OAuth 인증 코드로 로그인 및 JWT 발급")
+    @PostMapping("/kakao")
+    public ResponseEntity<ApiResponse<LoginResponse>> kakaoLogin(
+            @Valid @RequestBody KakaoLoginRequest request,
+            HttpServletResponse response) {
+        AuthService.LoginResult result = authService.kakaoLogin(
                 request.authorizationCode(), request.role());
 
         addRefreshTokenCookie(response, result.refreshToken());

--- a/src/main/java/org/example/shield/auth/controller/dto/KakaoLoginRequest.java
+++ b/src/main/java/org/example/shield/auth/controller/dto/KakaoLoginRequest.java
@@ -1,0 +1,13 @@
+package org.example.shield.auth.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Kakao OAuth 로그인 요청.
+ */
+public record KakaoLoginRequest(
+        @NotBlank(message = "인증 코드는 필수입니다")
+        String authorizationCode,
+
+        String role
+) {}

--- a/src/main/java/org/example/shield/auth/infrastructure/KakaoOAuthClient.java
+++ b/src/main/java/org/example/shield/auth/infrastructure/KakaoOAuthClient.java
@@ -1,0 +1,154 @@
+package org.example.shield.auth.infrastructure;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.extern.slf4j.Slf4j;
+import org.example.shield.auth.domain.OAuthClient;
+import org.example.shield.auth.domain.OAuthUserInfo;
+import org.example.shield.auth.exception.OAuthFailedException;
+import org.example.shield.common.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+/**
+ * Kakao OAuth 2.0 클라이언트.
+ *
+ * <ul>
+ *   <li>토큰 교환: POST {@code https://kauth.kakao.com/oauth/token} (form-urlencoded)</li>
+ *   <li>유저 정보: GET {@code https://kapi.kakao.com/v2/user/me}</li>
+ *   <li>응답 구조: {@code { id(Long), kakao_account: { email, profile: { nickname } } }}</li>
+ *   <li>이메일은 비즈앱 전환을 거쳐야 권한이 부여된다. 개인 앱 단계에서는 권한 자체가 없어
+ *       사용자가 동의해도 응답에 포함되지 않으므로, {@code email} 이 비어있을 경우
+ *       {@code kakao-{providerId}@shield.local} 형태의 합성 이메일을 발급한다.
+ *       비즈앱 전환 후에는 실제 이메일이 들어오므로 자연스럽게 전환된다.</li>
+ * </ul>
+ */
+@Slf4j
+@Component("kakaoOAuthClient")
+public class KakaoOAuthClient implements OAuthClient {
+
+    private static final String TOKEN_URI = "https://kauth.kakao.com/oauth/token";
+    private static final String USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
+
+    private final WebClient webClient;
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUri;
+
+    public KakaoOAuthClient(
+            @Value("${kakao.client-id}") String clientId,
+            @Value("${kakao.client-secret}") String clientSecret,
+            @Value("${kakao.redirect-uri}") String redirectUri) {
+        this.webClient = WebClient.create();
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUri = redirectUri;
+    }
+
+    @Override
+    public OAuthUserInfo getUserInfo(String authorizationCode) {
+        String accessToken = exchangeCodeForToken(authorizationCode);
+        return fetchUserInfo(accessToken);
+    }
+
+    private String exchangeCodeForToken(String authorizationCode) {
+        try {
+            MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+            form.add("grant_type", "authorization_code");
+            form.add("client_id", clientId);
+            form.add("client_secret", clientSecret);
+            form.add("redirect_uri", redirectUri);
+            form.add("code", authorizationCode);
+
+            KakaoTokenResponse response = webClient.post()
+                    .uri(TOKEN_URI)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData(form))
+                    .retrieve()
+                    .bodyToMono(KakaoTokenResponse.class)
+                    .block();
+
+            if (response == null || response.accessToken() == null) {
+                throw new OAuthFailedException(ErrorCode.OAUTH_CODE_INVALID);
+            }
+            return response.accessToken();
+        } catch (OAuthFailedException e) {
+            throw e;
+        } catch (WebClientResponseException e) {
+            log.error("Kakao OAuth token exchange failed: status={}, body={}",
+                    e.getStatusCode(), e.getResponseBodyAsString());
+            throw new OAuthFailedException(ErrorCode.OAUTH_CODE_INVALID);
+        } catch (Exception e) {
+            log.error("Kakao OAuth token exchange failed", e);
+            throw new OAuthFailedException(ErrorCode.OAUTH_CODE_INVALID);
+        }
+    }
+
+    private OAuthUserInfo fetchUserInfo(String accessToken) {
+        try {
+            KakaoUserResponse response = webClient.get()
+                    .uri(USER_INFO_URI)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .bodyToMono(KakaoUserResponse.class)
+                    .block();
+
+            if (response == null || response.id() == null) {
+                throw new OAuthFailedException(ErrorCode.OAUTH_USER_INFO_FAILED);
+            }
+
+            String email = response.kakaoAccount() != null ? response.kakaoAccount().email() : null;
+            String nickname = null;
+            if (response.kakaoAccount() != null && response.kakaoAccount().profile() != null) {
+                nickname = response.kakaoAccount().profile().nickname();
+            }
+
+            String providerId = String.valueOf(response.id());
+
+            // 카카오 비즈앱 전환 전에는 이메일 권한이 없어 응답에 포함되지 않는다.
+            // User.email NOT NULL UNIQUE 제약을 만족시키기 위해 providerId 기반 합성 이메일을 사용.
+            if (email == null || email.isBlank()) {
+                email = "kakao-" + providerId + "@shield.local";
+            }
+
+            // 닉네임 미동의 시 fallback (현실적으로 동의항목 필수로 설정해 발생하지 않음)
+            if (nickname == null || nickname.isBlank()) {
+                nickname = "카카오사용자";
+            }
+
+            return new OAuthUserInfo(email, nickname, providerId);
+        } catch (OAuthFailedException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Kakao OAuth user info fetch failed", e);
+            throw new OAuthFailedException(ErrorCode.OAUTH_USER_INFO_FAILED);
+        }
+    }
+
+    private record KakaoTokenResponse(
+            @JsonProperty("access_token") String accessToken,
+            @JsonProperty("token_type") String tokenType,
+            @JsonProperty("refresh_token") String refreshToken,
+            @JsonProperty("expires_in") Integer expiresIn,
+            String scope
+    ) {}
+
+    private record KakaoUserResponse(
+            Long id,
+            @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+    ) {
+        record KakaoAccount(
+                String email,
+                Profile profile
+        ) {
+            record Profile(
+                    String nickname
+            ) {}
+        }
+    }
+}

--- a/src/main/java/org/example/shield/user/domain/User.java
+++ b/src/main/java/org/example/shield/user/domain/User.java
@@ -50,6 +50,13 @@ public class User {
     @Column(unique = true)
     private String naverId;
 
+    /**
+     * 카카오 OAuth 사용자 식별자.
+     * provider = "KAKAO" 인 경우에만 값을 가진다.
+     */
+    @Column(unique = true)
+    private String kakaoId;
+
     private String refreshToken;
 
     private String profileImageUrl;
@@ -63,13 +70,15 @@ public class User {
 
     @Builder
     public User(String email, String name, UserRole role, String provider,
-                String googleId, String naverId, String profileImageUrl, String phone) {
+                String googleId, String naverId, String kakaoId,
+                String profileImageUrl, String phone) {
         this.email = email;
         this.name = name;
         this.role = role;
         this.provider = provider;
         this.googleId = googleId;
         this.naverId = naverId;
+        this.kakaoId = kakaoId;
         this.profileImageUrl = profileImageUrl;
         this.phone = phone;
     }

--- a/src/main/java/org/example/shield/user/domain/UserReader.java
+++ b/src/main/java/org/example/shield/user/domain/UserReader.java
@@ -14,5 +14,7 @@ public interface UserReader {
 
     Optional<User> findByNaverId(String naverId);
 
+    Optional<User> findByKakaoId(String kakaoId);
+
     Optional<User> findByEmail(String email);
 }

--- a/src/main/java/org/example/shield/user/infrastructure/UserReaderImpl.java
+++ b/src/main/java/org/example/shield/user/infrastructure/UserReaderImpl.java
@@ -38,6 +38,11 @@ public class UserReaderImpl implements UserReader {
     }
 
     @Override
+    public Optional<User> findByKakaoId(String kakaoId) {
+        return userRepository.findByKakaoId(kakaoId);
+    }
+
+    @Override
     public Optional<User> findByEmail(String email) {
         return userRepository.findByEmail(email);
     }

--- a/src/main/java/org/example/shield/user/infrastructure/UserRepository.java
+++ b/src/main/java/org/example/shield/user/infrastructure/UserRepository.java
@@ -12,5 +12,7 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
     Optional<User> findByNaverId(String naverId);
 
+    Optional<User> findByKakaoId(String kakaoId);
+
     Optional<User> findByEmail(String email);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -105,6 +105,15 @@ naver:
   client-secret: ${NAVER_CLIENT_SECRET:dummy-naver-secret}
   redirect-uri: ${NAVER_REDIRECT_URI:https://shieldai.kr/auth/naver/callback}
 
+# Kakao OAuth
+# - client-id: 카카오 개발자 콘솔의 REST API 키 (NOT JavaScript 키)
+# - client-secret: '카카오 로그인' > '보안' 에서 발급 + 활성화 (선택이지만 보안상 권장)
+# - redirect-uri: 콘솔의 'Redirect URI' 와 정확히 일치해야 함
+kakao:
+  client-id: ${KAKAO_REST_API_KEY:dummy-kakao-rest-api-key}
+  client-secret: ${KAKAO_CLIENT_SECRET:dummy-kakao-secret}
+  redirect-uri: ${KAKAO_REDIRECT_URI:https://shieldai.kr/auth/kakao/callback}
+
 # Supabase Storage
 supabase:
   url: ${SUPABASE_URL}

--- a/src/main/resources/db/migration/V12__add_kakao_id_to_users.sql
+++ b/src/main/resources/db/migration/V12__add_kakao_id_to_users.sql
@@ -1,0 +1,12 @@
+-- 카카오 OAuth 로그인 도입
+--
+-- users.kakao_id 컬럼 추가 (Kakao 계정 식별자 저장)
+-- - NULLABLE: Google/Naver 사용자는 null
+-- - UNIQUE: 동일 Kakao ID 로 두 user 생성 방지
+-- - 카카오 user id 는 Long 이지만 provider 간 일관성을 위해 VARCHAR 로 저장
+--   (Google/Naver 도 String, 코드의 OAuthUserInfo.providerId 가 String)
+
+ALTER TABLE users
+    ADD COLUMN kakao_id VARCHAR(255) UNIQUE;
+
+-- 인덱스는 UNIQUE 제약과 함께 자동 생성됨


### PR DESCRIPTION
## Summary

사용자 접근성 향상을 위해 카카오 로그인을 추가. Google/Naver OAuth 와 동일한 구조로 구현했고, 로컬 통합 테스트 (실제 카카오 인가코드 → JWT 발급) 완료.

## 변경 내용

### 신규: `KakaoOAuthClient`
- 토큰 교환: `POST https://kauth.kakao.com/oauth/token` (form-urlencoded)
- 유저 정보: `GET https://kapi.kakao.com/v2/user/me`
- 응답 매핑: `id(Long) → providerId(String)`, `kakao_account.email`, `kakao_account.profile.nickname`
- `@Component("kakaoOAuthClient")` 로 빈 이름 명시
- 에러 본문 로깅(`WebClientResponseException.getResponseBodyAsString()`) 추가

### 신규: `KakaoOAuthService`
- `@Qualifier("kakaoOAuthClient")` 명시 주입
- 명시적 생성자 사용 (Naver 와 동일 패턴)

### 신규: `POST /api/auth/kakao`
- Request: `{ authorizationCode, role }`
- Response: Google/Naver 와 동일 포맷 (`accessToken`, `refreshToken`, `isNewUser` 등)

### 합성 이메일 (Kakao 한정)
- 카카오 비즈앱 전환 전이면 `account_email` scope 권한이 부여되지 않아 응답에 이메일이 포함되지 않음
- `User.email` 이 NOT NULL UNIQUE 제약 → 합성 이메일 `kakao-{providerId}@shield.local` 발급
- 비즈앱 전환 후에는 실제 이메일이 들어와 자연스럽게 전환됨

### 수정: 도메인 확장
- `User` 엔티티에 `kakaoId` 필드 추가
- `UserReader` / `UserRepository` 에 `findByKakaoId` 추가

### 신규: Flyway V12
- `users.kakao_id` 컬럼 (VARCHAR(255), UNIQUE)

### 설정
- `application.yml`: `kakao.client-id/secret/redirect-uri` 블록 추가 (테스트 환경용 기본값 제공)

## 외부 설정

- 카카오 개발자 센터: SHIELD 앱 등록 + Callback URL `https://shieldai.kr/auth/kakao/callback` 등록 완료
- 동의 항목: 닉네임(필수) — 이메일은 비즈앱 전환 전이라 사용 불가
- EC2 env 에 `KAKAO_REST_API_KEY/CLIENT_SECRET/REDIRECT_URI` 추가 필요 (배포 전)

## Test Plan

- [x] `./gradlew test` 전체 통과 (회귀 없음)
- [x] 로컬 통합 테스트: 실제 Kakao 인가코드 → `POST /api/auth/kakao` → JWT 발급 성공
  - 응답: `isNewUser=true`, `userId` 발급, `name=이승진` (닉네임 매핑 OK)
- [ ] EC2 env 반영 + Jenkins 빌드 / 배포 성공
- [ ] 운영 환경: 프론트에서 Kakao 로그인 버튼 → 정상 동작

## Out of Scope

- 프론트엔드 카카오 로그인 버튼/콜백 (별도 SHIELD_FE PR)
- 카카오 비즈앱 전환 (사업자 등록 필요 — 캡스톤 시연 이후 검토)
- 다중 소셜 계정 통합 (한 사용자가 여러 provider 연결)

## Note

- 카카오 비즈앱 전환 전이라 운영 환경에서는 **앱 관리자 + 팀원 + 테스터** 로 등록된 카카오 계정만 로그인 가능. 시연용 계정은 콘솔의 `[앱 설정] > [팀 관리]` 에서 사전 등록 필요.
- Kakao Client Secret 은 채팅에 노출된 적이 있어 정식 운영 오픈 전 재발급 예정.
