### PR TITLE
[FIX] InboxFilter 에 CONFIRMED/REJECTED 단일 status 필터 추가

### DIFF
--- a/src/main/java/org/example/shield/brief/application/DeliveryService.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryService.java
@@ -173,6 +173,10 @@ public class DeliveryService {
                     lawyerId, DeliveryStatus.DELIVERED, pageable);
             case REVIEWING -> deliveryReader.findAllByLawyerIdAndStatusAndViewedAtIsNotNull(
                     lawyerId, DeliveryStatus.DELIVERED, pageable);
+            case CONFIRMED -> deliveryReader.findAllByLawyerIdAndStatus(
+                    lawyerId, DeliveryStatus.CONFIRMED, pageable);
+            case REJECTED -> deliveryReader.findAllByLawyerIdAndStatus(
+                    lawyerId, DeliveryStatus.REJECTED, pageable);
             case RESPONDED -> deliveryReader.findAllByLawyerIdAndStatusIn(
                     lawyerId, List.of(DeliveryStatus.CONFIRMED, DeliveryStatus.REJECTED), pageable);
         };

--- a/src/main/java/org/example/shield/brief/application/InboxFilter.java
+++ b/src/main/java/org/example/shield/brief/application/InboxFilter.java
@@ -4,5 +4,7 @@ public enum InboxFilter {
     ALL,
     NEW,
     REVIEWING,
+    CONFIRMED,
+    REJECTED,
     RESPONDED
 }


### PR DESCRIPTION
Closes #112

## Summary
CasesPage(진행 중 사건) 가 `filter=CONFIRMED` 로 BE 를 호출하지만, PR #111 후 InboxFilter enum 에 ALL/NEW/REVIEWING/RESPONDED 만 있어 400 발생하던 문제 해결.

## Changes
- `InboxFilter` enum 에 CONFIRMED, REJECTED 추가
- `DeliveryService.getInbox` switch 에 두 케이스 추가
  - CONFIRMED → findAllByLawyerIdAndStatus(CONFIRMED)
  - REJECTED → findAllByLawyerIdAndStatus(REJECTED)

## 전체 필터 매핑

| filter | 매핑 |
|---|---|
| ALL | 전체 |
| NEW | DELIVERED + viewedAt=null |
| REVIEWING | DELIVERED + viewedAt!=null |
| CONFIRMED | 수락 (진행 중 사건용) |
| REJECTED | 거절 |
| RESPONDED | CONFIRMED + REJECTED |

## Test plan
- [ ] GET /api/lawyer/inbox?filter=CONFIRMED → 수락한 의뢰만 반환
- [ ] GET /api/lawyer/inbox?filter=REJECTED → 거절한 의뢰만 반환
- [ ] 기존 ALL/NEW/REVIEWING/RESPONDED regression 없음