### PR TITLE
fix: /analyze 시 분류 충돌(409) 자동 해소 — AI 분류 우선 동기화

### DIFF
--- a/src/main/java/org/example/shield/consultation/controller/ConsultationController.java
+++ b/src/main/java/org/example/shield/consultation/controller/ConsultationController.java
@@ -120,6 +120,8 @@ public class ConsultationController {
 
         // P0-IV 멱등성 가드: 원자적 상태 전이 COLLECTING → ANALYZING
         Consultation consultation = consultationReader.findById(consultationId);
+        // Issue #102: AI 분류 우선 정책 — conflict 자동 해소를 위해 user 분류를 AI 결과로 동기화
+        consultation.syncUserClassificationWithAi();
         if (classificationResolver.resolve(consultation).conflict()) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
                     .body(ApiResponse.error("분류 확인이 필요합니다"));

--- a/src/main/java/org/example/shield/consultation/domain/Consultation.java
+++ b/src/main/java/org/example/shield/consultation/domain/Consultation.java
@@ -147,6 +147,19 @@ public class Consultation extends BaseEntity {
         this.aiTags = null;
     }
 
+    /**
+     * AI 분류 결과를 user 분류에 동기화 (AI 우선 정책, Issue #102).
+     * /analyze 진입 시 ClassificationResolver 의 conflict 를 자동 해소하기 위해 사용.
+     * ai_* 중 하나라도 값이 있으면 user_* 를 ai_* 로 덮어쓴다. ai_* 가 모두 null/empty 이면 no-op.
+     */
+    public void syncUserClassificationWithAi() {
+        boolean aiHasAny = isNonEmpty(aiDomains) || isNonEmpty(aiSubDomains) || isNonEmpty(aiTags);
+        if (!aiHasAny) return;
+        this.userDomains = aiDomains;
+        this.userSubDomains = aiSubDomains;
+        this.userTags = aiTags;
+    }
+
     public void updateLastResponseId(String responseId) {
         this.lastResponseId = responseId;
     }


### PR DESCRIPTION
Closes #102

## Summary
- 의뢰서 생성(`POST /consultations/{id}/analyze`) 시 user/ai 분류 불일치로 거의 모든 상담에서 발생하던 `409 분류 확인이 필요합니다` 에러를 해소
- AI 분류 우선 정책 — 대화 중 AI 가 정제한 분류가 더 정확하다는 전제

## Changes
- `Consultation.syncUserClassificationWithAi()` 도메인 메서드 추가 (멱등)
  - `ai_*` 중 하나라도 non-empty 면 `user_*` 를 `ai_*` 로 덮어쓰기
  - `ai_*` 가 모두 null/empty 면 no-op
- `ConsultationController.analyze()` 에서 conflict 체크 전에 sync 호출

## Test plan
- [ ] AI 분류 ≠ user 분류 인 상담에서 `/analyze` 호출 → 200 (이전: 409)
- [ ] AI 분류 = user 분류 인 상담에서 `/analyze` 호출 → 200 (regression)
- [ ] AI 분류가 모두 null 인 상담에서 `/analyze` 호출 → 기존 동작 그대로
- [ ] 이미 ANALYZING/ANALYZED 상태인 상담은 409 (기존 멱등성 가드 유지)

## Background
이전에는 SQL 핫픽스로 `UPDATE consultations SET user_domains = ai_domains ...` 직접 실행해 응급 대응. 매번 발생하므로 정식 해결책 도입.