### PR TITLE
fix: 변호사 의뢰함 필터 카테고리 viewedAt 기반으로 재정의

### DIFF
--- a/src/main/java/org/example/shield/brief/application/DeliveryService.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryService.java
@@ -160,10 +160,17 @@ public class DeliveryService {
         return new DeliveryListResponse(responses);
     }
 
-    public PageResponse<InboxResponse> getInbox(UUID lawyerId, DeliveryStatus status, Pageable pageable) {
-        Page<BriefDelivery> deliveries = (status != null)
-                ? deliveryReader.findAllByLawyerIdAndStatus(lawyerId, status, pageable)
-                : deliveryReader.findAllByLawyerId(lawyerId, pageable);
+    public PageResponse<InboxResponse> getInbox(UUID lawyerId, InboxFilter filter, Pageable pageable) {
+        InboxFilter f = filter != null ? filter : InboxFilter.ALL;
+        Page<BriefDelivery> deliveries = switch (f) {
+            case ALL -> deliveryReader.findAllByLawyerId(lawyerId, pageable);
+            case NEW -> deliveryReader.findAllByLawyerIdAndStatusAndViewedAtIsNull(
+                    lawyerId, DeliveryStatus.DELIVERED, pageable);
+            case REVIEWING -> deliveryReader.findAllByLawyerIdAndStatusAndViewedAtIsNotNull(
+                    lawyerId, DeliveryStatus.DELIVERED, pageable);
+            case RESPONDED -> deliveryReader.findAllByLawyerIdAndStatusIn(
+                    lawyerId, List.of(DeliveryStatus.CONFIRMED, DeliveryStatus.REJECTED), pageable);
+        };
 
         List<UUID> briefIds = deliveries.getContent().stream()
                 .map(BriefDelivery::getBriefId).toList();

--- a/src/main/java/org/example/shield/brief/application/DeliveryService.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryService.java
@@ -186,11 +186,14 @@ public class DeliveryService {
     }
 
     public InboxStatsResponse getInboxStats(UUID lawyerId) {
+        long newCount = deliveryReader.countByLawyerIdAndStatusAndViewedAtIsNull(lawyerId, DeliveryStatus.DELIVERED);
+        long reviewing = deliveryReader.countByLawyerIdAndStatusAndViewedAtIsNotNull(lawyerId, DeliveryStatus.DELIVERED);
         Map<DeliveryStatus, Long> statusCountMap = deliveryReader.countGroupByStatus(lawyerId);
-        long pending = statusCountMap.getOrDefault(DeliveryStatus.DELIVERED, 0L);
         long confirmed = statusCountMap.getOrDefault(DeliveryStatus.CONFIRMED, 0L);
         long rejected = statusCountMap.getOrDefault(DeliveryStatus.REJECTED, 0L);
-        return new InboxStatsResponse(pending + confirmed + rejected, pending, confirmed, rejected);
+        long responded = confirmed + rejected;
+        long all = newCount + reviewing + responded;
+        return new InboxStatsResponse(all, newCount, reviewing, confirmed, rejected, responded);
     }
 
     @Transactional

--- a/src/main/java/org/example/shield/brief/application/InboxFilter.java
+++ b/src/main/java/org/example/shield/brief/application/InboxFilter.java
@@ -1,0 +1,8 @@
+package org.example.shield.brief.application;
+
+public enum InboxFilter {
+    ALL,
+    NEW,
+    REVIEWING,
+    RESPONDED
+}

--- a/src/main/java/org/example/shield/brief/controller/LawyerInboxController.java
+++ b/src/main/java/org/example/shield/brief/controller/LawyerInboxController.java
@@ -5,12 +5,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.shield.brief.application.DeliveryService;
+import org.example.shield.brief.application.InboxFilter;
 import org.example.shield.brief.controller.dto.DeliveryStatusRequest;
 import org.example.shield.brief.controller.dto.DeliveryStatusResponse;
 import org.example.shield.brief.controller.dto.InboxDetailResponse;
 import org.example.shield.brief.controller.dto.InboxResponse;
 import org.example.shield.brief.controller.dto.InboxStatsResponse;
-import org.example.shield.common.enums.DeliveryStatus;
 import org.example.shield.common.response.ApiResponse;
 import org.example.shield.common.response.PageResponse;
 import org.springframework.data.domain.PageRequest;
@@ -37,15 +37,15 @@ public class LawyerInboxController {
 
     private final DeliveryService deliveryService;
 
-    @Operation(summary = "수신 의뢰서 목록", description = "변호사에게 전달된 의뢰서 목록을 조회합니다. status 파라미터로 필터링 가능")
+    @Operation(summary = "수신 의뢰서 목록", description = "filter=ALL|NEW|REVIEWING|RESPONDED 로 필터링")
     @GetMapping
     public ApiResponse<PageResponse<InboxResponse>> getInbox(
             @AuthenticationPrincipal UUID lawyerId,
-            @RequestParam(required = false) DeliveryStatus status,
+            @RequestParam(defaultValue = "ALL") InboxFilter filter,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         Pageable pageable = PageRequest.of(page, Math.min(size, 100), Sort.by(Sort.Direction.DESC, "sentAt"));
-        PageResponse<InboxResponse> result = deliveryService.getInbox(lawyerId, status, pageable);
+        PageResponse<InboxResponse> result = deliveryService.getInbox(lawyerId, filter, pageable);
         return ApiResponse.success("조회 성공", result);
     }
 

--- a/src/main/java/org/example/shield/brief/controller/dto/InboxStatsResponse.java
+++ b/src/main/java/org/example/shield/brief/controller/dto/InboxStatsResponse.java
@@ -1,8 +1,10 @@
 package org.example.shield.brief.controller.dto;
 
 public record InboxStatsResponse(
-        long total,
-        long pending,
+        long all,
+        long newCount,
+        long reviewing,
         long confirmed,
-        long rejected
+        long rejected,
+        long responded
 ) {}

--- a/src/main/java/org/example/shield/brief/domain/BriefDeliveryReader.java
+++ b/src/main/java/org/example/shield/brief/domain/BriefDeliveryReader.java
@@ -13,6 +13,9 @@ public interface BriefDeliveryReader {
     List<BriefDelivery> findAllByBriefId(UUID briefId);
     Page<BriefDelivery> findAllByLawyerId(UUID lawyerId, Pageable pageable);
     Page<BriefDelivery> findAllByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status, Pageable pageable);
+    Page<BriefDelivery> findAllByLawyerIdAndStatusAndViewedAtIsNull(UUID lawyerId, DeliveryStatus status, Pageable pageable);
+    Page<BriefDelivery> findAllByLawyerIdAndStatusAndViewedAtIsNotNull(UUID lawyerId, DeliveryStatus status, Pageable pageable);
+    Page<BriefDelivery> findAllByLawyerIdAndStatusIn(UUID lawyerId, List<DeliveryStatus> statuses, Pageable pageable);
     boolean existsByBriefIdAndLawyerId(UUID briefId, UUID lawyerId);
     boolean existsByBriefIdAndStatus(UUID briefId, DeliveryStatus status);
     List<BriefDelivery> findAllByBriefIdInAndStatus(List<UUID> briefIds, DeliveryStatus status);

--- a/src/main/java/org/example/shield/brief/domain/BriefDeliveryReader.java
+++ b/src/main/java/org/example/shield/brief/domain/BriefDeliveryReader.java
@@ -20,4 +20,6 @@ public interface BriefDeliveryReader {
     boolean existsByBriefIdAndStatus(UUID briefId, DeliveryStatus status);
     List<BriefDelivery> findAllByBriefIdInAndStatus(List<UUID> briefIds, DeliveryStatus status);
     Map<DeliveryStatus, Long> countGroupByStatus(UUID lawyerId);
+    long countByLawyerIdAndStatusAndViewedAtIsNull(UUID lawyerId, DeliveryStatus status);
+    long countByLawyerIdAndStatusAndViewedAtIsNotNull(UUID lawyerId, DeliveryStatus status);
 }

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryReaderImpl.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryReaderImpl.java
@@ -43,6 +43,21 @@ public class BriefDeliveryReaderImpl implements BriefDeliveryReader {
     }
 
     @Override
+    public Page<BriefDelivery> findAllByLawyerIdAndStatusAndViewedAtIsNull(UUID lawyerId, DeliveryStatus status, Pageable pageable) {
+        return briefDeliveryRepository.findAllByLawyerIdAndStatusAndViewedAtIsNull(lawyerId, status, pageable);
+    }
+
+    @Override
+    public Page<BriefDelivery> findAllByLawyerIdAndStatusAndViewedAtIsNotNull(UUID lawyerId, DeliveryStatus status, Pageable pageable) {
+        return briefDeliveryRepository.findAllByLawyerIdAndStatusAndViewedAtIsNotNull(lawyerId, status, pageable);
+    }
+
+    @Override
+    public Page<BriefDelivery> findAllByLawyerIdAndStatusIn(UUID lawyerId, List<DeliveryStatus> statuses, Pageable pageable) {
+        return briefDeliveryRepository.findAllByLawyerIdAndStatusIn(lawyerId, statuses, pageable);
+    }
+
+    @Override
     public boolean existsByBriefIdAndLawyerId(UUID briefId, UUID lawyerId) {
         return briefDeliveryRepository.existsByBriefIdAndLawyerId(briefId, lawyerId);
     }

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryReaderImpl.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryReaderImpl.java
@@ -81,4 +81,14 @@ public class BriefDeliveryReaderImpl implements BriefDeliveryReader {
                         row -> (Long) row[1]
                 ));
     }
+
+    @Override
+    public long countByLawyerIdAndStatusAndViewedAtIsNull(UUID lawyerId, DeliveryStatus status) {
+        return briefDeliveryRepository.countByLawyerIdAndStatusAndViewedAtIsNull(lawyerId, status);
+    }
+
+    @Override
+    public long countByLawyerIdAndStatusAndViewedAtIsNotNull(UUID lawyerId, DeliveryStatus status) {
+        return briefDeliveryRepository.countByLawyerIdAndStatusAndViewedAtIsNotNull(lawyerId, status);
+    }
 }

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryRepository.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryRepository.java
@@ -23,4 +23,7 @@ public interface BriefDeliveryRepository extends JpaRepository<BriefDelivery, UU
 
     @Query("SELECT d.status, COUNT(d) FROM BriefDelivery d WHERE d.lawyerId = :lawyerId GROUP BY d.status")
     List<Object[]> countGroupByStatus(UUID lawyerId);
