### PR TITLE
[FEAT] 사용자 프로필 이미지 업로드·교체·삭제 API (#97)

### DIFF
--- a/src/main/java/org/example/shield/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/shield/common/exception/ErrorCode.java
@@ -65,6 +65,11 @@ public enum ErrorCode {
     DOCUMENT_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기가 10MB를 초과합니다"),
     DOCUMENT_TYPE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다"),
 
+    // Profile Image (Issue #97)
+    PROFILE_IMAGE_EMPTY(HttpStatus.BAD_REQUEST, "이미지 파일이 비어 있습니다"),
+    PROFILE_IMAGE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "프로필 이미지 크기는 5MB 이하여야 합니다"),
+    PROFILE_IMAGE_TYPE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 형식입니다 (JPEG/PNG/WEBP 만 허용)"),
+
     // AI
     CHAT_AI_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "AI 응답 생성에 실패했습니다"),
 

--- a/src/main/java/org/example/shield/common/storage/StorageClient.java
+++ b/src/main/java/org/example/shield/common/storage/StorageClient.java
@@ -2,8 +2,32 @@ package org.example.shield.common.storage;
 
 import org.springframework.web.multipart.MultipartFile;
 
+/**
+ * 객체 스토리지 추상화.
+ *
+ * <p>기본 메서드들은 단일 default 버킷({@code supabase.storage.bucket}, 변호사 자격증명용)
+ * 을 대상으로 동작한다. 프로필 이미지처럼 별도 버킷이 필요한 경우 {@code *To} 시리즈 메서드로
+ * 명시적 bucket 을 지정한다.</p>
+ */
 public interface StorageClient {
+    /** Default 버킷에 업로드. 기존 호출부와의 호환 유지용. */
     String upload(String path, MultipartFile file);
+
+    /** Default 버킷의 객체 삭제. */
     void delete(String path);
+
+    /** Default 버킷의 객체에 대한 signed URL 발급. */
     String getSignedUrl(String path, int expiresInSeconds);
+
+    /** 지정 버킷에 업로드 (Issue #97 — 프로필 이미지 별도 버킷 지원). */
+    String uploadTo(String bucket, String path, MultipartFile file);
+
+    /** 지정 버킷의 객체 삭제. */
+    void deleteFrom(String bucket, String path);
+
+    /**
+     * 지정 public 버킷의 객체에 대한 공개 URL 을 반환한다.
+     * 버킷이 public 으로 설정되어 있어야 의미가 있다.
+     */
+    String getPublicUrl(String bucket, String path);
 }

