### PR TITLE
[FIX] 챗봇 500 + RAG SQL + 분야명 매핑 — 3종 결함 일괄 수정

### DIFF
--- a/src/main/java/org/example/shield/ai/application/ChecklistSlugMap.java
+++ b/src/main/java/org/example/shield/ai/application/ChecklistSlugMap.java
@@ -10,6 +10,10 @@ import java.util.Map;
  * <p>지시서({@code SHIELD_AI_bunryucegye_jageobjisiseo.md}) 고정 매핑이며,
  * {@code src/main/resources/ai/checklists/<slug>.yaml} 파일명과 1:1 대응됨.</p>
  *
+ * <p>프론트엔드의 카테고리 선택 라벨이 정식 L1 이름과 다른 축약형
+ * ("부동산", "이혼", "임대차" 등)일 수 있어 alias 매핑을 추가했다.
+ * 정식 이름 매핑이 실패하면 alias 표를 한 번 더 조회한다.</p>
+ *
  * <p>이 상수는 프로덕션 코드와 스키마 검증 테스트가 동일 소스를 참조하도록
  * 공유 상수로 추출되었다.</p>
  */
@@ -17,6 +21,9 @@ public final class ChecklistSlugMap {
 
     /** L1 한글 이름 → slug (삽입 순서 보존). */
     public static final Map<String, String> L1_TO_SLUG;
+
+    /** 축약형/별칭 → 정식 L1 한글 이름. */
+    private static final Map<String, String> ALIAS_TO_L1;
 
     static {
         Map<String, String> m = new LinkedHashMap<>();
@@ -29,6 +36,47 @@ public final class ChecklistSlugMap {
         m.put("임대차보호", "lease-protection");
         m.put("기업·상사거래", "commercial");
         L1_TO_SLUG = Collections.unmodifiableMap(m);
+
+        Map<String, String> a = new LinkedHashMap<>();
+        // 부동산 거래
+        a.put("부동산", "부동산 거래");
+        a.put("부동산거래", "부동산 거래");
+        // 이혼·위자료·재산분할
+        a.put("이혼", "이혼·위자료·재산분할");
+        a.put("위자료", "이혼·위자료·재산분할");
+        a.put("재산분할", "이혼·위자료·재산분할");
+        a.put("가사", "이혼·위자료·재산분할");
+        // 상속·유류분·유언
+        a.put("상속", "상속·유류분·유언");
+        a.put("유언", "상속·유류분·유언");
+        a.put("유류분", "상속·유류분·유언");
+        // 근로계약·해고·임금
+        a.put("근로", "근로계약·해고·임금");
+        a.put("노동", "근로계약·해고·임금");
+        a.put("해고", "근로계약·해고·임금");
+        a.put("임금", "근로계약·해고·임금");
+        a.put("근로계약", "근로계약·해고·임금");
+        // 손해배상·불법행위
+        a.put("손해배상", "손해배상·불법행위");
+        a.put("불법행위", "손해배상·불법행위");
+        a.put("교통사고", "손해배상·불법행위");
+        a.put("의료사고", "손해배상·불법행위");
+        // 채무·보증·개인파산·회생
+        a.put("채무", "채무·보증·개인파산·회생");
+        a.put("보증", "채무·보증·개인파산·회생");
+        a.put("파산", "채무·보증·개인파산·회생");
+        a.put("회생", "채무·보증·개인파산·회생");
+        a.put("개인파산", "채무·보증·개인파산·회생");
+        a.put("개인회생", "채무·보증·개인파산·회생");
+        // 임대차보호
+        a.put("임대차", "임대차보호");
+        a.put("전세", "임대차보호");
+        a.put("월세", "임대차보호");
+        // 기업·상사거래
+        a.put("기업", "기업·상사거래");
+        a.put("상사", "기업·상사거래");
+        a.put("상사거래", "기업·상사거래");
+        ALIAS_TO_L1 = Collections.unmodifiableMap(a);
     }
 
     private ChecklistSlugMap() {
@@ -37,11 +85,39 @@ public final class ChecklistSlugMap {
     /**
      * L1 한글 이름 → slug.
      *
-     * @param l1Name 온톨로지 L1 한글 이름 (예: "부동산 거래")
+     * <p>입력은 trim 후, 다음 순서로 매칭한다.</p>
+     * <ol>
+     *   <li>정식 L1 이름 직접 매칭 ({@link #L1_TO_SLUG})</li>
+     *   <li>alias 표를 통한 우회 매칭 ({@link #ALIAS_TO_L1})</li>
+     * </ol>
+     *
+     * @param l1Name 온톨로지 L1 한글 이름 또는 축약형 (예: "부동산 거래", "부동산")
      * @return 대응 slug 또는 null (매핑 없음)
      */
     public static String slugFor(String l1Name) {
         if (l1Name == null) return null;
-        return L1_TO_SLUG.get(l1Name);
+        String key = l1Name.trim();
+        if (key.isEmpty()) return null;
+
+        String direct = L1_TO_SLUG.get(key);
+        if (direct != null) return direct;
+
+        String canonical = ALIAS_TO_L1.get(key);
+        if (canonical == null) return null;
+        return L1_TO_SLUG.get(canonical);
+    }
+
+    /**
+     * L1 한글 이름 또는 축약형을 정식 L1 이름으로 정규화한다.
+     *
+     * <p>{@code slugFor(...)} 와 동일한 매칭 규칙을 사용한다. 매핑이 없으면 null.
+     * 카테고리 매핑/추천 등 slug 이외의 정식 이름이 필요한 경로에서 사용한다.</p>
+     */
+    public static String canonicalL1(String l1Name) {
+        if (l1Name == null) return null;
+        String key = l1Name.trim();
+        if (key.isEmpty()) return null;
+        if (L1_TO_SLUG.containsKey(key)) return key;
+        return ALIAS_TO_L1.get(key);
     }
 }

--- a/src/main/java/org/example/shield/ai/domain/LegalCaseJpaRepository.java
+++ b/src/main/java/org/example/shield/ai/domain/LegalCaseJpaRepository.java
@@ -106,7 +106,7 @@ public interface LegalCaseJpaRepository extends JpaRepository<LegalCaseEntity, L
                      OR lc.category_ids && CAST(:categoryIds AS text[]) )
                AND ( lc.content_tsv @@ plainto_tsquery('simple', :vectorQuery)
                   OR lc.content_tsv @@ to_tsquery('simple', :keywordQuery)
-                  OR COALESCE(lc.holding, '') %% :vectorQuery
+                  OR COALESCE(lc.holding, '') % CAST(:vectorQuery AS text)
                   OR lc.embedding IS NOT NULL )
              ORDER BY score DESC
              LIMIT :topK
@@ -145,7 +145,7 @@ public interface LegalCaseJpaRepository extends JpaRepository<LegalCaseEntity, L
                      OR lc.category_ids && CAST(:categoryIds AS text[]) )
                AND ( lc.content_tsv @@ plainto_tsquery('simple', :vectorQuery)
                   OR lc.content_tsv @@ to_tsquery('simple', :keywordQuery)
-                  OR COALESCE(lc.holding, '') %% :vectorQuery
+                  OR COALESCE(lc.holding, '') % CAST(:vectorQuery AS text)
                   OR lc.embedding IS NOT NULL )
              ORDER BY score DESC
              LIMIT :topK

--- a/src/main/java/org/example/shield/ai/domain/LegalChunkJpaRepository.java
+++ b/src/main/java/org/example/shield/ai/domain/LegalChunkJpaRepository.java
@@ -95,7 +95,7 @@ public interface LegalChunkJpaRepository extends JpaRepository<LegalChunkEntity,
                      OR lc.category_ids && CAST(:categoryIds AS text[]) )
                AND ( lc.content_tsv @@ plainto_tsquery('simple', :vectorQuery)
                   OR lc.content_tsv @@ to_tsquery('simple', :keywordQuery)
-                  OR lc.content %% :vectorQuery
+                  OR lc.content % CAST(:vectorQuery AS text)
                   OR lc.embedding IS NOT NULL )
              ORDER BY score DESC
              LIMIT :topK
