### PR TITLE
fix: 분류 수정 시 Brief.legalField 도 함께 갱신

### DIFF
--- a/src/main/java/org/example/shield/brief/domain/Brief.java
+++ b/src/main/java/org/example/shield/brief/domain/Brief.java
@@ -106,6 +106,15 @@ public class Brief extends BaseEntity {
         this.strategy = strategy;
     }
 
+    /**
+     * 분류 수정 시 Brief 의 법률 분야도 함께 갱신 (Issue #108).
+     * Consultation.user_domains 변경에 연동.
+     */
+    public void updateLegalField(String legalField) {
+        if (legalField == null || legalField.isBlank()) return;
+        this.legalField = legalField;
+    }
+
     public void updatePrivacySetting(PrivacySetting privacySetting) {
         this.privacySetting = privacySetting;
     }

--- a/src/main/java/org/example/shield/consultation/application/ConsultationService.java
+++ b/src/main/java/org/example/shield/consultation/application/ConsultationService.java
@@ -2,6 +2,7 @@ package org.example.shield.consultation.application;
 
 import lombok.RequiredArgsConstructor;
 import org.example.shield.brief.domain.BriefReader;
+import org.example.shield.brief.domain.BriefWriter;
 import org.example.shield.common.response.PageResponse;
 import org.example.shield.consultation.controller.dto.ClassifyResponse;
 import org.example.shield.consultation.controller.dto.ConsultationResponse;
@@ -28,6 +29,7 @@ public class ConsultationService {
     private final ConsultationWriter consultationWriter;
     private final MessageWriter messageWriter;
     private final BriefReader briefReader;
+    private final BriefWriter briefWriter;
     private final ClassificationResolver classificationResolver;
 
     private static final String WELCOME_MESSAGE =
@@ -78,6 +80,15 @@ public class ConsultationService {
         Consultation consultation = consultationReader.findById(consultationId);
         consultation.updateUserClassification(domains, subDomains, tags);
         consultationWriter.save(consultation);
+
+        // Issue #108: 이미 생성된 Brief 가 있다면 legalField 도 동기화.
+        // Brief 가 아직 생성 전(분석 중) 인 경우는 no-op.
+        if (domains != null && !domains.isEmpty()) {
+            briefReader.findOptionalByConsultationId(consultationId).ifPresent(brief -> {
+                brief.updateLegalField(domains.get(0));
+                briefWriter.save(brief);
+            });
+        }
 
         return new ClassifyResponse(domains, subDomains, tags);
     }


### PR DESCRIPTION
Closes #108

## Summary
- 사용자가 AnalyzingPage 에서 분야를 변경해도 의뢰서 상세에 옛 분야가 그대로 표시되던 문제 해결
- \`ConsultationService.updateClassification()\` 에 Brief 동기화 로직 추가

## Changes
- \`Brief.updateLegalField(String)\` 도메인 메서드 추가 (null/blank no-op)
- \`ConsultationService\` 에 \`BriefWriter\` 의존성 주입
- \`updateClassification()\` 끝에 Brief 조회 후 동기화:
  \`\`\`java
  briefReader.findOptionalByConsultationId(consultationId).ifPresent(brief -> {
      brief.updateLegalField(domains.get(0));
      briefWriter.save(brief);
  });
  \`\`\`

## Test plan
- [ ] 분석 완료 후 Brief 가 생성된 상태에서 분류 수정 → 의뢰서 상세의 법률 분야가 즉시 변경됨
- [ ] 분석 중 (Brief 미생성) 에 분류 수정 → Brief 동기화 no-op (예외 없이 정상 종료)
- [ ] domains 가 비어있을 때 → Brief 동기화 안 함
- [ ] ClassifyResponse 반환값 변경 없음 (FE 영향 없음)

## 연관
- FE [#41 / PR #43](https://github.com/capstoneSHIELD/SHIELD_FE/pull/43) — 분류 수정 시 화면 즉시 반영 (UI 측 fix)
- 본 PR — Brief 데이터 동기화 (BE 측 fix). 둘 다 머지되어야 사용자 경험이 완전해짐