+
+    long countByLawyerIdAndStatusAndViewedAtIsNull(UUID lawyerId, DeliveryStatus status);
+    long countByLawyerIdAndStatusAndViewedAtIsNotNull(UUID lawyerId, DeliveryStatus status);
 }

--- a/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryRepository.java
+++ b/src/main/java/org/example/shield/brief/infrastructure/BriefDeliveryRepository.java
@@ -14,6 +14,9 @@ public interface BriefDeliveryRepository extends JpaRepository<BriefDelivery, UU
     List<BriefDelivery> findAllByBriefId(UUID briefId);
     Page<BriefDelivery> findAllByLawyerId(UUID lawyerId, Pageable pageable);
     Page<BriefDelivery> findAllByLawyerIdAndStatus(UUID lawyerId, DeliveryStatus status, Pageable pageable);
+    Page<BriefDelivery> findAllByLawyerIdAndStatusAndViewedAtIsNull(UUID lawyerId, DeliveryStatus status, Pageable pageable);
+    Page<BriefDelivery> findAllByLawyerIdAndStatusAndViewedAtIsNotNull(UUID lawyerId, DeliveryStatus status, Pageable pageable);
+    Page<BriefDelivery> findAllByLawyerIdAndStatusIn(UUID lawyerId, List<DeliveryStatus> statuses, Pageable pageable);
     boolean existsByBriefIdAndLawyerId(UUID briefId, UUID lawyerId);
     boolean existsByBriefIdAndStatus(UUID briefId, DeliveryStatus status);
     List<BriefDelivery> findAllByBriefIdInAndStatus(List<UUID> briefIds, DeliveryStatus status);


### PR DESCRIPTION
Closes #110

## Summary
의뢰함 4개 카테고리 의미 명확화 — viewedAt 활용.

| 라벨 | 매핑 |
|---|---|
| 전체 (ALL) | 모든 의뢰 |
| 신규 (NEW) | DELIVERED + viewedAt = null |
| 검토 중 (REVIEWING) | DELIVERED + viewedAt != null |
| 응답 완료 (RESPONDED) | CONFIRMED + REJECTED |

## Changes
- `InboxFilter` enum 신규
- `BriefDeliveryReader/Repository/Impl` 에 viewedAt + status-in 쿼리 메서드 3개 추가
- `DeliveryService.getInbox(lawyerId, InboxFilter, Pageable)` 시그니처 변경
- `LawyerInboxController` query param `status` → `filter`

## API
`GET /api/lawyer/inbox?filter=NEW|REVIEWING|RESPONDED|ALL`

기본값 ALL.

## FE 후속
- TABS 키를 NEW/REVIEWING/RESPONDED 로 변경
- 대시보드 카드 라우팅도 `?filter=...` 로 변경 필요