@@ -131,7 +131,7 @@ public interface LegalChunkJpaRepository extends JpaRepository<LegalChunkEntity,
                      OR lc.category_ids && CAST(:categoryIds AS text[]) )
                AND ( lc.content_tsv @@ plainto_tsquery('simple', :vectorQuery)
                   OR lc.content_tsv @@ to_tsquery('simple', :keywordQuery)
-                  OR lc.content %% :vectorQuery
+                  OR lc.content % CAST(:vectorQuery AS text)
                   OR lc.embedding IS NOT NULL )
              ORDER BY score DESC
              LIMIT :topK
@@ -166,7 +166,7 @@ public interface LegalChunkJpaRepository extends JpaRepository<LegalChunkEntity,
              WHERE lc.abolition_date IS NULL
                AND ( lc.content_tsv @@ plainto_tsquery('simple', :vectorQuery)
                   OR lc.content_tsv @@ to_tsquery('simple', :keywordQuery)
-                  OR lc.content %% :vectorQuery )
+                  OR lc.content % CAST(:vectorQuery AS text) )
              ORDER BY score DESC
              LIMIT :topK
             """, nativeQuery = true)
@@ -193,7 +193,7 @@ public interface LegalChunkJpaRepository extends JpaRepository<LegalChunkEntity,
                AND lc.law_id IN (:lawIds)
                AND ( lc.content_tsv @@ plainto_tsquery('simple', :vectorQuery)
                   OR lc.content_tsv @@ to_tsquery('simple', :keywordQuery)
-                  OR lc.content %% :vectorQuery )
+                  OR lc.content % CAST(:vectorQuery AS text) )
              ORDER BY score DESC
              LIMIT :topK
             """, nativeQuery = true)

