### PR TITLE
[FIX] 챗봇 sendMessage 500 회귀 — 외부 tx 제거 + boundary REQUIRES_NEW

### DIFF
--- a/src/main/java/org/example/shield/consultation/application/ChatTransactionalBoundary.java
+++ b/src/main/java/org/example/shield/consultation/application/ChatTransactionalBoundary.java
@@ -8,6 +8,7 @@ import org.example.shield.consultation.domain.ConsultationWriter;
 import org.example.shield.consultation.domain.Message;
 import org.example.shield.consultation.domain.MessageWriter;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
@@ -46,7 +47,7 @@ public class ChatTransactionalBoundary {
      * 사용자 입력은 절대 유실되지 않는다 (Issue #45 후속 — PR-A 의 noRollbackFor
      * 보다 한 단계 더 강력한 격리).</p>
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Message saveUserMessage(UUID consultationId, String content) {
         Message userMessage = Message.createUserMessage(consultationId, content);
         return messageWriter.save(userMessage);
@@ -55,7 +56,7 @@ public class ChatTransactionalBoundary {
     /**
      * PII 감지 시 AI 채널로 안내 메시지만 저장하는 독립 트랜잭션 경로.
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Message savePiiAiMessage(UUID consultationId, String message) {
         Message piiMessage = Message.createAiMessage(
                 consultationId, message, null, null, null, null);
@@ -70,7 +71,7 @@ public class ChatTransactionalBoundary {
      *
      * <p>AI 메시지 저장 · 분류 반영 · lastMessage 갱신은 수행하지 않는다.</p>
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void persistBlankResponseId(UUID consultationId, String responseId) {
         if (responseId == null || responseId.isBlank()) {
             return;
@@ -91,7 +92,7 @@ public class ChatTransactionalBoundary {
      * @param payload        AI 응답 처리 결과 (분류·메시지·메타)
      * @return 저장된 AI {@link Message}
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Message finalizeAiResponse(UUID consultationId, AiFinalizePayload payload) {
         Consultation consultation = consultationReader.findById(consultationId);
 

--- a/src/main/java/org/example/shield/consultation/application/MessageService.java
+++ b/src/main/java/org/example/shield/consultation/application/MessageService.java
@@ -87,10 +87,12 @@ public class MessageService {
      * {@code lastResponseId} 는 커밋되어야 한다. 그렇지 않으면 AI 실패
      * 시마다 사용자 입력이 유실되어 재현 가능한 데이터 손실이 발생한다.</p>
      *
-     * <p>ChatAiException 이외의 런타임 예외는 기존 기본 동작(전체 롤백)
-     * 을 유지하므로 RAG/Cohere 호출 실패는 그대로 롤백된다.</p>
+     * <p>이 메서드 자체는 트랜잭션을 열지 않는다 (클래스 javadoc 참조).
+     * DB 작업은 모두 {@link ChatTransactionalBoundary} 의 짧은 독립 트랜잭션으로 위임된다.
+     * 외부 호출(RAG/Cohere) 중 발생한 SQL 오류가 외부 트랜잭션을 rollback-only 로
+     * 만들어 후속 commit 단계에서 {@code UnexpectedRollbackException} 으로 500 응답을
+     * 유발하던 회귀를 방지하기 위함이다.</p>
      */
-    @Transactional(noRollbackFor = ChatAiException.class)
     public SendMessageResponse sendMessage(UUID consultationId, String content) {
         long pipelineStart = System.nanoTime();
         try {

--- a/src/test/java/org/example/shield/consultation/application/MessageServiceTest.java
+++ b/src/test/java/org/example/shield/consultation/application/MessageServiceTest.java
@@ -296,31 +296,30 @@ class MessageServiceTest {
                 .isEqualTo(1L);
     }
 
-    // ── Issue #45 후속 — @Transactional(noRollbackFor=ChatAiException) 회귀 테스트 ──
+    // ── sendMessage 트랜잭션 격리 회귀 테스트 ──
 
     /**
-     * {@link MessageService#sendMessage} 는 반드시
-     * {@code @Transactional(noRollbackFor = ChatAiException.class)} 로
-     * 지정되어 있어야 한다. 이 어노테이션이 제거되거나 속성이 누락되면
-     * AI blank 응답 시 USER 메시지와 {@code lastResponseId} 까지 롤백되어
-     * Issue #45 가 재발한다 (사용자 입력 유실).
+     * {@link MessageService#sendMessage} 는 어떠한 외부 트랜잭션도 열지 않아야 한다.
      *
-     * <p>통합 테스트로 실제 트랜잭션 동작을 검증하는 것이 이상적이지만,
-     * 현재 테스트 슬라이스는 단위 레벨이므로 어노테이션 계약을
-     * 명시적으로 고정해 회귀를 방지한다.</p>
+     * <p>이전에는 {@code @Transactional(noRollbackFor = ChatAiException.class)} 로
+     * Issue #45(USER 메시지 유실)를 막았으나, RAG/Cohere 단계에서 발생한 SQL 오류가
+     * 외부 트랜잭션을 rollback-only 로 마킹하면 후속 commit 시점에
+     * {@code UnexpectedRollbackException} 으로 500 응답이 발생하는 회귀가 확인됐다.
+     *
+     * <p>현재 설계는 USER/AI/PII 영속화를 모두 {@link ChatTransactionalBoundary} 의
+     * {@code REQUIRES_NEW} 트랜잭션에 위임하여 외부 tx 의 상태와 무관하게 독립
+     * 커밋되도록 하며, sendMessage 자체는 트랜잭션 경계를 가지지 않는다. 이 계약이
+     * 깨지면 다시 외부 tx poisoning 으로 500 이 발생하므로 어노테이션을 직접 검증한다.
      */
     @Test
-    @DisplayName("sendMessage 는 @Transactional(noRollbackFor = ChatAiException.class) 계약을 유지해야 한다 (Issue #45 회귀)")
-    void sendMessage_transactionalContract_noRollbackForChatAiException() throws NoSuchMethodException {
+    @DisplayName("sendMessage 는 @Transactional 을 가지면 안 된다 (외부 tx poisoning 으로 인한 500 회귀 방지)")
+    void sendMessage_transactionalContract_noOuterTransaction() throws NoSuchMethodException {
         Method method = MessageService.class.getDeclaredMethod("sendMessage", UUID.class, String.class);
         Transactional annotation = method.getAnnotation(Transactional.class);
 
         assertThat(annotation)
-                .as("sendMessage 에 @Transactional 이 지정되어 있어야 한다")
-                .isNotNull();
-        assertThat(annotation.noRollbackFor())
-                .as("noRollbackFor 에 ChatAiException 이 포함되어야 USER 메시지 유실이 방지된다")
-                .contains(ChatAiException.class);
+                .as("sendMessage 에 @Transactional 이 지정되면 RAG/Cohere SQL 오류가 외부 tx 를 rollback-only 로 만들어 500 이 발생한다")
+                .isNull();
     }
 
     /**


### PR DESCRIPTION
## Summary

운영 환경에서 챗봇 메시지 전송 시 발생하던 **HTTP 500** (`UnexpectedRollbackException: Transaction silently rolled back because it has been marked as rollback-only`) 회귀를 수정합니다.

## 재현 / 원인

EC2 로그 분석 결과 호출 순서:

1. `MessageService.sendMessage` 가 `@Transactional(noRollbackFor = ChatAiException.class)` 로 외부 트랜잭션을 연다.
2. 그 안에서 `RagPipelineService.execute(...)` 가 SQL 오류 (예: `pg_trgm text %% unknown`) 를 던진다.
3. RAG 파이프라인은 예외를 catch & log 후 폴백으로 계속 진행하지만, JPA 는 이미 외부 트랜잭션을 **rollback-only** 로 마킹.
4. `ChatTransactionalBoundary.finalizeAiResponse` 가 외부 tx 에 join 되어 동일하게 rollback-only 상태가 됨.
5. 컨트롤러 반환 시점에 커밋이 시도되면서 `UnexpectedRollbackException` → 500.

스택트레이스:
```
at org.example.shield.consultation.application.MessageService$$SpringCGLIB$$0.sendMessage(<generated>)
at org.example.shield.consultation.controller.ConsultationController.sendMessage(ConsultationController.java:88)
```

## 변경 내용

### 1. `MessageService.sendMessage` 의 `@Transactional` 제거
- 클래스 javadoc 이 명시한 "이 서비스는 non-transactional 이다" 설계 의도와 일치시킴.
- DB 작업은 모두 `ChatTransactionalBoundary` 의 짧은 독립 트랜잭션으로 위임된다.
- `noRollbackFor=ChatAiException.class` 도 더 이상 필요 없음 (외부 tx 자체가 사라짐).

### 2. `ChatTransactionalBoundary` 의 모든 영속화 메서드를 `REQUIRES_NEW` 로 승격
- `saveUserMessage`, `savePiiAiMessage`, `persistBlankResponseId`, `finalizeAiResponse` 4개.
- 미래에 외부 tx 가 다시 생기더라도 USER / AI / PII 메시지는 항상 독립 커밋 보장.
- Issue #45 의 원래 목적 (USER 메시지 유실 방지) 도 어노테이션 의존 없이 구조적으로 보장.

### 3. 회귀 테스트 갱신
- 기존 `sendMessage_transactionalContract_noRollbackForChatAiException` 은 **어노테이션 존재** 를 검증.
- 새 계약 `sendMessage_transactionalContract_noOuterTransaction` 으로 교체 — **어노테이션 부재** 를 검증해 외부 tx poisoning 회귀 방지.

## Test Plan

- [x] `./gradlew test` 전체 통과 (206 → 206 그린, 어노테이션 회귀 테스트도 새 계약으로 그린)
- [ ] 배포 후 운영 환경에서 `POST /api/consultations/{id}/messages` 가 200 응답하는지 검증
  - 별도의 RAG/카테고리 매핑 버그가 있어도 500 이 아닌 정상 응답이 떨어져야 한다

## Out of Scope (별도 이슈로 분리 권장)

본 PR 은 "500 발생을 막는 것" 까지만 다룬다. 디버깅 과정에서 함께 확인된 별개 버그:

- 🟠 `pg_trgm text %% unknown` (Hybrid 검색 trigram 인자 null-safe 처리)
- 🟠 "부동산" 등 L1 분야명 동의어 매핑 누락 (PromptService / ChecklistLoader / ChecklistCoverageService)
- 🟡 LLM classification override 거부 시 warning 만 찍힘 — 이건 이미 정상 흐름 (변경 없음)

## 시급도

🔴 시연 안정성 직결. 카카오/네이버 로그인 PR 시리즈 다음으로 가장 시급.
