### PR TITLE
[FIX] LawyerInboxController query param 이름 불일치 + InboxFilter.DELIVERED 추가

### DIFF
--- a/src/main/java/org/example/shield/brief/application/DeliveryService.java
+++ b/src/main/java/org/example/shield/brief/application/DeliveryService.java
@@ -173,6 +173,8 @@ public class DeliveryService {
                     lawyerId, DeliveryStatus.DELIVERED, pageable);
             case REVIEWING -> deliveryReader.findAllByLawyerIdAndStatusAndViewedAtIsNotNull(
                     lawyerId, DeliveryStatus.DELIVERED, pageable);
+            case DELIVERED -> deliveryReader.findAllByLawyerIdAndStatus(
+                    lawyerId, DeliveryStatus.DELIVERED, pageable);
             case CONFIRMED -> deliveryReader.findAllByLawyerIdAndStatus(
                     lawyerId, DeliveryStatus.CONFIRMED, pageable);
             case REJECTED -> deliveryReader.findAllByLawyerIdAndStatus(

--- a/src/main/java/org/example/shield/brief/application/InboxFilter.java
+++ b/src/main/java/org/example/shield/brief/application/InboxFilter.java
@@ -4,6 +4,7 @@ public enum InboxFilter {
     ALL,
     NEW,
     REVIEWING,
+    DELIVERED,
     CONFIRMED,
     REJECTED,
     RESPONDED

--- a/src/main/java/org/example/shield/brief/controller/LawyerInboxController.java
+++ b/src/main/java/org/example/shield/brief/controller/LawyerInboxController.java
@@ -37,15 +37,15 @@ public class LawyerInboxController {
 
     private final DeliveryService deliveryService;
 
-    @Operation(summary = "수신 의뢰서 목록", description = "filter=ALL|NEW|REVIEWING|RESPONDED 로 필터링")
+    @Operation(summary = "수신 의뢰서 목록", description = "status=ALL|DELIVERED|CONFIRMED|REJECTED|NEW|REVIEWING|RESPONDED 로 필터링")
     @GetMapping
     public ApiResponse<PageResponse<InboxResponse>> getInbox(
             @AuthenticationPrincipal UUID lawyerId,
-            @RequestParam(defaultValue = "ALL") InboxFilter filter,
+            @RequestParam(name = "status", defaultValue = "ALL") InboxFilter status,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         Pageable pageable = PageRequest.of(page, Math.min(size, 100), Sort.by(Sort.Direction.DESC, "sentAt"));
-        PageResponse<InboxResponse> result = deliveryService.getInbox(lawyerId, filter, pageable);
+        PageResponse<InboxResponse> result = deliveryService.getInbox(lawyerId, status, pageable);
         return ApiResponse.success("조회 성공", result);
     }
 


### PR DESCRIPTION
## 증상

변호사 의뢰함 (`/lawyer/inbox`) 의 탭 (전체/대기중/수락/거절) 이 모두 전체 의뢰서를 표시. 필터 동작 안 함.

## 원인

- FE `inboxApi.getList` 가 query param 을 `status` 로 전송 (`src/lib/inboxApi.ts:17`)
- BE `LawyerInboxController.getInbox` 는 `@RequestParam(defaultValue="ALL") InboxFilter filter` 로 받음 — 이름 불일치
- BE 가 status 무시 후 default `InboxFilter.ALL` 사용

추가로 FE 의 "대기 중" 탭은 `'DELIVERED'` 를 전송하지만 InboxFilter enum 엔 DELIVERED 없음 (NEW/REVIEWING/CONFIRMED/REJECTED/RESPONDED 만).

## 변경

- `InboxFilter` enum 에 `DELIVERED` 추가
- `DeliveryService.getInbox` switch 에 `case DELIVERED -> findAllByLawyerIdAndStatus(DELIVERED)` 추가
- `LawyerInboxController.getInbox` 의 `@RequestParam` 이름 `filter` → `status` 로 변경

FE 변경 없음.

Closes #119