### PR TITLE
[FEAT] Google OAuth redirect URI 동적 처리 + 화이트리스트

### DIFF
--- a/src/main/java/org/example/shield/auth/infrastructure/GoogleOAuthClient.java
+++ b/src/main/java/org/example/shield/auth/infrastructure/GoogleOAuthClient.java
@@ -9,6 +9,9 @@ import org.example.shield.common.exception.ErrorCode;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.Arrays;
@@ -66,14 +69,17 @@ public class GoogleOAuthClient implements OAuthClient {
 
     private String exchangeCodeForToken(String authorizationCode, String redirectUri) {
         try {
+            MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+            form.add("grant_type", "authorization_code");
+            form.add("client_id", clientId);
+            form.add("client_secret", clientSecret);
+            form.add("redirect_uri", redirectUri);
+            form.add("code", authorizationCode);
+
             GoogleTokenResponse response = webClient.post()
                     .uri("https://oauth2.googleapis.com/token")
                     .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                    .bodyValue("code=" + authorizationCode
-                            + "&client_id=" + clientId
-                            + "&client_secret=" + clientSecret
-                            + "&redirect_uri=" + redirectUri
-                            + "&grant_type=authorization_code")
+                    .body(BodyInserters.fromFormData(form))
                     .retrieve()
                     .bodyToMono(GoogleTokenResponse.class)
                     .block();

--- a/src/main/java/org/example/shield/auth/infrastructure/GoogleOAuthClient.java
+++ b/src/main/java/org/example/shield/auth/infrastructure/GoogleOAuthClient.java
@@ -11,6 +11,16 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Google OAuth 2.0 클라이언트.
+ *
+ * <p>Issue #116: 모바일 native 앱 지원을 위해 redirect_uri 를 동적으로 받고
+ * {@code allowed-redirect-uris} 화이트리스트로 검증한다. Kakao/Naver 와 동일 패턴.</p>
+ */
 @Slf4j
 @Component("googleOAuthClient")
 public class GoogleOAuthClient implements OAuthClient {
@@ -18,29 +28,43 @@ public class GoogleOAuthClient implements OAuthClient {
     private final WebClient webClient;
     private final String clientId;
     private final String clientSecret;
-    private final String redirectUri;
+    private final String defaultRedirectUri;
+    private final Set<String> allowedRedirectUris;
 
     public GoogleOAuthClient(
             @Value("${google.client-id}") String clientId,
             @Value("${google.client-secret}") String clientSecret,
-            @Value("${google.redirect-uri}") String redirectUri) {
+            @Value("${google.redirect-uri}") String defaultRedirectUri,
+            @Value("${google.allowed-redirect-uris}") String allowedRedirectUrisCsv) {
         this.webClient = WebClient.create();
         this.clientId = clientId;
         this.clientSecret = clientSecret;
-        this.redirectUri = redirectUri;
+        this.defaultRedirectUri = defaultRedirectUri;
+        this.allowedRedirectUris = Arrays.stream(allowedRedirectUrisCsv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     @Override
     public OAuthUserInfo getUserInfo(String authorizationCode, String redirectUri) {
-        // Phase 1 (Issue #114): Google 은 모바일 native OAuth 미지원 상태.
-        // redirectUri 매개변수는 인터페이스 통일을 위해 받지만 사용하지 않고 환경변수의
-        // 기본 redirect-uri 를 그대로 사용한다. Phase 2 에서 Google native SDK 또는
-        // Android OAuth Client 도입 시 활용 예정.
-        String accessToken = exchangeCodeForToken(authorizationCode);
+        String resolvedRedirectUri = resolveRedirectUri(redirectUri);
+        String accessToken = exchangeCodeForToken(authorizationCode, resolvedRedirectUri);
         return fetchUserInfo(accessToken);
     }
 
-    private String exchangeCodeForToken(String authorizationCode) {
+    private String resolveRedirectUri(String requested) {
+        if (requested == null || requested.isBlank()) {
+            return defaultRedirectUri;
+        }
+        if (!allowedRedirectUris.contains(requested)) {
+            log.warn("Google OAuth: rejected redirect_uri='{}' (not in whitelist)", requested);
+            throw new OAuthFailedException(ErrorCode.OAUTH_INVALID_REDIRECT_URI);
+        }
+        return requested;
+    }
+
+    private String exchangeCodeForToken(String authorizationCode, String redirectUri) {
         try {
             GoogleTokenResponse response = webClient.post()
                     .uri("https://oauth2.googleapis.com/token")
@@ -78,7 +102,7 @@ public class GoogleOAuthClient implements OAuthClient {
             if (response == null || response.email() == null) {
                 throw new OAuthFailedException(ErrorCode.OAUTH_USER_INFO_FAILED);
             }
-            return new OAuthUserInfo(response.email(), response.name(), response.id());  // providerId = Google ID
+            return new OAuthUserInfo(response.email(), response.name(), response.id());
         } catch (OAuthFailedException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -92,10 +92,14 @@ jwt:
   refresh-token-expiry: 1209600000
 
 # Google OAuth
+# - allowed-redirect-uris: 클라이언트가 보낸 redirect_uri 화이트리스트 (Issue #116).
+#   모바일 native 앱은 https 의 `-mobile` suffix URL 사용. mobile callback 페이지가
+#   받은 code 를 shield:// scheme 으로 native 앱에 전달.
 google:
   client-id: ${GOOGLE_CLIENT_ID}
   client-secret: ${GOOGLE_CLIENT_SECRET}
   redirect-uri: ${GOOGLE_REDIRECT_URI}
+  allowed-redirect-uris: ${GOOGLE_ALLOWED_REDIRECT_URIS:https://shieldai.kr/auth/google/callback,https://shieldai.kr/auth/google/callback-mobile,https://localhost:5174/auth/google/callback}
 
 # Naver OAuth (Issue #83)
 # 테스트/로컬에서 env 미설정 시에도 컨텍스트 로드되도록 기본값 제공.


### PR DESCRIPTION
## 개요

Phase 1 (#114) 에서 Kakao/Naver 만 redirectUri 동적 사용했고 Google 은 시그니처만 통일. Phase 2 에서 Google 도 동일 패턴 적용.

Closes #116

## 변경 내역

### `application.yml`
- `google.allowed-redirect-uris` 신규
- default: `https://shieldai.kr/auth/google/callback,https://shieldai.kr/auth/google/callback-mobile,https://localhost:5174/auth/google/callback`
- `GOOGLE_ALLOWED_REDIRECT_URIS` 환경변수로 override 가능

### `GoogleOAuthClient`
- `defaultRedirectUri` + `allowedRedirectUris` 주입 (Kakao/Naver 와 동일 패턴)
- `resolveRedirectUri()` 메서드 — null/blank 면 기본값, 외엔 화이트리스트 검증
- `exchangeCodeForToken(code, redirectUri)` — 토큰 교환 시 동적 redirect_uri 사용

## 백워드 호환성

- 옛 FE (redirectUri 미전송) → BE 가 기본 환경변수 `GOOGLE_REDIRECT_URI` 사용 → 기존 동작 100% 동일
- 새 FE (redirectUri 전송) → 화이트리스트 검증 후 사용
- EC2 환경변수 `GOOGLE_REDIRECT_URI=https://shieldai.kr/auth/google/callback` 와 화이트리스트 default 일치 → 추가 env 설정 불필요

## FE 작업

연계 FE 이슈: capstoneSHIELD/SHIELD_FE#56

## 테스트 계획

- [ ] 기존 웹 Google 로그인 (운영 `shieldai.kr`) 정상 작동
- [ ] 새 FE 의 mobile callback 흐름 — 화이트리스트 통과 후 토큰 교환 성공
- [ ] 화이트리스트 외 URL 전송 시 `OAUTH_INVALID_REDIRECT_URI` 응답