### PR TITLE
[FIX] ConsultationResponse 에 allCompleted 영구 노출 (#100)

### DIFF
--- a/src/main/java/org/example/shield/consultation/application/ChatTransactionalBoundary.java
+++ b/src/main/java/org/example/shield/consultation/application/ChatTransactionalBoundary.java
@@ -146,4 +146,18 @@ public class ChatTransactionalBoundary {
 
         return savedAi;
     }
+
+    /**
+     * allCompleted 게이트가 true 를 반환했을 때 영구 저장 (Issue #100).
+     * Idempotent — 이미 true 면 no-op.
+     * 별도 짧은 트랜잭션으로 분리해 외부 API 호출 동안 DB 점유를 피한다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markConsultationAllCompleted(UUID consultationId) {
+        Consultation consultation = consultationReader.findById(consultationId);
+        if (!consultation.isAllCompleted()) {
+            consultation.markAllCompleted();
+            consultationWriter.save(consultation);
+        }
+    }
 }

--- a/src/main/java/org/example/shield/consultation/application/MessageService.java
+++ b/src/main/java/org/example/shield/consultation/application/MessageService.java
@@ -244,6 +244,11 @@ public class MessageService {
             boolean effectiveAllCompleted = evaluateAllCompletedGate(
                     consultationId, consultation, parsed, turnLimitReached);
 
+            // 8. allCompleted=true 시 영구 저장 — 페이지 재진입 복원용 (Issue #100, idempotent)
+            if (effectiveAllCompleted) {
+                chatTxBoundary.markConsultationAllCompleted(consultationId);
+            }
+
             chatMetrics.recordSendMessage(pipelineStart, turnLimitReached ? "turn_limit_reached" : "success");
             // 방금 저장된 USER 메시지를 포함한 누적 턴 수로 진행률 계산
             SendMessageResponse.Progress progress =

--- a/src/main/java/org/example/shield/consultation/controller/dto/ConsultationResponse.java
+++ b/src/main/java/org/example/shield/consultation/controller/dto/ConsultationResponse.java
@@ -20,7 +20,9 @@ public record ConsultationResponse(
         String lastMessage,
         LocalDateTime lastMessageAt,
         LocalDateTime createdAt,
-        BriefSummary brief
+        BriefSummary brief,
+        /** AI 사실관계 수집 완료 여부 (Issue #100). FE 의 의뢰서 생성 버튼 노출 복원용. */
+        boolean allCompleted
 ) {
     public record BriefSummary(UUID briefId, String title, String status) {}
 
@@ -39,7 +41,8 @@ public record ConsultationResponse(
                 consultation.getLastMessage(),
                 consultation.getLastMessageAt(),
                 consultation.getCreatedAt(),
-                brief
+                brief,
+                consultation.isAllCompleted()
         );
     }
 }

--- a/src/main/java/org/example/shield/consultation/domain/Consultation.java
+++ b/src/main/java/org/example/shield/consultation/domain/Consultation.java
@@ -79,6 +79,15 @@ public class Consultation extends BaseEntity {
     @Column(columnDefinition = "text")
     private String lastResponseId;
 
+    /**
+     * AI 가 사실관계 수집을 완료했는지 여부 (Issue #100, V16 마이그레이션).
+     * MessageService.evaluateAllCompletedGate 가 true 를 반환한 시점에 영구 저장되며,
+     * 한 번 true 가 되면 다시 false 로 돌리지 않는다 (idempotent).
+     * FE 가 GET /consultations/{id} 응답으로 의뢰서 생성 버튼 노출 여부를 복원하는 데 사용한다.
+     */
+    @Column(name = "all_completed", nullable = false)
+    private boolean allCompleted = false;
+
     @Version
     @Column(name = "version", nullable = false)
     private Long version;
@@ -153,6 +162,16 @@ public class Consultation extends BaseEntity {
 
     public void updateSlotState(SlotLedger slotState) {
         this.slotState = slotState;
+    }
+
+    /**
+     * AI 사실관계 수집 완료 시 호출. Idempotent — 한 번 true 면 다시 호출돼도 변화 없음.
+     * MessageService.evaluateAllCompletedGate 결과가 true 일 때 호출된다 (Issue #100).
+     */
+    public void markAllCompleted() {
+        if (!this.allCompleted) {
+            this.allCompleted = true;
+        }
     }
 
     /**

--- a/src/main/resources/db/migration/V16__add_all_completed_to_consultations.sql
+++ b/src/main/resources/db/migration/V16__add_all_completed_to_consultations.sql
@@ -1,0 +1,10 @@
+-- V16: consultations.all_completed 컬럼 추가 (Issue #100)
+--
+-- MessageService.evaluateAllCompletedGate 의 결과를 영구 저장하여
+-- 페이지 재진입(GET /consultations/{id}) 시 의뢰서 생성 버튼 활성화 상태를
+-- 복원할 수 있도록 한다. 한 번 true 가 되면 idempotent (다시 false 로 돌리지 않음).
+ALTER TABLE consultations
+ADD COLUMN IF NOT EXISTS all_completed BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN consultations.all_completed IS
+    'AI 가 사실관계 수집을 완료했는지 여부 (영구 저장). MessageService 의 allCompleted 게이트 true 시점에 설정.';


### PR DESCRIPTION
Closes #100

## Summary
- 사용자가 채팅에서 \`allCompleted=true\` 도달 후 로그아웃→재로그인 시 의뢰서 생성 버튼이 사라지던 문제 수정.
- \`allCompleted\` 를 \`Consultation\` 엔티티에 영구 저장하고 \`ConsultationResponse\` 로 노출.

## Changes
- **V16 migration**: \`consultations.all_completed BOOLEAN NOT NULL DEFAULT FALSE\`
- **Consultation.java**: \`allCompleted\` 필드 + \`markAllCompleted()\` (idempotent — 한 번 true 면 no-op)
- **ChatTransactionalBoundary.java**: \`markConsultationAllCompleted(UUID)\` — REQUIRES_NEW 짧은 tx
- **MessageService.java**: \`evaluateAllCompletedGate=true\` 시 위 메서드 호출 (외부 API tx 밖)
- **ConsultationResponse.java**: \`boolean allCompleted\` 필드 노출

## Test plan
- [ ] V16 migration apply 확인
- [ ] 새 상담 생성 → all_completed=false
- [ ] sendMessage 여러 턴 → evaluateAllCompletedGate=true 도달 시 all_completed=true 로 변경
- [ ] GET /api/consultations/{id} 응답에 \`allCompleted: true\` 포함
- [ ] 같은 상담에 추가 sendMessage 호출 시에도 idempotent (변화 없음)
- [x] \`./gradlew compileJava\` 통과

## FE 측 동반 작업
SHIELD_FE 에서 \`useConsultationDetail\` 로 \`consultation.allCompleted\` 를 읽어 ChatPage 진입 시 \`setAllCompleted(true)\` 호출하도록 수정 예정 (별도 PR).