--- a/src/main/java/org/example/shield/consultation/application/ChatTransactionalBoundary.java
+++ b/src/main/java/org/example/shield/consultation/application/ChatTransactionalBoundary.java
@@ -8,6 +8,7 @@ import org.example.shield.consultation.domain.ConsultationWriter;
 import org.example.shield.consultation.domain.Message;
 import org.example.shield.consultation.domain.MessageWriter;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
@@ -46,7 +47,7 @@ public class ChatTransactionalBoundary {
      * 사용자 입력은 절대 유실되지 않는다 (Issue #45 후속 — PR-A 의 noRollbackFor
      * 보다 한 단계 더 강력한 격리).</p>
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Message saveUserMessage(UUID consultationId, String content) {
         Message userMessage = Message.createUserMessage(consultationId, content);
         return messageWriter.save(userMessage);
@@ -55,7 +56,7 @@ public class ChatTransactionalBoundary {
     /**
      * PII 감지 시 AI 채널로 안내 메시지만 저장하는 독립 트랜잭션 경로.
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Message savePiiAiMessage(UUID consultationId, String message) {
         Message piiMessage = Message.createAiMessage(
                 consultationId, message, null, null, null, null);
@@ -70,7 +71,7 @@ public class ChatTransactionalBoundary {
      *
      * <p>AI 메시지 저장 · 분류 반영 · lastMessage 갱신은 수행하지 않는다.</p>
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void persistBlankResponseId(UUID consultationId, String responseId) {
         if (responseId == null || responseId.isBlank()) {
             return;
@@ -91,7 +92,7 @@ public class ChatTransactionalBoundary {
      * @param payload        AI 응답 처리 결과 (분류·메시지·메타)
      * @return 저장된 AI {@link Message}
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Message finalizeAiResponse(UUID consultationId, AiFinalizePayload payload) {
         Consultation consultation = consultationReader.findById(consultationId);
 

--- a/src/main/java/org/example/shield/consultation/application/MessageService.java
+++ b/src/main/java/org/example/shield/consultation/application/MessageService.java
@@ -87,10 +87,12 @@ public class MessageService {
      * {@code lastResponseId} 는 커밋되어야 한다. 그렇지 않으면 AI 실패
      * 시마다 사용자 입력이 유실되어 재현 가능한 데이터 손실이 발생한다.</p>
      *
-     * <p>ChatAiException 이외의 런타임 예외는 기존 기본 동작(전체 롤백)
-     * 을 유지하므로 RAG/Cohere 호출 실패는 그대로 롤백된다.</p>
+     * <p>이 메서드 자체는 트랜잭션을 열지 않는다 (클래스 javadoc 참조).
+     * DB 작업은 모두 {@link ChatTransactionalBoundary} 의 짧은 독립 트랜잭션으로 위임된다.
+     * 외부 호출(RAG/Cohere) 중 발생한 SQL 오류가 외부 트랜잭션을 rollback-only 로
+     * 만들어 후속 commit 단계에서 {@code UnexpectedRollbackException} 으로 500 응답을
+     * 유발하던 회귀를 방지하기 위함이다.</p>
      */
-    @Transactional(noRollbackFor = ChatAiException.class)
     public SendMessageResponse sendMessage(UUID consultationId, String content) {
         long pipelineStart = System.nanoTime();
         try {

--- a/src/test/java/org/example/shield/consultation/application/MessageServiceTest.java
+++ b/src/test/java/org/example/shield/consultation/application/MessageServiceTest.java
@@ -296,31 +296,30 @@ class MessageServiceTest {
                 .isEqualTo(1L);
     }
 
-    // ── Issue #45 후속 — @Transactional(noRollbackFor=ChatAiException) 회귀 테스트 ──
+    // ── sendMessage 트랜잭션 격리 회귀 테스트 ──
 
     /**
-     * {@link MessageService#sendMessage} 는 반드시
-     * {@code @Transactional(noRollbackFor = ChatAiException.class)} 로
-     * 지정되어 있어야 한다. 이 어노테이션이 제거되거나 속성이 누락되면
-     * AI blank 응답 시 USER 메시지와 {@code lastResponseId} 까지 롤백되어
-     * Issue #45 가 재발한다 (사용자 입력 유실).
+     * {@link MessageService#sendMessage} 는 어떠한 외부 트랜잭션도 열지 않아야 한다.
      *
-     * <p>통합 테스트로 실제 트랜잭션 동작을 검증하는 것이 이상적이지만,
-     * 현재 테스트 슬라이스는 단위 레벨이므로 어노테이션 계약을
-     * 명시적으로 고정해 회귀를 방지한다.</p>
+     * <p>이전에는 {@code @Transactional(noRollbackFor = ChatAiException.class)} 로
+     * Issue #45(USER 메시지 유실)를 막았으나, RAG/Cohere 단계에서 발생한 SQL 오류가
+     * 외부 트랜잭션을 rollback-only 로 마킹하면 후속 commit 시점에
+     * {@code UnexpectedRollbackException} 으로 500 응답이 발생하는 회귀가 확인됐다.
+     *
+     * <p>현재 설계는 USER/AI/PII 영속화를 모두 {@link ChatTransactionalBoundary} 의
+     * {@code REQUIRES_NEW} 트랜잭션에 위임하여 외부 tx 의 상태와 무관하게 독립
+     * 커밋되도록 하며, sendMessage 자체는 트랜잭션 경계를 가지지 않는다. 이 계약이
+     * 깨지면 다시 외부 tx poisoning 으로 500 이 발생하므로 어노테이션을 직접 검증한다.
      */
     @Test
-    @DisplayName("sendMessage 는 @Transactional(noRollbackFor = ChatAiException.class) 계약을 유지해야 한다 (Issue #45 회귀)")
-    void sendMessage_transactionalContract_noRollbackForChatAiException() throws NoSuchMethodException {
+    @DisplayName("sendMessage 는 @Transactional 을 가지면 안 된다 (외부 tx poisoning 으로 인한 500 회귀 방지)")
+    void sendMessage_transactionalContract_noOuterTransaction() throws NoSuchMethodException {
         Method method = MessageService.class.getDeclaredMethod("sendMessage", UUID.class, String.class);
         Transactional annotation = method.getAnnotation(Transactional.class);
 
         assertThat(annotation)
-                .as("sendMessage 에 @Transactional 이 지정되어 있어야 한다")
-                .isNotNull();
-        assertThat(annotation.noRollbackFor())
-                .as("noRollbackFor 에 ChatAiException 이 포함되어야 USER 메시지 유실이 방지된다")
-                .contains(ChatAiException.class);
+                .as("sendMessage 에 @Transactional 이 지정되면 RAG/Cohere SQL 오류가 외부 tx 를 rollback-only 로 만들어 500 이 발생한다")
+                .isNull();
     }
 
     /**


### PR DESCRIPTION
## Summary

운영 환경 챗봇 메시지 전송 시 발생하던 세 가지 결함을 한꺼번에 수정합니다.

1. **HTTP 500** (`UnexpectedRollbackException`) — 외부 tx poisoning
2. **RAG SQL 실패** — `pg_trgm` `%%` 연산자 에러로 매 호출마다 폴백
3. **분야명 매핑 누락** — 축약형 입력시 체크리스트/프롬프트 적용 안 됨

## 재현 및 진단

EC2 로그(`/api/consultations/{id}/messages` 호출)에서 다음 순서로 문제가 발생:

```
1) ERROR: operator does not exist: text %% unknown          ← #2
2) RAG 파이프라인 실패, 폴백 (RAG 없이 진행)                  ← #2 결과
3) WARN 지원하지 않는 L1 분야입니다: 부동산                    ← #3
4) WARN LLM attempted to override locked classification ...   ← 정상 동작
5) ERROR UnexpectedRollbackException ... rollback-only        ← #1 (500)
```

#2 의 SQL 실패가 외부 `@Transactional` 을 rollback-only 로 마킹 → #1 의 500 으로 표면화.
#3 은 RAG/체크리스트가 폴백되더라도 별도 warning 만 남기는 문제.

## 변경 내용

### #1 — 외부 트랜잭션 제거 (`MessageService.sendMessage`)
- 클래스 javadoc 이 명시하던 "non-transactional" 설계 의도와 일치시킴.
- `@Transactional(noRollbackFor = ChatAiException.class)` 어노테이션 제거.
- `ChatTransactionalBoundary` 4개 메서드 (`saveUserMessage`, `savePiiAiMessage`, `persistBlankResponseId`, `finalizeAiResponse`) 를 `Propagation.REQUIRES_NEW` 로 승격해 미래에 외부 tx 가 재도입돼도 USER / AI / PII 메시지가 독립 커밋 보장.
- 회귀 테스트 갱신: 어노테이션 *존재* 검증 → *부재* 검증으로 새 계약 고정.

### #2 — pg_trgm 연산자 escape 제거 + CAST 명시
- Spring Boot 4 / Hibernate 7 native query 에서 `%` 는 더 이상 escape 불필요. 코드의 `%%` 를 `%` 로 정정.
- `application.yml` 의 `stringtype=unspecified` 하에 바인드 파라미터가 `unknown` 타입으로 전달돼 PG 가 operator overload 분해에 실패할 가능성이 있어 `CAST(:vectorQuery AS text)` 명시.
- 영향 파일:
  - [LegalChunkJpaRepository.java](src/main/java/org/example/shield/ai/domain/LegalChunkJpaRepository.java) — 6곳
  - [LegalCaseJpaRepository.java](src/main/java/org/example/shield/ai/domain/LegalCaseJpaRepository.java) — 2곳

### #3 — L1 분야명 alias 매핑
- [ChecklistSlugMap](src/main/java/org/example/shield/ai/application/ChecklistSlugMap.java) 에 축약형 alias 표 추가.
- 8개 정식 L1 (`부동산 거래`, `이혼·위자료·재산분할`, …) 에 대응되는 일반적 축약형(`부동산`, `이혼`, `임대차`, `상속`, `채무`, `노동`, …) 약 30개 매핑.
- `slugFor` 는 정식 이름 매칭 실패 시 alias 표를 한 번 더 조회.
- 외부에서 정식 이름이 필요한 경우 `canonicalL1(name)` 헬퍼 추가.

## Test Plan

- [x] `./gradlew test` 전체 통과 (206 tests, 어노테이션 회귀 테스트도 새 계약으로 그린)
- [ ] **머지 후 운영 환경 검증**:
  - `POST /api/consultations/{id}/messages` 가 200 응답
  - EC2 로그에 `text %% unknown` 에러 미발생
  - 로그에 `RagPipelineService 실행 — vectorQuery=...` 형태로 정상 동작 표시
  - `부동산` 등 축약형 입력 시 `지원하지 않는 L1 분야입니다` warning 미발생

## 효과

- 사용자가 챗봇 메시지 보낼 때 **500 에러 즉시 사라짐**.
- RAG 파이프라인이 실제로 동작 → AI 응답에 법령/판례 context 반영 (이전엔 RAG_STUB 와 동일 효과였음).
- 프론트 카테고리 축약형 입력에도 체크리스트/프롬프트 정상 적용.

## Out of Scope (별도 이슈 권장)

- 의뢰서 PATCH 응답에 수정된 brief 본문 전체 포함 (의뢰인 화면 갱신 이슈 BE 측 보강)
- 관리자 pending 목록 default status 필터 (승인된 변호사가 pending 에 잔존)
- 변호사 의뢰 24시간 자동 거절 + 응답에 `hoursRemaining` 필드
