### PR TITLE
fix: OpenAI classify 응답을 String 으로 받아 ObjectMapper 로 파싱

### DIFF
--- a/src/main/java/org/example/shield/ai/infrastructure/OpenAiClassifyClient.java
+++ b/src/main/java/org/example/shield/ai/infrastructure/OpenAiClassifyClient.java
@@ -1,6 +1,7 @@
 package org.example.shield.ai.infrastructure;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.example.shield.ai.config.OpenAiApiConfig;
 import org.example.shield.ai.dto.AiCallResult;
@@ -28,19 +29,22 @@ public class OpenAiClassifyClient {
     private final WebClient openAiWebClient;
     private final OpenAiApiConfig config;
     private final AiRagOperationalMetrics operationalMetrics;
+    private final ObjectMapper objectMapper;
 
     public OpenAiClassifyClient(@Qualifier("openAiWebClient") WebClient openAiWebClient,
                                 OpenAiApiConfig config) {
-        this(openAiWebClient, config, null);
+        this(openAiWebClient, config, null, new ObjectMapper());
     }
 
     @Autowired
     public OpenAiClassifyClient(@Qualifier("openAiWebClient") WebClient openAiWebClient,
                                 OpenAiApiConfig config,
-                                AiRagOperationalMetrics operationalMetrics) {
+                                AiRagOperationalMetrics operationalMetrics,
+                                ObjectMapper objectMapper) {
         this.openAiWebClient = openAiWebClient;
         this.config = config;
         this.operationalMetrics = operationalMetrics;
+        this.objectMapper = objectMapper;
     }
 
     public AiCallResult<String> callRawJson(List<CohereChatRequest.Message> messages) {
@@ -52,19 +56,23 @@ public class OpenAiClassifyClient {
         Map<String, Object> request = buildRequest(messages);
 
         try {
-            JsonNode response = openAiWebClient.post()
+            // Issue #104: Spring Boot 4 Jackson 3 가 구 JsonNode 추상 타입을 deserialize 못해서
+            // 일단 String 으로 받은 뒤 ObjectMapper 로 JsonNode 변환.
+            String responseBody = openAiWebClient.post()
                     .uri("/v1/chat/completions")
                     .bodyValue(request)
                     .retrieve()
-                    .bodyToMono(JsonNode.class)
+                    .bodyToMono(String.class)
                     .timeout(Duration.ofMillis(config.getClassifyReadTimeout()))
                     .retryWhen(Retry.backoff(3, Duration.ofSeconds(1))
                             .filter(this::isRetryable))
                     .block();
 
-            if (response == null) {
+            if (responseBody == null || responseBody.isBlank()) {
                 throw new AnalysisFailedException("OpenAI classify API response is null");
             }
+
+            JsonNode response = objectMapper.readTree(responseBody);
 
             String contentJson = response.path("choices")
                     .path(0)


### PR DESCRIPTION
Closes #104

## Summary
- Spring Boot 4 의 Jackson 3 가 구 `com.fasterxml.jackson.databind.JsonNode` 추상 타입을 deserialize 하지 못해 OpenAI 분류 호출이 100% 실패하던 문제 해결
- `bodyToMono(JsonNode.class)` → `bodyToMono(String.class)` + `ObjectMapper.readTree()` 직접 파싱

## Background
[OpenAiClassifyClient.java:59](https://github.com/capstoneSHIELD/SHIELD_BE/blob/develop/src/main/java/org/example/shield/ai/infrastructure/OpenAiClassifyClient.java#L59) 가 Spring 의 기본 Jackson decoder 를 통해 응답을 `JsonNode` 로 변환을 시도. 그러나 Jackson 3 (`tools.jackson.databind.*`) 가 구 `com.fasterxml.jackson.databind.JsonNode` 추상 타입에 대해 default constructor 가 없다며 `InvalidDefinitionException` 발생.

```
Caused by: tools.jackson.databind.exc.InvalidDefinitionException:
Cannot construct instance of `com.fasterxml.jackson.databind.JsonNode`
(no Creators, like default constructor, exist)
```

CohereClient 는 구체 클래스(`CohereChatResponse`)를 사용해 영향 없음.

## Impact (없음 ~ 매우 낮음)
- `callRawJson()` 시그니처/반환값 변경 없음 → 호출자 (`IntentClassificationService`) 수정 0
- 2-인자 생성자 유지 → 기존 단위 테스트 (`OpenAiClassifyClientTest`) 수정 불필요
- `ObjectMapper` 는 `CohereApiConfig` 가 이미 빈으로 등록 → 의존성 자동 주입
- Cohere 분류 경로 (`AI_CLASSIFY_PROVIDER=cohere`) 는 OpenAI 클라이언트를 거치지 않으므로 영향 없음

## Test plan
- [ ] `AI_CLASSIFY_PROVIDER=openai`, `OPENAI_CLASSIFY_MODEL=gpt-4o-mini`, `OPENAI_CLASSIFY_REASONING_EFFORT=` 설정 후 채팅 1회 → `OpenAI classify API call succeeded` 로그 확인
- [ ] `Type definition error` 사라짐
- [ ] `Intent classification failed, using fallback` 안 보임
- [ ] 분류 latency 가 약 1초로 측정됨 (이전: 6.2s with Cohere)
- [ ] Cohere 경로 (`AI_CLASSIFY_PROVIDER=cohere`) 에서는 기존 동작 유지

## Deployment note
머지 후 EC2 에 새 jar 배포 + `systemctl restart shield-backend` 필요. 환경변수 변경은 별도 없음.