--- a/src/main/java/org/example/shield/common/storage/SupabaseStorageClient.java
+++ b/src/main/java/org/example/shield/common/storage/SupabaseStorageClient.java
@@ -16,15 +16,17 @@ import java.util.Map;
 public class SupabaseStorageClient implements StorageClient {
 
     private final WebClient webClient;
-    private final String bucket;
+    private final String defaultBucket;
     private final String baseUrl;
+    private final String publicBaseUrl;
 
     public SupabaseStorageClient(
             @Value("${supabase.url}") String supabaseUrl,
             @Value("${supabase.service-role-key}") String serviceRoleKey,
-            @Value("${supabase.storage.bucket}") String bucket) {
-        this.bucket = bucket;
+            @Value("${supabase.storage.bucket}") String defaultBucket) {
+        this.defaultBucket = defaultBucket;
         this.baseUrl = supabaseUrl + "/storage/v1";
+        this.publicBaseUrl = supabaseUrl + "/storage/v1/object/public";
         this.webClient = WebClient.builder()
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + serviceRoleKey)
                 .defaultHeader("apikey", serviceRoleKey)
@@ -33,6 +35,29 @@ public class SupabaseStorageClient implements StorageClient {
 
     @Override
     public String upload(String path, MultipartFile file) {
+        return uploadTo(defaultBucket, path, file);
+    }
+
+    @Override
+    public void delete(String path) {
+        deleteFrom(defaultBucket, path);
+    }
+
+    @Override
+    public String getSignedUrl(String path, int expiresInSeconds) {
+        Map<String, Object> response = webClient.post()
+                .uri(URI.create(baseUrl + "/object/sign/" + defaultBucket + "/" + path))
+                .bodyValue(Map.of("expiresIn", expiresInSeconds))
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+
+        String signedUrl = (String) response.get("signedURL");
+        return baseUrl + signedUrl;
+    }
+
+    @Override
+    public String uploadTo(String bucket, String path, MultipartFile file) {
         try {
             byte[] fileBytes = file.getBytes();
             String contentType = file.getContentType() != null ? file.getContentType() : "application/octet-stream";
@@ -54,7 +79,7 @@ public class SupabaseStorageClient implements StorageClient {
     }
 
     @Override
-    public void delete(String path) {
+    public void deleteFrom(String bucket, String path) {
         webClient.delete()
                 .uri(URI.create(baseUrl + "/object/" + bucket + "/" + path))
                 .retrieve()
@@ -65,15 +90,7 @@ public class SupabaseStorageClient implements StorageClient {
     }
 
     @Override
-    public String getSignedUrl(String path, int expiresInSeconds) {
-        Map<String, Object> response = webClient.post()
-                .uri(URI.create(baseUrl + "/object/sign/" + bucket + "/" + path))
-                .bodyValue(Map.of("expiresIn", expiresInSeconds))
-                .retrieve()
-                .bodyToMono(Map.class)
-                .block();
-
-        String signedUrl = (String) response.get("signedURL");
-        return baseUrl + signedUrl;
+    public String getPublicUrl(String bucket, String path) {
+        return publicBaseUrl + "/" + bucket + "/" + path;
     }
 }

--- a/src/main/java/org/example/shield/user/application/ProfileImageService.java
+++ b/src/main/java/org/example/shield/user/application/ProfileImageService.java
@@ -1,0 +1,143 @@
+package org.example.shield.user.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.shield.common.exception.BusinessException;
+import org.example.shield.common.exception.ErrorCode;
+import org.example.shield.common.storage.StorageClient;
+import org.example.shield.user.controller.dto.ProfileImageResponse;
+import org.example.shield.user.domain.User;
+import org.example.shield.user.domain.UserReader;
+import org.example.shield.user.domain.UserWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 프로필 이미지 업로드/교체/삭제 서비스 (Issue #97).
+ *
+ * <p>저장소 정책:</p>
+ * <ul>
+ *   <li>버킷: {@code supabase.storage.profile-bucket} (기본 {@code profile_images}).
+ *       Supabase 콘솔에서 Public 으로 설정되어 있어야 반환되는 URL 이 직접 접근 가능하다.</li>
+ *   <li>객체 경로: {@code {userId}/{uuid}.{ext}} — 사용자별 폴더로 격리.</li>
+ *   <li>기존 이미지가 있으면 새 업로드 성공 후 best-effort 로 이전 객체를 삭제한다.
+ *       삭제 실패는 신규 업로드 결과에 영향 주지 않는다 (잔여 객체는 후속 정리).</li>
+ * </ul>
+ *
+ * <p>검증 정책:</p>
+ * <ul>
+ *   <li>빈 파일 거부.</li>
+ *   <li>크기 상한 5MB.</li>
+ *   <li>허용 MIME: {@code image/jpeg}, {@code image/png}, {@code image/webp}.</li>
+ * </ul>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProfileImageService {
+
+    private static final long MAX_FILE_SIZE = 5L * 1024 * 1024;
+
+    /** MIME → 파일 확장자 매핑. 허용 목록은 이 맵의 key set 으로 정의된다. */
+    private static final Map<String, String> ALLOWED_MIME_TO_EXT = Map.of(
+            "image/jpeg", "jpg",
+            "image/png", "png",
+            "image/webp", "webp"
+    );
+
+    private final StorageClient storageClient;
+    private final UserReader userReader;
+    private final UserWriter userWriter;
+
+    @Value("${supabase.storage.profile-bucket:profile_images}")
+    private String profileBucket;
+
+    /**
+     * 새 프로필 이미지 업로드 (또는 교체).
+     *
+     * @return 새로 저장된 공개 URL 을 담은 응답.
+     */
+    @Transactional
+    public ProfileImageResponse upload(UUID userId, MultipartFile file) {
+        validate(file);
+
+        User user = userReader.findById(userId);
+        String previousUrl = user.getProfileImageUrl();
+
+        String ext = ALLOWED_MIME_TO_EXT.get(file.getContentType());
+        String storagePath = userId + "/" + UUID.randomUUID() + "." + ext;
+
+        // 새 파일을 먼저 업로드한 뒤에 기존 객체를 정리한다 (장애 격리).
+        storageClient.uploadTo(profileBucket, storagePath, file);
+        String publicUrl = storageClient.getPublicUrl(profileBucket, storagePath);
+
+        user.updateProfileImageUrl(publicUrl);
+        userWriter.save(user);
+
+        if (previousUrl != null && !previousUrl.isBlank()) {
+            tryDeleteByPublicUrl(previousUrl);
+        }
+
+        log.info("프로필 이미지 업로드 완료. userId={}, path={}", userId, storagePath);
+        return ProfileImageResponse.of(publicUrl);
+    }
+
+    /**
+     * 프로필 이미지 제거. 기존 이미지가 있으면 객체도 best-effort 로 삭제.
+     */
+    @Transactional
+    public ProfileImageResponse delete(UUID userId) {
+        User user = userReader.findById(userId);
+        String previousUrl = user.getProfileImageUrl();
+
+        if (previousUrl == null || previousUrl.isBlank()) {
+            return ProfileImageResponse.cleared();
+        }
+
+        user.clearProfileImageUrl();
+        userWriter.save(user);
+        tryDeleteByPublicUrl(previousUrl);
+
+        log.info("프로필 이미지 삭제 완료. userId={}", userId);
+        return ProfileImageResponse.cleared();
+    }
+
+    private void validate(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new BusinessException(ErrorCode.PROFILE_IMAGE_EMPTY) {};
+        }
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new BusinessException(ErrorCode.PROFILE_IMAGE_SIZE_EXCEEDED) {};
+        }
+        String mime = file.getContentType();
+        if (mime == null || !ALLOWED_MIME_TO_EXT.containsKey(mime.toLowerCase())) {
+            throw new BusinessException(ErrorCode.PROFILE_IMAGE_TYPE_NOT_SUPPORTED) {};
+        }
+    }
+
+    /**
+     * 공개 URL 에서 객체 경로를 복원해 삭제 시도. 외부 URL(예: 카카오 프로필)이거나
+     * 경로 추출 실패 시 조용히 skip 한다 — 사용자 흐름에 영향 없어야 함.
+     */
+    private void tryDeleteByPublicUrl(String publicUrl) {
+        try {
+            String marker = "/object/public/" + profileBucket + "/";
+            int idx = publicUrl.indexOf(marker);
+            if (idx < 0) {
+                log.debug("이전 프로필 이미지 URL 이 우리 버킷 경로가 아님 — 삭제 skip: {}", publicUrl);
+                return;
+            }
+            String path = publicUrl.substring(idx + marker.length());
+            storageClient.deleteFrom(profileBucket, path);
+        } catch (Exception e) {
+            log.warn("이전 프로필 이미지 삭제 실패 (best-effort, 사용자 흐름 영향 없음): url={}, err={}",
+                    publicUrl, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/example/shield/user/controller/UserController.java
+++ b/src/main/java/org/example/shield/user/controller/UserController.java
@@ -4,15 +4,21 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.shield.common.response.ApiResponse;
+import org.example.shield.user.application.ProfileImageService;
 import org.example.shield.user.application.UserService;
+import org.example.shield.user.controller.dto.ProfileImageResponse;
 import org.example.shield.user.controller.dto.UserResponse;
 import org.example.shield.user.controller.dto.UserUpdateRequest;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
 
@@ -23,6 +29,7 @@ import java.util.UUID;
 public class UserController {
 
     private final UserService userService;
+    private final ProfileImageService profileImageService;
 
     @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자 정보 조회")
     @GetMapping("/me")
@@ -39,5 +46,25 @@ public class UserController {
             @RequestBody UserUpdateRequest request) {
         UserResponse response = userService.updateMyInfo(userId, request);
         return ApiResponse.success("수정 완료", response);
+    }
+
+    @Operation(
+            summary = "프로필 이미지 업로드/교체",
+            description = "JPEG/PNG/WEBP, 5MB 이하. 기존 이미지가 있으면 새 이미지로 교체된다 (Issue #97)."
+    )
+    @PostMapping(value = "/me/profile-image", consumes = "multipart/form-data")
+    public ApiResponse<ProfileImageResponse> uploadProfileImage(
+            @AuthenticationPrincipal UUID userId,
+            @RequestPart("file") MultipartFile file) {
+        ProfileImageResponse response = profileImageService.upload(userId, file);
+        return ApiResponse.success("프로필 이미지가 업로드되었습니다", response);
+    }
+
+    @Operation(summary = "프로필 이미지 삭제", description = "프로필 이미지를 제거하고 기본 상태로 복귀시킨다 (Issue #97).")
+    @DeleteMapping("/me/profile-image")
+    public ApiResponse<ProfileImageResponse> deleteProfileImage(
+            @AuthenticationPrincipal UUID userId) {
+        ProfileImageResponse response = profileImageService.delete(userId);
+        return ApiResponse.success("프로필 이미지가 삭제되었습니다", response);
     }
 }

--- a/src/main/java/org/example/shield/user/controller/dto/ProfileImageResponse.java
+++ b/src/main/java/org/example/shield/user/controller/dto/ProfileImageResponse.java
@@ -1,0 +1,16 @@
+package org.example.shield.user.controller.dto;
+
+/**
+ * 프로필 이미지 업로드/삭제 응답 (Issue #97).
+ *
+ * <p>삭제 응답에서는 {@code profileImageUrl} 가 null 로 내려간다.</p>
+ */
+public record ProfileImageResponse(String profileImageUrl) {
+    public static ProfileImageResponse of(String url) {
+        return new ProfileImageResponse(url);
+    }
+
+    public static ProfileImageResponse cleared() {
+        return new ProfileImageResponse(null);
+    }
+}

--- a/src/main/java/org/example/shield/user/domain/User.java
+++ b/src/main/java/org/example/shield/user/domain/User.java
@@ -93,6 +93,24 @@ public class User {
     }
 
     /**
+     * 프로필 이미지 URL 설정/교체 (Issue #97). 호출자는 빈 문자열을 넘기지 말 것 — 삭제는
+     * {@link #clearProfileImageUrl()} 를 사용한다.
+     */
+    public void updateProfileImageUrl(String profileImageUrl) {
+        if (profileImageUrl == null || profileImageUrl.isBlank()) {
+            throw new IllegalArgumentException("profileImageUrl must not be blank — use clearProfileImageUrl() to remove");
+        }
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    /**
+     * 프로필 이미지 URL 제거 (Issue #97). null 로 복귀.
+     */
+    public void clearProfileImageUrl() {
+        this.profileImageUrl = null;
+    }
+
+    /**
      * 소셜 로그인으로 가입한 일반 유저(USER)가 변호사 추가정보 입력을 완료했을 때
      * 역할을 LAWYER 로 승격시킨다. 이미 LAWYER/ADMIN 인 경우에는 변경하지 않는다.
      */

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -115,11 +115,15 @@ kakao:
   redirect-uri: ${KAKAO_REDIRECT_URI:https://shieldai.kr/auth/kakao/callback}
 
 # Supabase Storage
+# - bucket          : 변호사 자격증명 등 비공개 문서 저장 버킷 (signed URL 사용)
+# - profile-bucket  : 프로필 이미지 저장 버킷. public 으로 설정해 사용 (Issue #97).
+#                     Supabase 콘솔에서 미리 bucket 생성 + Public 토글 ON 필요.
 supabase:
   url: ${SUPABASE_URL}
   service-role-key: ${SUPABASE_SERVICE_ROLE_KEY}
   storage:
     bucket: lawyer_documents
+    profile-bucket: ${SUPABASE_PROFILE_BUCKET:profile_images}
 
 # Firebase Cloud Messaging
 firebase:

--- a/src/test/java/org/example/shield/user/application/ProfileImageServiceTest.java
+++ b/src/test/java/org/example/shield/user/application/ProfileImageServiceTest.java
@@ -1,0 +1,183 @@
+package org.example.shield.user.application;
+
+import org.example.shield.common.enums.UserRole;
+import org.example.shield.common.exception.BusinessException;
+import org.example.shield.common.storage.StorageClient;
+import org.example.shield.user.controller.dto.ProfileImageResponse;
+import org.example.shield.user.domain.User;
+import org.example.shield.user.domain.UserReader;
+import org.example.shield.user.domain.UserWriter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProfileImageServiceTest {
+
+    private static final String BUCKET = "profile_images";
+
+    @Mock private StorageClient storageClient;
+    @Mock private UserReader userReader;
+    @Mock private UserWriter userWriter;
+
+    @InjectMocks private ProfileImageService service;
+
+    private UUID userId;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(service, "profileBucket", BUCKET);
+        userId = UUID.randomUUID();
+        user = User.builder()
+                .email("test@shield.local")
+                .name("테스트")
+                .role(UserRole.USER)
+                .provider("DEV")
+                .googleId("dev-" + UUID.randomUUID())
+                .build();
+        given(userReader.findById(userId)).willReturn(user);
+        given(userWriter.save(any(User.class))).willAnswer(inv -> inv.getArgument(0));
+        given(storageClient.getPublicUrl(eq(BUCKET), anyString()))
+                .willAnswer(inv -> "https://supa/storage/v1/object/public/" + BUCKET + "/" + inv.getArgument(1));
+    }
+
+    @Test
+    @DisplayName("정상 PNG 업로드 → 새 URL 저장 + 이전 이미지 없으면 delete 호출 안 함")
+    void upload_validPng_persistsNewUrl() {
+        MultipartFile file = pngFile(1024);
+
+        ProfileImageResponse response = service.upload(userId, file);
+
+        assertThat(response.profileImageUrl()).startsWith("https://supa/storage/v1/object/public/" + BUCKET + "/" + userId);
+        assertThat(response.profileImageUrl()).endsWith(".png");
+        assertThat(user.getProfileImageUrl()).isEqualTo(response.profileImageUrl());
+        verify(storageClient, times(1)).uploadTo(eq(BUCKET), anyString(), eq(file));
+        verify(userWriter, times(1)).save(user);
+        verify(storageClient, never()).deleteFrom(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("기존 이미지가 있는 사용자가 새 이미지 업로드 → 새 URL 저장 + 이전 객체 best-effort 삭제")
+    void upload_replacesExisting() {
+        String prev = "https://supa/storage/v1/object/public/" + BUCKET + "/" + userId + "/old-uuid.jpg";
+        user.updateProfileImageUrl(prev);
+
+        ProfileImageResponse response = service.upload(userId, jpegFile(1024));
+
+        assertThat(response.profileImageUrl()).isNotEqualTo(prev);
+        assertThat(user.getProfileImageUrl()).isEqualTo(response.profileImageUrl());
+        verify(storageClient, times(1)).deleteFrom(BUCKET, userId + "/old-uuid.jpg");
+    }
+
+    @Test
+    @DisplayName("이전 객체 삭제 실패해도 신규 업로드는 성공 처리 (best-effort)")
+    void upload_previousDeletionFailureIsSwallowed() {
+        String prev = "https://supa/storage/v1/object/public/" + BUCKET + "/" + userId + "/old-uuid.jpg";
+        user.updateProfileImageUrl(prev);
+        willThrow(new RuntimeException("supabase 5xx")).given(storageClient)
+                .deleteFrom(eq(BUCKET), anyString());
+
+        ProfileImageResponse response = service.upload(userId, jpegFile(1024));
+
+        assertThat(response.profileImageUrl()).isNotEqualTo(prev);
+        assertThat(user.getProfileImageUrl()).isEqualTo(response.profileImageUrl());
+    }
+
+    @Test
+    @DisplayName("외부 URL (예: 카카오 프로필) 이 기존 값이면 삭제 시도 skip — 우리 버킷 경로 아님")
+    void upload_previousExternalUrl_skipsDeletion() {
+        user.updateProfileImageUrl("https://k.kakaocdn.net/some/avatar.jpg");
+
+        service.upload(userId, pngFile(1024));
+
+        verify(storageClient, never()).deleteFrom(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("빈 파일 → PROFILE_IMAGE_EMPTY 400")
+    void upload_emptyFile_rejected() {
+        MultipartFile empty = new MockMultipartFile("file", "x.png", "image/png", new byte[0]);
+
+        assertThatThrownBy(() -> service.upload(userId, empty))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("비어");
+
+        verify(storageClient, never()).uploadTo(anyString(), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("5MB 초과 → PROFILE_IMAGE_SIZE_EXCEEDED 400")
+    void upload_oversize_rejected() {
+        MultipartFile big = pngFile(5 * 1024 * 1024 + 1);
+
+        assertThatThrownBy(() -> service.upload(userId, big))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("5MB");
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 MIME (예: gif) → PROFILE_IMAGE_TYPE_NOT_SUPPORTED 400")
+    void upload_disallowedMime_rejected() {
+        MultipartFile gif = new MockMultipartFile("file", "anim.gif", "image/gif", new byte[]{0x47, 0x49, 0x46});
+
+        assertThatThrownBy(() -> service.upload(userId, gif))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("이미지 형식");
+    }
+
+    @Test
+    @DisplayName("이미지가 있는 사용자 delete → 필드 null + 객체 삭제 호출")
+    void delete_existingImage_clearsAndDeletes() {
+        String prev = "https://supa/storage/v1/object/public/" + BUCKET + "/" + userId + "/cur.webp";
+        user.updateProfileImageUrl(prev);
+
+        ProfileImageResponse response = service.delete(userId);
+
+        assertThat(response.profileImageUrl()).isNull();
+        assertThat(user.getProfileImageUrl()).isNull();
+        verify(storageClient, times(1)).deleteFrom(BUCKET, userId + "/cur.webp");
+        verify(userWriter, times(1)).save(user);
+    }
+
+    @Test
+    @DisplayName("이미지가 없는 사용자 delete → 객체 삭제 호출 없이 cleared 응답")
+    void delete_noImage_noop() {
+        ProfileImageResponse response = service.delete(userId);
+
+        assertThat(response.profileImageUrl()).isNull();
+        verify(storageClient, never()).deleteFrom(anyString(), anyString());
+        verify(userWriter, never()).save(any());
+    }
+
+    private MultipartFile pngFile(int size) {
+        return new MockMultipartFile("file", "p.png", "image/png", new byte[size]);
+    }
+
+    private MultipartFile jpegFile(int size) {
+        return new MockMultipartFile("file", "p.jpg", "image/jpeg", new byte[size]);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #97

`User.profileImageUrl` 컬럼과 응답 DTO 는 이미 존재했으나 이를 채우는 백엔드 로직이 전혀 없어 항상 null 로 내려가던 문제를 해결한다. 변호사·일반 사용자 모두 자신의 프로필 이미지를 업로드·교체·삭제할 수 있는 REST API 를 추가한다.

## 변경 내용

### 1. 도메인

- `User.updateProfileImageUrl(url)` / `User.clearProfileImageUrl()` 도메인 메서드 추가
- blank 입력 시 IllegalArgumentException 던져 호출자 실수 방지

### 2. 스토리지 추상화

기존 `StorageClient` 는 단일 default 버킷(`supabase.storage.bucket = lawyer_documents`) 에 묶여 있었다. 호환을 깨지 않고 multi-bucket 지원을 추가했다:

- `uploadTo(bucket, path, file)` / `deleteFrom(bucket, path)` / `getPublicUrl(bucket, path)` 메서드 시리즈 추가
- 기존 `upload(path, file)` / `delete(path)` / `getSignedUrl(path, expires)` 는 그대로 동작 (default 버킷 위임)
- `SupabaseStorageClient` 가 두 시리즈 모두 구현 + public URL 생성 헬퍼 추가

### 3. 서비스 — `ProfileImageService`

- **Validate**: 빈 파일 거부, 5MB 상한, MIME 화이트리스트(`image/jpeg`, `image/png`, `image/webp`)
- **Path**: `{userId}/{uuid}.{ext}` — 사용자별 폴더 격리
- **순서**: 새 파일 업로드 성공 → User 갱신 → 이전 객체 best-effort 삭제. 이전 객체 삭제 실패해도 신규 업로드 성공 처리 (잔여 객체는 후속 cleanup 으로)
- 이전 URL 이 우리 버킷 경로가 아니면 (예: 카카오 프로필 URL) 삭제 skip

### 4. 컨트롤러

| Method | Path | Body |
|---|---|---|
| `POST` | `/api/users/me/profile-image` | `multipart/form-data` `file` |
| `DELETE` | `/api/users/me/profile-image` | (없음) |

응답: `ProfileImageResponse { profileImageUrl }` — 삭제 시 null 반환.

### 5. 에러 코드 (3종 추가)

- `PROFILE_IMAGE_EMPTY` (400)
- `PROFILE_IMAGE_SIZE_EXCEEDED` (400)
- `PROFILE_IMAGE_TYPE_NOT_SUPPORTED` (400)

### 6. 설정

```yaml
supabase:
  storage:
    bucket: lawyer_documents
    profile-bucket: ${SUPABASE_PROFILE_BUCKET:profile_images}
```

## 운영 사전 작업 (배포 전 필수)

1. Supabase 콘솔 → Storage → 새 버킷 `profile_images` 생성
2. 해당 버킷의 **Public toggle ON** (반환되는 URL 이 직접 접근 가능해야 함)
3. (선택) EC2 env 에 `SUPABASE_PROFILE_BUCKET` 추가 — 기본값 `profile_images` 라 안 해도 됨

## Test Plan

- [x] `./gradlew test` 전체 통과 (회귀 없음)
- [x] `ProfileImageServiceTest` 9건 그린:
  - 정상 PNG 업로드 → 새 URL 저장
  - 기존 이미지 교체 시 이전 객체 삭제
  - 이전 객체 삭제 실패 → 신규 업로드 성공 격리
  - 외부 URL (카카오 등) 이전 값 → 삭제 skip
  - 빈 파일 → 400
  - 5MB 초과 → 400
  - 비허용 MIME (gif) → 400
  - 이미지 있는 사용자 delete → 필드 null + 객체 삭제
  - 이미지 없는 사용자 delete → no-op
- [ ] **머지 후 운영 검증**: Supabase 버킷 생성 + Public 설정 → 실제 업로드 → `GET /api/users/me` 응답에 `profileImageUrl` 노출 확인

## Out of Scope

- OAuth 가입 시 provider 프로필 이미지 자동 매핑 (Naver `profile_image`, Kakao 등) — 별도 이슈
- 이미지 리사이징/썸네일 생성 — 별도 이슈
- 변호사 자격증명 문서 업로드 (기존 `/api/lawyers/me/documents`) — 영향 없음

## 시급도

🟡 시연 직전 안정성 위급은 아니나, 변호사 프로필 카드가 시연 화면 핵심이라 시각적 완성도에 영향. 머지 후 프론트(이총명) 측 작업으로 이어진다.
