### PR TITLE
fix: 의뢰 전달 후 24시간 경과 시 변호사 수락/거절 차단

### DIFF
--- a/src/main/java/org/example/shield/brief/application/DeliveryService.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryService.java
@@ -65,6 +65,11 @@ public class DeliveryService {
             throw new BusinessException(ErrorCode.DELIVERY_ALREADY_PROCESSED) {};
         }
 
+        // Issue #106: 24시간 응답 기한 경과 시 수락/거절 불가
+        if (delivery.isExpired()) {
+            throw new BusinessException(ErrorCode.DELIVERY_EXPIRED) {};
+        }
+
         // 1차 가드: 이미 다른 변호사가 수락한 의뢰서는 추가 수락 차단 (빠른 fail).
         // 2차 방어: Brief.@Version (낙관적 락), 3차 방어: deliveries partial unique index.
         if (status == DeliveryStatus.CONFIRMED

--- a/src/main/java/org/example/shield/brief/controller/dto/InboxDetailResponse.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/InboxDetailResponse.java
@@ -19,7 +19,9 @@ public record InboxDetailResponse(
         String status,
         String clientName,
         String clientEmail,
-        LocalDateTime sentAt
+        LocalDateTime sentAt,
+        /** 24시간 응답 기한 경과 여부 (Issue #106). */
+        boolean isExpired
 ) {
     public static InboxDetailResponse of(BriefDelivery delivery, Brief brief,
                                           String clientName, String clientEmail) {
@@ -34,7 +36,8 @@ public record InboxDetailResponse(
                 delivery.getStatus().name(),
                 clientName,
                 clientEmail,
-                delivery.getSentAt()
+                delivery.getSentAt(),
+                delivery.isExpired()
         );
     }
 }

--- a/src/main/java/org/example/shield/brief/controller/dto/InboxResponse.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/InboxResponse.java
@@ -12,7 +12,9 @@ public record InboxResponse(
         String briefTitle,
         String legalField,
         String status,
-        LocalDateTime sentAt
+        LocalDateTime sentAt,
+        /** 24시간 응답 기한 경과 여부 (Issue #106). FE 가 수락 버튼 비활성화 등에 사용. */
+        boolean isExpired
 ) {
     public static InboxResponse of(BriefDelivery delivery, Brief brief) {
         return new InboxResponse(
@@ -21,7 +23,8 @@ public record InboxResponse(
                 brief.getTitle(),
                 brief.getLegalField(),
                 delivery.getStatus().name(),
-                delivery.getSentAt()
+                delivery.getSentAt(),
+                delivery.isExpired()
         );
     }
 }

--- a/src/main/java/org/example/shield/brief/domain/BriefDelivery.java
+++ b/src/main/java/org/example/shield/brief/domain/BriefDelivery.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.shield.common.enums.DeliveryStatus;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -22,6 +23,12 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BriefDelivery {
+
+    /**
+     * 의뢰서 전달 후 변호사가 응답할 수 있는 기간 (Issue #106).
+     * 이 시간 경과 후에는 수락/거절이 모두 불가능.
+     */
+    public static final Duration RESPONSE_WINDOW = Duration.ofHours(24);
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -68,12 +75,27 @@ public class BriefDelivery {
         }
     }
 
+    /**
+     * 24시간 응답 기한 경과 여부 (Issue #106).
+     * 이미 응답된 건은 false 반환 (응답 후에는 만료 개념이 의미 없음).
+     */
+    public boolean isExpired() {
+        if (this.status != DeliveryStatus.DELIVERED) return false;
+        return this.sentAt.plus(RESPONSE_WINDOW).isBefore(LocalDateTime.now());
+    }
+
     public void accept() {
+        if (isExpired()) {
+            throw new IllegalStateException("delivery_expired");
+        }
         this.status = DeliveryStatus.CONFIRMED;
         this.respondedAt = LocalDateTime.now();
     }
 
     public void reject(String reason) {
+        if (isExpired()) {
+            throw new IllegalStateException("delivery_expired");
+        }
         this.status = DeliveryStatus.REJECTED;
         this.rejectionReason = reason;
         this.respondedAt = LocalDateTime.now();

--- a/src/main/java/org/example/shield/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/shield/common/exception/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
     DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 전달 건입니다"),
     DELIVERY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 전달된 변호사입니다"),
     DELIVERY_ALREADY_PROCESSED(HttpStatus.CONFLICT, "이미 처리된 의뢰서입니다"),
+    DELIVERY_EXPIRED(HttpStatus.CONFLICT, "전달된 지 24시간이 지나 응답이 불가능합니다"),
 
     // Brief - Delivery
     BRIEF_NOT_CONFIRMED(HttpStatus.BAD_REQUEST, "의뢰서를 먼저 확정해 주세요"),


### PR DESCRIPTION
Closes #106

## Summary
- 24시간이 지난 의뢰도 변호사가 여전히 수락 가능했던 문제 해결
- BriefDelivery 도메인에 응답 기한 정의 (\`RESPONSE_WINDOW = Duration.ofHours(24)\`)
- accept()/reject() + DeliveryService 양쪽에 만료 가드 추가

## Changes

### Domain (BriefDelivery)
- \`RESPONSE_WINDOW\` 상수: \`Duration.ofHours(24)\`
- \`isExpired()\`: \`sentAt + 24h < now()\` 검사. DELIVERED 상태에서만 의미 있음
- \`accept()\` / \`reject()\`: 만료 시 \`IllegalStateException\`

### Service (DeliveryService.updateDeliveryStatus)
- DELIVERED 상태 체크 이후 \`isExpired()\` 추가 가드
- 만료 시 \`BusinessException(DELIVERY_EXPIRED)\` 변환 → 409 Conflict

### Error Code
- \`DELIVERY_EXPIRED(HttpStatus.CONFLICT, \"전달된 지 24시간이 지나 응답이 불가능합니다\")\`

### DTO
- \`InboxResponse\`, \`InboxDetailResponse\` 에 \`isExpired: boolean\` 필드 추가
- FE 가 만료 배지 + 수락 버튼 비활성화에 활용

## DB 영향
- 없음. \`sentAt\` 컬럼만으로 만료 시간 계산
- \`DeliveryStatus.EXPIRED\` enum 추가는 PostgreSQL \`ALTER TYPE ADD VALUE\` 제약으로 후속 작업
- 만료된 건도 status 는 여전히 \`DELIVERED\` — \`isExpired\` 필드로 별도 판별

## Test plan
- [ ] \`sentAt + 24h\` 가 지난 delivery → 수락 시도 → 409 \`DELIVERY_EXPIRED\`
- [ ] \`sentAt + 24h\` 가 지난 delivery → 거절 시도 → 409 \`DELIVERY_EXPIRED\`
- [ ] \`sentAt + 24h\` 이내 delivery → 정상 수락/거절
- [ ] InboxResponse 조회 시 \`isExpired\` 필드가 시간 기준으로 정확히 계산됨
- [ ] 이미 CONFIRMED/REJECTED 인 delivery 의 \`isExpired\` 는 false (만료 개념 부적용)

## Follow-up
- FE PR: 변호사 의뢰함 / 대시보드에서 \`isExpired=true\` 일 때 \"만료\" 배지 + 수락 버튼 비활성화 (별도 이슈)