### PR TITLE
[FEAT] 챗봇 메시지 응답에 상담 진행률 노출 (#88)

### DIFF
--- a/src/main/java/org/example/shield/consultation/application/MessageService.java
+++ b/src/main/java/org/example/shield/consultation/application/MessageService.java
@@ -113,7 +113,10 @@ public class MessageService {
             } catch (SanitizeService.PiiDetectedException e) {
                 Message savedPii = chatTxBoundary.savePiiAiMessage(consultationId, e.getMessage());
                 chatMetrics.recordSendMessage(pipelineStart, "pii");
-                return SendMessageResponse.from(savedPii, false);
+                // PII 거부 시 USER 메시지는 저장되지 않으므로 진행률 증가 없음
+                SendMessageResponse.Progress piiProgress =
+                        SendMessageResponse.Progress.of((int) existingUserTurns, maxUserTurns);
+                return SendMessageResponse.from(savedPii, false, piiProgress);
             }
 
             // 1. USER 메시지 저장 (독립 트랜잭션 — 후속 실패와 무관하게 보존)
@@ -208,7 +211,10 @@ public class MessageService {
                     consultationId, consultation, parsed, turnLimitReached);
 
             chatMetrics.recordSendMessage(pipelineStart, turnLimitReached ? "turn_limit_reached" : "success");
-            return SendMessageResponse.from(savedAi, effectiveAllCompleted);
+            // 방금 저장된 USER 메시지를 포함한 누적 턴 수로 진행률 계산
+            SendMessageResponse.Progress progress =
+                    SendMessageResponse.Progress.of((int) existingUserTurns + 1, maxUserTurns);
+            return SendMessageResponse.from(savedAi, effectiveAllCompleted, progress);
         } catch (ChatAiException | ConsultationTurnLimitExceededException e) {
             throw e; // already metered
         } catch (RuntimeException e) {

--- a/src/main/java/org/example/shield/consultation/controller/dto/SendMessageResponse.java
+++ b/src/main/java/org/example/shield/consultation/controller/dto/SendMessageResponse.java
@@ -7,6 +7,13 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * 메시지 전송 응답 (Issue #45 / Issue #88).
+ *
+ * <p>{@code progress} 는 의뢰인 화면에서 상담 진행률 표시(예: "3/10", 30%) 에 사용된다.
+ * 백엔드는 {@code max-user-turns} 상한과 방금 저장된 USER 턴 수를 기준으로 계산해
+ * 응답에 함께 내려준다. 자세한 계약은 {@link Progress} 참조.</p>
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record SendMessageResponse(
         UUID messageId,
@@ -14,7 +21,8 @@ public record SendMessageResponse(
         String content,
         LocalDateTime createdAt,
         boolean allCompleted,
-        Classification classification
+        Classification classification,
+        Progress progress
 ) {
     public static SendMessageResponse from(Message message, boolean allCompleted) {
         return new SendMessageResponse(
@@ -23,6 +31,7 @@ public record SendMessageResponse(
                 message.getContent(),
                 message.getCreatedAt(),
                 allCompleted,
+                null,
                 null
         );
     }
@@ -38,7 +47,37 @@ public record SendMessageResponse(
                 message.getContent(),
                 message.getCreatedAt(),
                 allCompleted,
-                classif
+                classif,
+                null
+        );
+    }
+
+    public static SendMessageResponse from(Message message, boolean allCompleted, Progress progress) {
+        return new SendMessageResponse(
+                message.getId(),
+                message.getRole().name(),
+                message.getContent(),
+                message.getCreatedAt(),
+                allCompleted,
+                null,
+                progress
+        );
+    }
+
+    public static SendMessageResponse from(Message message, boolean allCompleted,
+                                           List<String> primaryField, List<String> tags,
+                                           Progress progress) {
+        Classification classif = (allCompleted && primaryField != null)
+                ? new Classification(primaryField, tags)
+                : null;
+        return new SendMessageResponse(
+                message.getId(),
+                message.getRole().name(),
+                message.getContent(),
+                message.getCreatedAt(),
+                allCompleted,
+                classif,
+                progress
         );
     }
 
@@ -46,4 +85,24 @@ public record SendMessageResponse(
             List<String> primaryField,
             List<String> tags
     ) {}
+
+    /**
+     * 상담 진행률 (Issue #88).
+     *
+     * @param currentTurn     방금 저장한 USER 메시지 포함 누적 USER 턴 수 (1~maxTurns).
+     * @param maxTurns        설정된 USER 턴 상한 (현재 10).
+     * @param progressPercent {@code currentTurn * 100 / maxTurns} 정수 (10~100).
+     */
+    public record Progress(
+            int currentTurn,
+            int maxTurns,
+            int progressPercent
+    ) {
+        public static Progress of(int currentTurn, int maxTurns) {
+            int safeMax = Math.max(maxTurns, 1);
+            int clampedCurrent = Math.min(Math.max(currentTurn, 0), safeMax);
+            int percent = clampedCurrent * 100 / safeMax;
+            return new Progress(clampedCurrent, safeMax, percent);
+        }
+    }
 }

--- a/src/test/java/org/example/shield/consultation/application/MessageServiceTest.java
+++ b/src/test/java/org/example/shield/consultation/application/MessageServiceTest.java
@@ -453,4 +453,82 @@ class MessageServiceTest {
         assertThat(meterRegistry.timer(ChatMetrics.METRIC_SEND_MESSAGE, "outcome", "success").count())
                 .isEqualTo(1L);
     }
+
+    // ── Issue #88 — 상담 진행률 응답 필드 ─────────────────────────────────
+
+    /**
+     * 첫 USER 메시지 — 저장 후 누적 1턴이 되므로 progress = (1, 10, 10).
+     */
+    @Test
+    @DisplayName("첫 메시지 응답에 progress(1, 10, 10) 포함")
+    void sendMessage_firstTurn_progressIsTenPercent() {
+        given(messageReader.countByConsultationIdAndRole(consultationId, MessageRole.USER))
+                .willReturn(0L);
+
+        ChatParsedResponse parsed = new ChatParsedResponse();
+        parsed.setNextQuestion("어떤 상황이신가요?");
+        parsed.setAiDomains(List.of());
+        parsed.setAiSubDomains(List.of());
+        parsed.setAiTags(List.of());
+        given(cohereService.chat(any(), anyString(), anyString(), any()))
+                .willReturn(new AiCallResult<>("resp-first", parsed, 100, 42, 250));
+
+        SendMessageResponse response = messageService.sendMessage(consultationId, "첫 입력");
+
+        assertThat(response.progress()).isNotNull();
+        assertThat(response.progress().currentTurn()).isEqualTo(1);
+        assertThat(response.progress().maxTurns()).isEqualTo(10);
+        assertThat(response.progress().progressPercent()).isEqualTo(10);
+    }
+
+    /**
+     * 10번째 USER 메시지 — 진행률 100%.
+     */
+    @Test
+    @DisplayName("10번째 메시지 응답에 progress(10, 10, 100) 포함")
+    void sendMessage_lastTurn_progressIsHundredPercent() {
+        given(messageReader.countByConsultationIdAndRole(consultationId, MessageRole.USER))
+                .willReturn(9L);
+
+        ChatParsedResponse parsed = new ChatParsedResponse();
+        parsed.setNextQuestion("거의 끝났습니다.");
+        parsed.setAllCompleted(false);
+        parsed.setAiDomains(List.of());
+        parsed.setAiSubDomains(List.of());
+        parsed.setAiTags(List.of());
+        given(cohereService.chat(any(), anyString(), anyString(), any()))
+                .willReturn(new AiCallResult<>("resp-last", parsed, 100, 42, 250));
+
+        SendMessageResponse response = messageService.sendMessage(consultationId, "10번째 입력");
+
+        assertThat(response.progress()).isNotNull();
+        assertThat(response.progress().currentTurn()).isEqualTo(10);
+        assertThat(response.progress().maxTurns()).isEqualTo(10);
+        assertThat(response.progress().progressPercent()).isEqualTo(100);
+    }
+
+    /**
+     * PII 거부 분기 — USER 메시지가 저장되지 않으므로 progress 는 기존 turn 그대로(증가 없음).
+     */
+    @Test
+    @DisplayName("PII 거부 시 progress 는 기존 turn 그대로 유지 (증가 없음)")
+    void sendMessage_piiRejected_progressDoesNotIncrement() {
+        // 기존 3턴 완료된 상담에서 4번째 시도가 PII 로 거부됨
+        given(messageReader.countByConsultationIdAndRole(consultationId, MessageRole.USER))
+                .willReturn(3L);
+        given(sanitizeService.sanitizeUserText(anyString()))
+                .willThrow(new SanitizeService.PiiDetectedException("주민번호 감지"));
+        given(chatTxBoundary.savePiiAiMessage(eq(consultationId), anyString()))
+                .willAnswer(inv -> Message.createAiMessage(consultationId, inv.getArgument(1),
+                        null, null, null, null));
+
+        SendMessageResponse response = messageService.sendMessage(consultationId, "주민번호 1234");
+
+        assertThat(response.progress()).isNotNull();
+        assertThat(response.progress().currentTurn())
+                .as("PII 거부 시 USER 미저장 → 기존 3턴 유지")
+                .isEqualTo(3);
+        assertThat(response.progress().maxTurns()).isEqualTo(10);
+        assertThat(response.progress().progressPercent()).isEqualTo(30);
+    }
 }


### PR DESCRIPTION
## Summary

Closes #88

의뢰인 화면에서 상담 진행률 바를 표시할 수 있도록 메시지 전송 응답에 `progress` 객체를 추가한다. 백엔드는 내부 USER 턴 수 / `max-user-turns` 상한을 기반으로 `currentTurn / maxTurns / progressPercent` 를 계산해 함께 내려준다.

## 변경 내용

### 1. `SendMessageResponse.Progress` 신규 도입

```java
public record Progress(int currentTurn, int maxTurns, int progressPercent) {
    public static Progress of(int currentTurn, int maxTurns) { ... }
}
```

- 정적 팩토리 `Progress.of` 는 입력값을 `[0, maxTurns]` 범위로 클램프하고 `currentTurn * 100 / maxTurns` 로 정수 percent 를 계산. `maxTurns ≤ 0` 같은 비정상 입력도 1 로 보정해 ZeroDivision 방지.
- `SendMessageResponse` 는 기존 4개 `from(...)` 팩토리 오버로드에 progress 인자 버전 2개를 추가해 호환성 유지.

### 2. `MessageService.sendMessage` 에서 값 채우기

- 정상 경로: USER 메시지 저장 후 `(existingUserTurns + 1, maxUserTurns)` 로 진행률 계산.
- PII 거부 경로: USER 미저장이므로 `(existingUserTurns, maxUserTurns)` 로 기존 turn 유지 (증가 없음).

### 3. 테스트 갱신 (`MessageServiceTest`)

- 첫 메시지: `progress(1, 10, 10)`
- 10번째 메시지: `progress(10, 10, 100)`
- PII 거부 후: `progress(3, 10, 30)` (3턴 완료된 상담에서 4번째 PII → 3 그대로)

## Test Plan

- [x] `./gradlew test` 전체 통과 (회귀 없음 + 신규 progress 검증 3건 그린)
- [ ] 머지 후 운영 환경에서 `POST /api/consultations/{id}/messages` 응답에 `progress` 객체가 포함되는지 검증
  - 예: 첫 메시지 응답이 `{ ..., "progress": { "currentTurn": 1, "maxTurns": 10, "progressPercent": 10 } }` 형태인지

## 영향 범위

- 프론트엔드(SHIELD_FE)는 응답에 새 필드가 추가된 것이라 **기존 동작은 그대로 유지**. 점진적 도입 가능.
- `@JsonInclude(NON_NULL)` 로 인해 `progress` 가 null 이면 직렬화되지 않음 — 다만 정상 흐름에서는 항상 채워져 내려간다.

## Out of Scope

- 프론트엔드 진행률 바 UI 구현 (SHIELD_FE 별도 작업)
- `GET /api/consultations/{id}` 단건 조회 응답에 progress 포함 (페이지 새로고침 복원용) — 필요 시 별도 이슈
- 체크리스트 커버리지 기반 정확한 진행률 (옵션 B) — 시연용은 턴 기반으로 충분

## 시급도

🟢 시연 직전 UX 보강. 작업량 작고 기존 동작에 영향 없어 안전하게 머지 가능.
