### PR TITLE
[FEAT] OAuth redirect URI 동적 처리 (모바일 native 앱 지원)

### DIFF
--- a/src/main/java/org/example/shield/auth/application/AuthService.java
+++ b/src/main/java/org/example/shield/auth/application/AuthService.java
@@ -31,8 +31,8 @@ public class AuthService {
 
     public record LoginResult(LoginResponse response, String refreshToken) {}
 
-    public LoginResult googleLogin(String authorizationCode, String role) {
-        OAuthUserInfo userInfo = googleOAuthService.getUserInfo(authorizationCode);
+    public LoginResult googleLogin(String authorizationCode, String redirectUri, String role) {
+        OAuthUserInfo userInfo = googleOAuthService.getUserInfo(authorizationCode, redirectUri);
 
         // 신규 가입 여부를 구분하기 위해 조회 시점을 명시적으로 분리한다.
         var existing = userReader.findByGoogleId(userInfo.providerId());
@@ -73,8 +73,8 @@ public class AuthService {
     /**
      * Naver OAuth 로그인 (Issue #83). googleLogin 과 동일 구조, naverId 컬럼으로 user 식별.
      */
-    public LoginResult naverLogin(String authorizationCode, String role) {
-        OAuthUserInfo userInfo = naverOAuthService.getUserInfo(authorizationCode);
+    public LoginResult naverLogin(String authorizationCode, String redirectUri, String role) {
+        OAuthUserInfo userInfo = naverOAuthService.getUserInfo(authorizationCode, redirectUri);
 
         var existing = userReader.findByNaverId(userInfo.providerId());
         boolean isNewUser = existing.isEmpty();
@@ -110,8 +110,8 @@ public class AuthService {
     /**
      * Kakao OAuth 로그인. googleLogin/naverLogin 과 동일 구조, kakaoId 컬럼으로 user 식별.
      */
-    public LoginResult kakaoLogin(String authorizationCode, String role) {
-        OAuthUserInfo userInfo = kakaoOAuthService.getUserInfo(authorizationCode);
+    public LoginResult kakaoLogin(String authorizationCode, String redirectUri, String role) {
+        OAuthUserInfo userInfo = kakaoOAuthService.getUserInfo(authorizationCode, redirectUri);
 
         var existing = userReader.findByKakaoId(userInfo.providerId());
         boolean isNewUser = existing.isEmpty();

--- a/src/main/java/org/example/shield/auth/application/GoogleOAuthService.java
+++ b/src/main/java/org/example/shield/auth/application/GoogleOAuthService.java
@@ -14,7 +14,7 @@ public class GoogleOAuthService {
         this.oAuthClient = oAuthClient;
     }
 
-    public OAuthUserInfo getUserInfo(String authorizationCode) {
-        return oAuthClient.getUserInfo(authorizationCode);
+    public OAuthUserInfo getUserInfo(String authorizationCode, String redirectUri) {
+        return oAuthClient.getUserInfo(authorizationCode, redirectUri);
     }
 }

--- a/src/main/java/org/example/shield/auth/application/KakaoOAuthService.java
+++ b/src/main/java/org/example/shield/auth/application/KakaoOAuthService.java
@@ -20,7 +20,7 @@ public class KakaoOAuthService {
         this.oAuthClient = oAuthClient;
     }
 
-    public OAuthUserInfo getUserInfo(String authorizationCode) {
-        return oAuthClient.getUserInfo(authorizationCode);
+    public OAuthUserInfo getUserInfo(String authorizationCode, String redirectUri) {
+        return oAuthClient.getUserInfo(authorizationCode, redirectUri);
     }
 }

--- a/src/main/java/org/example/shield/auth/application/NaverOAuthService.java
+++ b/src/main/java/org/example/shield/auth/application/NaverOAuthService.java
@@ -20,7 +20,7 @@ public class NaverOAuthService {
         this.oAuthClient = oAuthClient;
     }
 
-    public OAuthUserInfo getUserInfo(String authorizationCode) {
-        return oAuthClient.getUserInfo(authorizationCode);
+    public OAuthUserInfo getUserInfo(String authorizationCode, String redirectUri) {
+        return oAuthClient.getUserInfo(authorizationCode, redirectUri);
     }
 }

--- a/src/main/java/org/example/shield/auth/controller/AuthController.java
+++ b/src/main/java/org/example/shield/auth/controller/AuthController.java
@@ -40,7 +40,7 @@ public class AuthController {
             @Valid @RequestBody GoogleLoginRequest request,
             HttpServletResponse response) {
         AuthService.LoginResult result = authService.googleLogin(
-                request.authorizationCode(), request.role());
+                request.authorizationCode(), request.redirectUri(), request.role());
 
         addRefreshTokenCookie(response, result.refreshToken());
         return ResponseEntity.ok(ApiResponse.success("로그인 성공", result.response()));
@@ -52,7 +52,7 @@ public class AuthController {
             @Valid @RequestBody NaverLoginRequest request,
             HttpServletResponse response) {
         AuthService.LoginResult result = authService.naverLogin(
-                request.authorizationCode(), request.role());
+                request.authorizationCode(), request.redirectUri(), request.role());
 
         addRefreshTokenCookie(response, result.refreshToken());
         return ResponseEntity.ok(ApiResponse.success("로그인 성공", result.response()));
@@ -64,7 +64,7 @@ public class AuthController {
             @Valid @RequestBody KakaoLoginRequest request,
             HttpServletResponse response) {
         AuthService.LoginResult result = authService.kakaoLogin(
-                request.authorizationCode(), request.role());
+                request.authorizationCode(), request.redirectUri(), request.role());
 
         addRefreshTokenCookie(response, result.refreshToken());
         return ResponseEntity.ok(ApiResponse.success("로그인 성공", result.response()));

--- a/src/main/java/org/example/shield/auth/controller/dto/GoogleLoginRequest.java
+++ b/src/main/java/org/example/shield/auth/controller/dto/GoogleLoginRequest.java
@@ -2,9 +2,18 @@ package org.example.shield.auth.controller.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
+/**
+ * Google OAuth 로그인 요청.
+ *
+ * <p>{@code redirectUri} 는 Issue #114 에서 추가된 필드로, 인터페이스 일관성을 위해
+ * Kakao/Naver 와 동일하게 받지만 현재 Google 클라이언트는 환경변수 redirect-uri 만 사용.
+ * Phase 2 에서 Google native SDK 또는 Android OAuth Client 도입 시 활용 예정.</p>
+ */
 public record GoogleLoginRequest(
         @NotBlank(message = "인증 코드는 필수입니다")
         String authorizationCode,
+
+        String redirectUri,
 
         String role
 ) {}

--- a/src/main/java/org/example/shield/auth/controller/dto/KakaoLoginRequest.java
+++ b/src/main/java/org/example/shield/auth/controller/dto/KakaoLoginRequest.java
@@ -4,10 +4,15 @@ import jakarta.validation.constraints.NotBlank;
 
 /**
  * Kakao OAuth 로그인 요청.
+ *
+ * <p>{@code redirectUri} 는 모바일 native 앱 지원 시 클라이언트가 사용한 redirect_uri 를
+ * 명시 전달하기 위한 필드 (Issue #114). 미지정 시 BE 의 기본 redirect_uri 사용.</p>
  */
 public record KakaoLoginRequest(
         @NotBlank(message = "인증 코드는 필수입니다")
         String authorizationCode,
+
+        String redirectUri,
 
         String role
 ) {}

--- a/src/main/java/org/example/shield/auth/controller/dto/NaverLoginRequest.java
+++ b/src/main/java/org/example/shield/auth/controller/dto/NaverLoginRequest.java
@@ -4,10 +4,15 @@ import jakarta.validation.constraints.NotBlank;
 
 /**
  * Naver OAuth 로그인 요청 (Issue #83).
+ *
+ * <p>{@code redirectUri} 는 모바일 native 앱 지원 시 클라이언트가 사용한 redirect_uri 를
+ * 명시 전달하기 위한 필드 (Issue #114). 미지정 시 BE 의 기본 redirect_uri 사용.</p>
  */
 public record NaverLoginRequest(
         @NotBlank(message = "인증 코드는 필수입니다")
         String authorizationCode,
+
+        String redirectUri,
 
         String role
 ) {}

--- a/src/main/java/org/example/shield/auth/domain/OAuthClient.java
+++ b/src/main/java/org/example/shield/auth/domain/OAuthClient.java
@@ -2,5 +2,5 @@ package org.example.shield.auth.domain;
 
 public interface OAuthClient {
 
-    OAuthUserInfo getUserInfo(String token);
+    OAuthUserInfo getUserInfo(String code, String redirectUri);
 }

--- a/src/main/java/org/example/shield/auth/infrastructure/GoogleOAuthClient.java
+++ b/src/main/java/org/example/shield/auth/infrastructure/GoogleOAuthClient.java
@@ -31,7 +31,11 @@ public class GoogleOAuthClient implements OAuthClient {
     }
 
     @Override
-    public OAuthUserInfo getUserInfo(String authorizationCode) {
+    public OAuthUserInfo getUserInfo(String authorizationCode, String redirectUri) {
+        // Phase 1 (Issue #114): Google 은 모바일 native OAuth 미지원 상태.
+        // redirectUri 매개변수는 인터페이스 통일을 위해 받지만 사용하지 않고 환경변수의
+        // 기본 redirect-uri 를 그대로 사용한다. Phase 2 에서 Google native SDK 또는
+        // Android OAuth Client 도입 시 활용 예정.
         String accessToken = exchangeCodeForToken(authorizationCode);
         return fetchUserInfo(accessToken);
     }

--- a/src/main/java/org/example/shield/auth/infrastructure/KakaoOAuthClient.java
+++ b/src/main/java/org/example/shield/auth/infrastructure/KakaoOAuthClient.java
@@ -15,6 +15,10 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /**
  * Kakao OAuth 2.0 클라이언트.
  *
@@ -27,6 +31,9 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
  *       {@code kakao-{providerId}@shield.local} 형태의 합성 이메일을 발급한다.
  *       비즈앱 전환 후에는 실제 이메일이 들어오므로 자연스럽게 전환된다.</li>
  * </ul>
+ *
+ * <p>Issue #114: 모바일 native 앱 지원을 위해 redirect_uri 를 동적으로 받고
+ * {@code allowed-redirect-uris} 화이트리스트로 검증한다.</p>
  */
 @Slf4j
 @Component("kakaoOAuthClient")
@@ -38,25 +45,43 @@ public class KakaoOAuthClient implements OAuthClient {
     private final WebClient webClient;
     private final String clientId;
     private final String clientSecret;
-    private final String redirectUri;
+    private final String defaultRedirectUri;
+    private final Set<String> allowedRedirectUris;
 
     public KakaoOAuthClient(
             @Value("${kakao.client-id}") String clientId,
             @Value("${kakao.client-secret}") String clientSecret,
-            @Value("${kakao.redirect-uri}") String redirectUri) {
+            @Value("${kakao.redirect-uri}") String defaultRedirectUri,
+            @Value("${kakao.allowed-redirect-uris}") String allowedRedirectUrisCsv) {
         this.webClient = WebClient.create();
         this.clientId = clientId;
         this.clientSecret = clientSecret;
-        this.redirectUri = redirectUri;
+        this.defaultRedirectUri = defaultRedirectUri;
+        this.allowedRedirectUris = Arrays.stream(allowedRedirectUrisCsv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     @Override
-    public OAuthUserInfo getUserInfo(String authorizationCode) {
-        String accessToken = exchangeCodeForToken(authorizationCode);
+    public OAuthUserInfo getUserInfo(String authorizationCode, String redirectUri) {
+        String resolvedRedirectUri = resolveRedirectUri(redirectUri);
+        String accessToken = exchangeCodeForToken(authorizationCode, resolvedRedirectUri);
         return fetchUserInfo(accessToken);
     }
 
-    private String exchangeCodeForToken(String authorizationCode) {
+    private String resolveRedirectUri(String requested) {
+        if (requested == null || requested.isBlank()) {
+            return defaultRedirectUri;
+        }
+        if (!allowedRedirectUris.contains(requested)) {
+            log.warn("Kakao OAuth: rejected redirect_uri='{}' (not in whitelist)", requested);
+            throw new OAuthFailedException(ErrorCode.OAUTH_INVALID_REDIRECT_URI);
+        }
+        return requested;
+    }
+
+    private String exchangeCodeForToken(String authorizationCode, String redirectUri) {
         try {
             MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
             form.add("grant_type", "authorization_code");

--- a/src/main/java/org/example/shield/auth/infrastructure/NaverOAuthClient.java
+++ b/src/main/java/org/example/shield/auth/infrastructure/NaverOAuthClient.java
@@ -11,6 +11,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /**
  * Naver OAuth 2.0 클라이언트 (Issue #83).
  *
@@ -19,6 +23,9 @@ import org.springframework.web.util.UriComponentsBuilder;
  *   <li>유저 정보: {@code https://openapi.naver.com/v1/nid/me}</li>
  *   <li>응답 구조: {@code { resultcode, message, response: { id, email, name, ... } }}</li>
  * </ul>
+ *
+ * <p>Issue #114: 모바일 native 앱 지원을 위해 redirect_uri 를 동적으로 받고
+ * {@code allowed-redirect-uris} 화이트리스트로 검증한다.</p>
  */
 @Slf4j
 @Component("naverOAuthClient")
@@ -30,25 +37,43 @@ public class NaverOAuthClient implements OAuthClient {
     private final WebClient webClient;
     private final String clientId;
     private final String clientSecret;
-    private final String redirectUri;
+    private final String defaultRedirectUri;
+    private final Set<String> allowedRedirectUris;
 
     public NaverOAuthClient(
             @Value("${naver.client-id}") String clientId,
             @Value("${naver.client-secret}") String clientSecret,
-            @Value("${naver.redirect-uri}") String redirectUri) {
+            @Value("${naver.redirect-uri}") String defaultRedirectUri,
+            @Value("${naver.allowed-redirect-uris}") String allowedRedirectUrisCsv) {
         this.webClient = WebClient.create();
         this.clientId = clientId;
         this.clientSecret = clientSecret;
-        this.redirectUri = redirectUri;
+        this.defaultRedirectUri = defaultRedirectUri;
+        this.allowedRedirectUris = Arrays.stream(allowedRedirectUrisCsv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     @Override
-    public OAuthUserInfo getUserInfo(String authorizationCode) {
-        String accessToken = exchangeCodeForToken(authorizationCode);
+    public OAuthUserInfo getUserInfo(String authorizationCode, String redirectUri) {
+        String resolvedRedirectUri = resolveRedirectUri(redirectUri);
+        String accessToken = exchangeCodeForToken(authorizationCode, resolvedRedirectUri);
         return fetchUserInfo(accessToken);
     }
 
-    private String exchangeCodeForToken(String authorizationCode) {
+    private String resolveRedirectUri(String requested) {
+        if (requested == null || requested.isBlank()) {
+            return defaultRedirectUri;
+        }
+        if (!allowedRedirectUris.contains(requested)) {
+            log.warn("Naver OAuth: rejected redirect_uri='{}' (not in whitelist)", requested);
+            throw new OAuthFailedException(ErrorCode.OAUTH_INVALID_REDIRECT_URI);
+        }
+        return requested;
+    }
+
+    private String exchangeCodeForToken(String authorizationCode, String redirectUri) {
         try {
             String url = UriComponentsBuilder.fromUriString(TOKEN_URI)
                     .queryParam("grant_type", "authorization_code")

--- a/src/main/java/org/example/shield/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/shield/common/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     // Auth - OAuth
     OAUTH_CODE_INVALID(HttpStatus.UNAUTHORIZED, "OAuth 인증 코드가 유효하지 않습니다"),
     OAUTH_USER_INFO_FAILED(HttpStatus.UNAUTHORIZED, "OAuth 사용자 정보 조회에 실패했습니다"),
+    OAUTH_INVALID_REDIRECT_URI(HttpStatus.BAD_REQUEST, "허용되지 않은 redirect URI 입니다"),
 
     // Auth - Role
     INVALID_ROLE(HttpStatus.BAD_REQUEST, "유효하지 않은 역할입니다 (USER, LAWYER, ADMIN)"),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -100,19 +100,25 @@ google:
 # Naver OAuth (Issue #83)
 # 테스트/로컬에서 env 미설정 시에도 컨텍스트 로드되도록 기본값 제공.
 # 운영 환경(EC2)에는 실제 NAVER_* 환경변수가 주입됨.
+# allowed-redirect-uris: 클라이언트가 보낸 redirect_uri 화이트리스트 (Issue #114).
+#   카카오/네이버 정책상 redirect URI 는 https 만 받으므로, 모바일 native 도 https URL 을 사용.
+#   `-mobile` suffix 페이지가 받은 code 를 shield:// scheme deep link 로 native 앱에 전달.
 naver:
   client-id: ${NAVER_CLIENT_ID:dummy-naver-client-id}
   client-secret: ${NAVER_CLIENT_SECRET:dummy-naver-secret}
   redirect-uri: ${NAVER_REDIRECT_URI:https://shieldai.kr/auth/naver/callback}
+  allowed-redirect-uris: ${NAVER_ALLOWED_REDIRECT_URIS:https://shieldai.kr/auth/naver/callback,https://shieldai.kr/auth/naver/callback-mobile,https://localhost:5174/auth/naver/callback}
 
 # Kakao OAuth
 # - client-id: 카카오 개발자 콘솔의 REST API 키 (NOT JavaScript 키)
 # - client-secret: '카카오 로그인' > '보안' 에서 발급 + 활성화 (선택이지만 보안상 권장)
 # - redirect-uri: 콘솔의 'Redirect URI' 와 정확히 일치해야 함
+# - allowed-redirect-uris: 클라이언트가 보낸 redirect_uri 화이트리스트 (Issue #114).
 kakao:
   client-id: ${KAKAO_REST_API_KEY:dummy-kakao-rest-api-key}
   client-secret: ${KAKAO_CLIENT_SECRET:dummy-kakao-secret}
   redirect-uri: ${KAKAO_REDIRECT_URI:https://shieldai.kr/auth/kakao/callback}
+  allowed-redirect-uris: ${KAKAO_ALLOWED_REDIRECT_URIS:https://shieldai.kr/auth/kakao/callback,https://shieldai.kr/auth/kakao/callback-mobile,https://localhost:5174/auth/kakao/callback}
 
 # Supabase Storage
 # - bucket          : 변호사 자격증명 등 비공개 문서 저장 버킷 (signed URL 사용)


### PR DESCRIPTION
## 개요

SHIELD FE 의 Android 네이티브 앱 (Capacitor) 에서 OAuth 로그인이 동작하도록 BE 의 redirect URI 처리를 동적으로 변경. 카카오/네이버 정책상 custom scheme (`shield://`) 은 redirect URI 로 등록 불가하므로, 모바일 앱도 https URL (`-mobile` suffix 페이지) 을 사용하고 그 페이지에서 deep link 로 native 앱에 전달하는 패턴.

Closes #114

## 변경 내역

### Domain / DTO
- `OAuthClient.getUserInfo(String code, String redirectUri)` 시그니처 통일 — 모든 구현체 동일
- `KakaoLoginRequest`, `NaverLoginRequest`, `GoogleLoginRequest` 에 `redirectUri` optional 필드 추가

### Infrastructure
- `KakaoOAuthClient`, `NaverOAuthClient`:
  - `allowed-redirect-uris` 화이트리스트 (콤마 분리 CSV) 주입
  - 클라이언트 전달 redirectUri 가 null/blank 이면 기본값, 아니면 화이트리스트 검증 후 사용
  - 토큰 교환 시 검증된 redirectUri 사용
- `GoogleOAuthClient`: 시그니처만 통일, redirectUri 매개변수는 Phase 2 까지 미사용

### 설정 / 에러
- `application.yml`: `kakao.allowed-redirect-uris`, `naver.allowed-redirect-uris` 신규
  - default: `https://shieldai.kr/auth/{provider}/callback`, `...-mobile`, `https://localhost:5174/...`
- `ErrorCode.OAUTH_INVALID_REDIRECT_URI` (HTTP 400) 추가

### 호출 체인
- `AuthService.{kakao,naver,google}Login` 에 `redirectUri` 매개변수 추가 → OAuthService → OAuthClient 로 전달
- `AuthController`: `request.redirectUri()` 도 service 에 전달

## 백워드 호환성

- 옛 FE (redirectUri 미전송) → BE 가 기본 환경변수 (`KAKAO_REDIRECT_URI`) 사용 → 기존 동작 100% 동일
- 새 FE 에서 redirectUri 보내도 화이트리스트에 포함된 값이면 통과
- EC2 환경변수 (`KAKAO_REDIRECT_URI=https://shieldai.kr/auth/kakao/callback`) 와 화이트리스트 default 일치 — 추가 설정 불필요

## 테스트 계획

- [ ] 기존 웹 카카오/네이버 로그인 정상 작동 (운영 도메인 `shieldai.kr`)
- [ ] 새 FE 의 mobile callback 흐름 — 화이트리스트 통과 후 토큰 교환 성공
- [ ] 화이트리스트 외 URL 전송 시 `OAUTH_INVALID_REDIRECT_URI` 응답

## FE 작업

연계 FE PR: capstoneSHIELD/SHIELD_FE (feat/capacitor-android)